### PR TITLE
feat: add ActivityPub ForgeFed actor

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-05-03T12:18:18.433Z for PR creation at branch issue-9-d545a925a750 for issue https://github.com/link-assistant/router/issues/9
-# Updated: 2026-05-09T06:04:44.414Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-03T12:18:18.433Z for PR creation at branch issue-9-d545a925a750 for issue https://github.com/link-assistant/router/issues/9
+# Updated: 2026-05-09T06:04:44.414Z

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,7 +909,7 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "link-assistant-router"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/changelog.d/20260509_060900_activitypub_forgefed.md
+++ b/changelog.d/20260509_060900_activitypub_forgefed.md
@@ -1,0 +1,2 @@
+### Added
+- Expose a minimal ActivityPub and ForgeFed actor surface for the code task actor, including inbox, outbox, followers, public key metadata, and a problemsets Follow activity document.

--- a/src/activitypub.rs
+++ b/src/activitypub.rs
@@ -1,0 +1,253 @@
+//! Minimal `ActivityPub` / `ForgeFed` endpoint support.
+//!
+//! The router exposes a local service actor and accepts inbound activities so
+//! a ForgeFed-capable problem source can discover and address it.
+
+use axum::extract::State;
+use axum::http::{header, HeaderMap, HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Response};
+use serde_json::{json, Value};
+
+use crate::proxy::AppState;
+
+const ACTIVITY_JSON: &str = "application/activity+json";
+
+/// Build the public actor representation for this router instance.
+#[must_use]
+pub fn actor_document(actor_base_url: &str, public_key_pem: &str) -> Value {
+    let base = actor_base_url.trim_end_matches('/');
+    json!({
+        "@context": activitypub_context(),
+        "id": format!("{base}/actor/code"),
+        "type": "Service",
+        "preferredUsername": "code",
+        "name": "Link Assistant Code Router",
+        "summary": "ActivityPub and ForgeFed service actor for coding problem federation",
+        "inbox": format!("{base}/inbox/code"),
+        "outbox": format!("{base}/outbox/code"),
+        "followers": format!("{base}/actors/code/followers"),
+        "aliases": [
+            format!("urn:link-assistant:router:code"),
+            format!("{base}/actor/code")
+        ],
+        "publicKey": {
+            "id": format!("{base}/actor/code#main-key"),
+            "owner": format!("{base}/actor/code"),
+            "publicKeyPem": public_key_pem
+        }
+    })
+}
+
+/// Build an ordered collection for the local actor outbox.
+#[must_use]
+pub fn outbox_document(actor_base_url: &str) -> Value {
+    let base = actor_base_url.trim_end_matches('/');
+    json!({
+        "@context": activitypub_context(),
+        "id": format!("{base}/outbox/code"),
+        "type": "OrderedCollection",
+        "totalItems": 0,
+        "orderedItems": []
+    })
+}
+
+/// Build an ordered collection for followers.
+#[must_use]
+pub fn followers_document(actor_base_url: &str) -> Value {
+    let base = actor_base_url.trim_end_matches('/');
+    json!({
+        "@context": activitypub_context(),
+        "id": format!("{base}/actors/code/followers"),
+        "type": "OrderedCollection",
+        "totalItems": 0,
+        "orderedItems": []
+    })
+}
+
+/// Build a Follow activity targeting the public problemsets actor.
+#[must_use]
+pub fn follow_problemsets_activity(actor_base_url: &str) -> Value {
+    let base = actor_base_url.trim_end_matches('/');
+    json!({
+        "@context": activitypub_context(),
+        "id": format!("{base}/activities/follow-problemsets-code-001"),
+        "type": "Follow",
+        "actor": format!("{base}/actor/code"),
+        "object": "https://problemsets.lefine.pro/actor/code",
+        "to": ["https://problemsets.lefine.pro/actor/code"]
+    })
+}
+
+/// Validate the minimum fields required for an inbound `ActivityStreams` object.
+pub fn validate_activity(activity: &Value) -> Result<(), &'static str> {
+    require_string(activity, "id")?;
+    require_string(activity, "type")?;
+    if activity.get("actor").and_then(Value::as_str).is_none()
+        && activity
+            .get("attributedTo")
+            .and_then(Value::as_str)
+            .is_none()
+    {
+        return Err("activity must include actor or attributedTo");
+    }
+    Ok(())
+}
+
+/// `GET /actor/code`.
+#[allow(clippy::unused_async)]
+pub async fn actor(State(state): State<AppState>) -> impl IntoResponse {
+    activity_response(actor_document(
+        &state.activitypub_actor_base_url,
+        &state.activitypub_public_key_pem,
+    ))
+}
+
+/// `GET /outbox/code`.
+#[allow(clippy::unused_async)]
+pub async fn outbox(State(state): State<AppState>) -> impl IntoResponse {
+    activity_response(outbox_document(&state.activitypub_actor_base_url))
+}
+
+/// `GET /actors/code/followers`.
+#[allow(clippy::unused_async)]
+pub async fn followers(State(state): State<AppState>) -> impl IntoResponse {
+    activity_response(followers_document(&state.activitypub_actor_base_url))
+}
+
+/// `GET /activities/follow-problemsets-code-001`.
+#[allow(clippy::unused_async)]
+pub async fn follow_problemsets(State(state): State<AppState>) -> impl IntoResponse {
+    activity_response(follow_problemsets_activity(
+        &state.activitypub_actor_base_url,
+    ))
+}
+
+/// `POST /inbox/code`.
+#[allow(clippy::unused_async)]
+pub async fn inbox(axum::Json(activity): axum::Json<Value>) -> impl IntoResponse {
+    match validate_activity(&activity) {
+        Ok(()) => {
+            let response = json!({
+                "@context": activitypub_context(),
+                "type": "Accept",
+                "object": activity
+            });
+            (
+                StatusCode::ACCEPTED,
+                activity_headers(),
+                axum::Json(response),
+            )
+                .into_response()
+        }
+        Err(message) => (
+            StatusCode::BAD_REQUEST,
+            axum::Json(json!({
+                "error": "invalid_activity",
+                "message": message
+            })),
+        )
+            .into_response(),
+    }
+}
+
+fn activity_response(value: Value) -> Response {
+    (StatusCode::OK, activity_headers(), axum::Json(value)).into_response()
+}
+
+fn activity_headers() -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static(r"application/activity+json"),
+    );
+    headers.insert(header::ACCEPT, HeaderValue::from_static(ACTIVITY_JSON));
+    headers
+}
+
+fn activitypub_context() -> Value {
+    json!([
+        "https://www.w3.org/ns/activitystreams",
+        "https://forgefed.org/ns",
+        {
+            "fep": "https://w3id.org/fep/ef61#",
+            "aliases": "fep:aliases"
+        }
+    ])
+}
+
+fn require_string<'a>(activity: &'a Value, field: &'static str) -> Result<&'a str, &'static str> {
+    activity
+        .get(field)
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .ok_or(match field {
+            "id" => "activity id is required",
+            "type" => "activity type is required",
+            _ => "required field is missing",
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BASE: &str = "https://router.example";
+    const KEY: &str = "-----BEGIN PUBLIC KEY-----\nabc\n-----END PUBLIC KEY-----";
+
+    #[test]
+    fn actor_contains_required_activitypub_and_forgefed_metadata() {
+        let doc = actor_document(BASE, KEY);
+
+        assert_eq!(doc["id"], "https://router.example/actor/code");
+        assert_eq!(doc["type"], "Service");
+        assert_eq!(doc["inbox"], "https://router.example/inbox/code");
+        assert_eq!(doc["outbox"], "https://router.example/outbox/code");
+        assert_eq!(
+            doc["followers"],
+            "https://router.example/actors/code/followers"
+        );
+        assert_eq!(doc["publicKey"]["owner"], doc["id"]);
+        assert_eq!(doc["publicKey"]["publicKeyPem"], KEY);
+        assert!(doc["@context"]
+            .as_array()
+            .expect("context array")
+            .iter()
+            .any(|item| item == "https://forgefed.org/ns"));
+        assert!(doc["aliases"].as_array().expect("aliases").len() >= 2);
+    }
+
+    #[test]
+    fn follow_activity_targets_problemsets_actor() {
+        let activity = follow_problemsets_activity(BASE);
+
+        assert_eq!(activity["type"], "Follow");
+        assert_eq!(activity["actor"], "https://router.example/actor/code");
+        assert_eq!(
+            activity["object"],
+            "https://problemsets.lefine.pro/actor/code"
+        );
+        assert_eq!(
+            activity["to"][0],
+            "https://problemsets.lefine.pro/actor/code"
+        );
+    }
+
+    #[test]
+    fn inbound_activity_requires_core_fields() {
+        let valid = json!({
+            "id": "https://remote.example/activity/1",
+            "type": "Create",
+            "actor": "https://remote.example/actor"
+        });
+        assert!(validate_activity(&valid).is_ok());
+
+        let invalid = json!({
+            "id": "https://remote.example/activity/1",
+            "type": "Create"
+        });
+        assert_eq!(
+            validate_activity(&invalid),
+            Err("activity must include actor or attributedTo")
+        );
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,7 +25,8 @@ use clap::Subcommand;
 use lino_arguments::Parser as LinoParser;
 
 use crate::config::{
-    default_data_dir, ApiFormat, BuildArgs, Config, ConfigError, RoutingMode, StoragePolicy,
+    default_activitypub_public_key_pem, default_data_dir, ApiFormat, BuildArgs, Config,
+    ConfigError, RoutingMode, StoragePolicy,
 };
 
 /// Top-level CLI parser.
@@ -88,6 +89,14 @@ pub struct Cli {
     /// Path to the local Claude CLI binary used by the CLI backend.
     #[arg(long, env = "CLAUDE_CLI_BIN", global = true)]
     pub claude_cli_bin: Option<PathBuf>,
+
+    /// Public base URL for the `ActivityPub` actor.
+    #[arg(long, env = "ACTIVITYPUB_ACTOR_BASE_URL", global = true)]
+    pub activitypub_actor_base_url: Option<String>,
+
+    /// Public key PEM advertised by the `ActivityPub` actor.
+    #[arg(long, env = "ACTIVITYPUB_PUBLIC_KEY_PEM", global = true)]
+    pub activitypub_public_key_pem: Option<String>,
 
     /// Disable the OpenAI-compatible API surface.
     #[arg(long, env = "DISABLE_OPENAI_API", global = true)]
@@ -179,6 +188,14 @@ impl Cli {
             RoutingMode::from_str_opt(&self.routing_mode).ok_or(ConfigError::InvalidRoutingMode)?;
         let storage_policy = StoragePolicy::from_str_opt(&self.storage_policy).unwrap_or_default();
         let data_dir = self.data_dir.clone().unwrap_or_else(default_data_dir);
+        let activitypub_actor_base_url = self
+            .activitypub_actor_base_url
+            .clone()
+            .unwrap_or_else(|| format!("http://{}:{}", self.host, self.port));
+        let activitypub_public_key_pem = self
+            .activitypub_public_key_pem
+            .clone()
+            .unwrap_or_else(default_activitypub_public_key_pem);
         Config::build(BuildArgs {
             host: &self.host,
             port: &port,
@@ -191,6 +208,8 @@ impl Cli {
             storage_policy,
             data_dir,
             claude_cli_bin: self.claude_cli_bin.clone(),
+            activitypub_actor_base_url,
+            activitypub_public_key_pem,
             enable_openai_api: !self.disable_openai_api,
             enable_anthropic_api: !self.disable_anthropic_api,
             enable_metrics: !self.disable_metrics,
@@ -220,6 +239,8 @@ mod tests {
             storage_policy: "memory".into(),
             data_dir: Some(std::path::PathBuf::from("/tmp/d")),
             claude_cli_bin: None,
+            activitypub_actor_base_url: Some("https://router.example".into()),
+            activitypub_public_key_pem: None,
             disable_openai_api: false,
             disable_anthropic_api: false,
             disable_metrics: false,
@@ -251,6 +272,8 @@ mod tests {
             storage_policy: "memory".into(),
             data_dir: None,
             claude_cli_bin: None,
+            activitypub_actor_base_url: None,
+            activitypub_public_key_pem: None,
             disable_openai_api: false,
             disable_anthropic_api: false,
             disable_metrics: false,

--- a/src/config.rs
+++ b/src/config.rs
@@ -123,6 +123,10 @@ pub struct Config {
     pub data_dir: PathBuf,
     /// Optional path to the local `claude` CLI binary used by the CLI backend.
     pub claude_cli_bin: Option<PathBuf>,
+    /// Public base URL used for `ActivityPub` actor and collection IDs.
+    pub activitypub_actor_base_url: String,
+    /// Public key PEM advertised on the `ActivityPub` actor.
+    pub activitypub_public_key_pem: String,
     /// Whether to enable the OpenAI-compatible API surface.
     pub enable_openai_api: bool,
     /// Whether to enable the Anthropic-compatible (direct) proxy surface.
@@ -170,6 +174,10 @@ impl Config {
             .unwrap_or_default();
         let data_dir = env::var("DATA_DIR").map_or_else(|_| default_data_dir(), PathBuf::from);
         let claude_cli_bin = env::var("CLAUDE_CLI_BIN").ok().map(PathBuf::from);
+        let activitypub_actor_base_url = env::var("ACTIVITYPUB_ACTOR_BASE_URL")
+            .unwrap_or_else(|_| format!("http://{host}:{port}"));
+        let activitypub_public_key_pem = env::var("ACTIVITYPUB_PUBLIC_KEY_PEM")
+            .unwrap_or_else(|_| default_activitypub_public_key_pem());
         let enable_openai_api = env::var("ENABLE_OPENAI_API").map_or(true, |v| {
             !matches!(v.as_str(), "0" | "false" | "FALSE" | "off")
         });
@@ -205,6 +213,8 @@ impl Config {
             storage_policy,
             data_dir,
             claude_cli_bin,
+            activitypub_actor_base_url,
+            activitypub_public_key_pem,
             enable_openai_api,
             enable_anthropic_api,
             enable_metrics,
@@ -239,6 +249,11 @@ impl Config {
             storage_policy: args.storage_policy,
             data_dir: args.data_dir,
             claude_cli_bin: args.claude_cli_bin,
+            activitypub_actor_base_url: args
+                .activitypub_actor_base_url
+                .trim_end_matches('/')
+                .to_string(),
+            activitypub_public_key_pem: args.activitypub_public_key_pem,
             enable_openai_api: args.enable_openai_api,
             enable_anthropic_api: args.enable_anthropic_api,
             enable_metrics: args.enable_metrics,
@@ -262,6 +277,8 @@ pub struct BuildArgs<'a> {
     pub storage_policy: StoragePolicy,
     pub data_dir: PathBuf,
     pub claude_cli_bin: Option<PathBuf>,
+    pub activitypub_actor_base_url: String,
+    pub activitypub_public_key_pem: String,
     pub enable_openai_api: bool,
     pub enable_anthropic_api: bool,
     pub enable_metrics: bool,
@@ -278,6 +295,13 @@ pub fn default_data_dir() -> PathBuf {
     }
     let home = env::var("HOME").unwrap_or_else(|_| "/var/lib/link-assistant-router".to_string());
     PathBuf::from(home).join(".link-assistant-router")
+}
+
+/// Development public key advertised by the `ActivityPub` actor when no key is
+/// configured. Production deployments should provide their real public key.
+#[must_use]
+pub fn default_activitypub_public_key_pem() -> String {
+    "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA0000000000000000000000000000000000000000000=\n-----END PUBLIC KEY-----".to_string()
 }
 
 /// Errors that can occur during configuration loading.
@@ -327,6 +351,8 @@ mod tests {
             storage_policy: StoragePolicy::Memory,
             data_dir: PathBuf::from("/tmp/test-data"),
             claude_cli_bin: None,
+            activitypub_actor_base_url: "https://router.example".into(),
+            activitypub_public_key_pem: default_activitypub_public_key_pem(),
             enable_openai_api: true,
             enable_anthropic_api: true,
             enable_metrics: true,
@@ -373,6 +399,8 @@ mod tests {
             storage_policy: StoragePolicy::Memory,
             data_dir: PathBuf::from("/tmp/test-data"),
             claude_cli_bin: None,
+            activitypub_actor_base_url: "https://router.example".into(),
+            activitypub_public_key_pem: default_activitypub_public_key_pem(),
             enable_openai_api: true,
             enable_anthropic_api: true,
             enable_metrics: true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 //! access via custom-issued tokens.
 
 pub mod accounts;
+pub mod activitypub;
 pub mod cli;
 pub mod config;
 pub mod metrics;

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 use axum::routing::{get, post};
 use axum::Router;
 use link_assistant_router::accounts::{AccountRouter, SelectionStrategy};
+use link_assistant_router::activitypub;
 use link_assistant_router::cli::{AccountOp, Cli, Command, TokenOp};
 use link_assistant_router::config::{Config, RoutingMode, StoragePolicy};
 use link_assistant_router::metrics::Metrics;
@@ -147,10 +148,20 @@ async fn run_server(config: Config, logger: LogLazy) -> Result<(), Box<dyn std::
         logger,
         admin_key: config.admin_key.clone(),
         metrics: Arc::clone(&metrics),
+        activitypub_actor_base_url: config.activitypub_actor_base_url.clone(),
+        activitypub_public_key_pem: config.activitypub_public_key_pem.clone(),
     };
 
     let mut app = Router::new()
         .route("/health", get(proxy::health))
+        .route("/actor/code", get(activitypub::actor))
+        .route("/inbox/code", post(activitypub::inbox))
+        .route("/outbox/code", get(activitypub::outbox))
+        .route("/actors/code/followers", get(activitypub::followers))
+        .route(
+            "/activities/follow-problemsets-code-001",
+            get(activitypub::follow_problemsets),
+        )
         .route("/api/tokens", post(proxy::issue_token))
         .route("/api/tokens/list", get(proxy::list_tokens))
         .route("/api/tokens/revoke", post(proxy::revoke_token));

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -47,6 +47,10 @@ pub struct AppState {
     pub admin_key: Option<String>,
     /// Live metrics counter handle.
     pub metrics: Arc<crate::metrics::Metrics>,
+    /// Public base URL for `ActivityPub` actor documents.
+    pub activitypub_actor_base_url: String,
+    /// Public key PEM advertised by the `ActivityPub` actor.
+    pub activitypub_public_key_pem: String,
 }
 
 /// The legacy API path prefix used to route requests through the proxy.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -245,8 +245,89 @@ mod required_headers_tests {
     }
 }
 
+mod activitypub_tests {
+    use link_assistant_router::activitypub::{
+        actor_document, follow_problemsets_activity, followers_document, outbox_document,
+        validate_activity,
+    };
+    use serde_json::json;
+
+    const BASE: &str = "https://router.example";
+    const KEY: &str = "-----BEGIN PUBLIC KEY-----\nabc\n-----END PUBLIC KEY-----";
+
+    #[test]
+    fn actor_document_exposes_required_activitypub_fields() {
+        let actor = actor_document(BASE, KEY);
+
+        assert_eq!(actor["id"], "https://router.example/actor/code");
+        assert_eq!(actor["type"], "Service");
+        assert_eq!(actor["inbox"], "https://router.example/inbox/code");
+        assert_eq!(actor["outbox"], "https://router.example/outbox/code");
+        assert_eq!(
+            actor["followers"],
+            "https://router.example/actors/code/followers"
+        );
+        assert_eq!(
+            actor["publicKey"]["id"],
+            "https://router.example/actor/code#main-key"
+        );
+        assert_eq!(actor["publicKey"]["publicKeyPem"], KEY);
+        assert!(actor["aliases"].as_array().expect("aliases").len() >= 2);
+    }
+
+    #[test]
+    fn actor_context_includes_forgefed_and_fep_ef61_aliases() {
+        let actor = actor_document(BASE, KEY);
+        let context = actor["@context"].as_array().expect("context array");
+
+        assert!(context
+            .iter()
+            .any(|item| item == "https://www.w3.org/ns/activitystreams"));
+        assert!(context.iter().any(|item| item == "https://forgefed.org/ns"));
+        assert!(context.iter().any(|item| item["aliases"] == "fep:aliases"));
+    }
+
+    #[test]
+    fn follow_activity_can_be_posted_to_problemsets_inbox() {
+        let follow = follow_problemsets_activity(BASE);
+
+        assert_eq!(
+            follow["id"],
+            "https://router.example/activities/follow-problemsets-code-001"
+        );
+        assert_eq!(follow["type"], "Follow");
+        assert_eq!(follow["actor"], "https://router.example/actor/code");
+        assert_eq!(
+            follow["object"],
+            "https://problemsets.lefine.pro/actor/code"
+        );
+        assert_eq!(follow["to"][0], "https://problemsets.lefine.pro/actor/code");
+    }
+
+    #[test]
+    fn inbox_validation_rejects_objects_without_actor_or_attributed_to() {
+        let activity = json!({
+            "id": "https://remote.example/activities/1",
+            "type": "Create"
+        });
+
+        assert_eq!(
+            validate_activity(&activity),
+            Err("activity must include actor or attributedTo")
+        );
+    }
+
+    #[test]
+    fn collections_are_addressable_ordered_collections() {
+        assert_eq!(outbox_document(BASE)["type"], "OrderedCollection");
+        assert_eq!(followers_document(BASE)["type"], "OrderedCollection");
+    }
+}
+
 mod config_verbose_tests {
-    use link_assistant_router::config::{BuildArgs, Config, RoutingMode, StoragePolicy};
+    use link_assistant_router::config::{
+        default_activitypub_public_key_pem, BuildArgs, Config, RoutingMode, StoragePolicy,
+    };
     use std::path::PathBuf;
 
     fn args_with_verbose(verbose: bool) -> BuildArgs<'static> {
@@ -262,6 +343,8 @@ mod config_verbose_tests {
             storage_policy: StoragePolicy::Memory,
             data_dir: PathBuf::from("/tmp/test-data"),
             claude_cli_bin: None,
+            activitypub_actor_base_url: "https://router.example".into(),
+            activitypub_public_key_pem: default_activitypub_public_key_pem(),
             enable_openai_api: true,
             enable_anthropic_api: true,
             enable_metrics: true,


### PR DESCRIPTION
## Summary
- Adds a minimal ActivityPub / ForgeFed service actor at `/actor/code` with inbox, outbox, followers, aliases, and public key metadata.
- Adds `/inbox/code`, `/outbox/code`, `/actors/code/followers`, and a dereferenceable `/activities/follow-problemsets-code-001` Follow activity targeting `https://problemsets.lefine.pro/actor/code`.
- Adds `ACTIVITYPUB_ACTOR_BASE_URL` and `ACTIVITYPUB_PUBLIC_KEY_PEM` configuration for deployable actor IDs and key metadata.

Fixes #11

## Reproduction / Verification
Before this change the router had no ActivityPub routes, so `GET /actor/code` would fall through to the proxy instead of returning a federated actor document.

Automated coverage added:
- Actor document includes required ActivityPub fields, ForgeFed context, FEP-ef61 aliases, and public key metadata.
- Follow activity targets the problemsets actor.
- Inbox validation rejects malformed ActivityStreams objects.
- Outbox and followers endpoints produce ordered collections.

## Local Checks
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features`
- `cargo test`
- `rust-script scripts/check-file-size.rs`