### PR TITLE
Add optional Gonka upstream provider

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-03T12:18:18.433Z for PR creation at branch issue-9-d545a925a750 for issue https://github.com/link-assistant/router/issues/9
+# Updated: 2026-05-09T06:44:04.727Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-05-03T12:18:18.433Z for PR creation at branch issue-9-d545a925a750 for issue https://github.com/link-assistant/router/issues/9
-# Updated: 2026-05-09T06:44:04.727Z

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,6 +321,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "ctor"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,6 +362,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -502,6 +540,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,6 +614,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -909,7 +963,7 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "link-assistant-router"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -918,6 +972,7 @@ dependencies = [
  "chrono",
  "clap",
  "futures-util",
+ "hex",
  "http",
  "http-body-util",
  "hyper",
@@ -928,6 +983,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "tokio",
  "tokio-test",
@@ -1456,6 +1512,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1900,6 +1967,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1963,6 +2036,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,8 @@ lino-arguments = "0.3"
 clap = { version = "4", features = ["derive", "env"] }
 base64 = "0.22"
 async-trait = "0.1"
+sha2 = "0.10"
+hex = "0.4"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Link.Assistant.Router is a transparent proxy that sits between API clients (such
 - **Proxies all Anthropic API requests** transparently, including SSE/streaming responses
 - **Supports Claude MAX (OAuth)** by reading Claude Code session credentials
 - **OpenAI-compatible endpoints** — `/v1/chat/completions`, `/v1/responses`, `/v1/models` translate to and from Anthropic Messages
+- **Optional Gonka upstream** — `UPSTREAM_PROVIDER=gonka` forwards OpenAI-compatible routes to Gonka instead of translating them to Anthropic
 - **Multi-account routing** — pool any number of Claude MAX accounts; round-robin / priority / least-used; automatic cooldowns on 429
 - **Issues custom `la_sk_...` JWT tokens** with expiration and revocation for multi-tenant access
 - **Persistent token store** — text (Lino) **and** binary backends, both on by default; tokens survive restarts
@@ -37,6 +38,11 @@ Link.Assistant.Router (Rust / axum)
    v
 Anthropic API (api.anthropic.com)
 ```
+
+When `UPSTREAM_PROVIDER=gonka`, clients still authenticate to the router with
+`Authorization: Bearer la_sk_...`, but upstream OpenAI-compatible requests are
+sent to Gonka with Gonka signing headers instead of the client token. This
+project remains Link.Assistant.Router; Gonka is an optional backend.
 
 ## Quick Start
 
@@ -215,6 +221,10 @@ Claude Code will work exactly as normal, with all requests transparently proxied
 
 `gpt-4o`, `gpt-4o-mini`, `gpt-4`, and the `o*` reasoning families auto-map to the Claude Sonnet / Haiku / Opus tiers respectively. Native `claude-*` IDs pass through unchanged.
 
+With `UPSTREAM_PROVIDER=gonka`, `/v1/chat/completions` and `/v1/responses`
+forward OpenAI-compatible JSON to Gonka without Anthropic translation. If a
+request omits `model`, the router uses `GONKA_MODEL`.
+
 ### Observability (`--disable-metrics` to opt out)
 
 | Endpoint | Method | Description |
@@ -292,9 +302,34 @@ Configuration is read from CLI flags, environment variables, and an optional `.l
 | `--port` / `ROUTER_PORT` | `8080` | No | Port to listen on |
 | `--host` / `ROUTER_HOST` | `0.0.0.0` | No | Host/IP to bind to |
 | `--claude-code-home` / `CLAUDE_CODE_HOME` | `~/.claude` | No | Primary Claude Code credentials directory |
+| `--upstream-provider` / `UPSTREAM_PROVIDER` | `anthropic` | No | Upstream provider: `anthropic` or `gonka` |
 | `--upstream-base-url` / `UPSTREAM_BASE_URL` | `https://api.anthropic.com` | No | Upstream Anthropic API URL |
 | `--api-format` / `UPSTREAM_API_FORMAT` | (auto) | No | Restrict the proxy to `anthropic` / `bedrock` / `vertex` |
 | `--verbose` / `VERBOSE` | `false` | No | Verbose tracing |
+
+### Gonka provider
+
+Gonka support is optional. Anthropic remains the default provider, and existing
+Claude MAX OAuth behavior is unchanged unless `UPSTREAM_PROVIDER=gonka` is set.
+
+```env
+TOKEN_SECRET=your-router-token-secret
+
+UPSTREAM_PROVIDER=gonka
+GONKA_PRIVATE_KEY=your_gonka_private_key
+GONKA_SOURCE_URL=https://node4.gonka.ai
+GONKA_MODEL=Qwen/Qwen3-235B-A22B-Instruct-2507-FP8
+```
+
+| Flag / env | Default | Required | Description |
+|---|---|---|---|
+| `--gonka-private-key` / `GONKA_PRIVATE_KEY` | — | Yes, for Gonka | Private key used to sign Gonka upstream requests |
+| `--gonka-source-url` / `GONKA_SOURCE_URL` | `https://node4.gonka.ai` | No | Gonka source node URL |
+| `--gonka-model` / `GONKA_MODEL` | `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8` | No | Default model for Gonka OpenAI-compatible requests |
+
+Your Gonka account must be activated for inference, funded, and have a
+published on-chain public key. Participant registration is only needed for
+hosting.
 
 ### Routing & storage
 

--- a/changelog.d/20260509_065055_gonka_provider.md
+++ b/changelog.d/20260509_065055_gonka_provider.md
@@ -1,0 +1,2 @@
+### Added
+- Optional Gonka upstream provider selection with Gonka config, forwarding, model listing, and request signing for OpenAI-compatible routes.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,7 +26,7 @@ use lino_arguments::Parser as LinoParser;
 
 use crate::config::{
     default_activitypub_public_key_pem, default_data_dir, ApiFormat, BuildArgs, Config,
-    ConfigError, RoutingMode, StoragePolicy,
+    ConfigError, RoutingMode, StoragePolicy, UpstreamProvider,
 };
 
 /// Top-level CLI parser.
@@ -89,6 +89,37 @@ pub struct Cli {
     /// Path to the local Claude CLI binary used by the CLI backend.
     #[arg(long, env = "CLAUDE_CLI_BIN", global = true)]
     pub claude_cli_bin: Option<PathBuf>,
+
+    /// Upstream provider: anthropic or gonka.
+    #[arg(
+        long,
+        env = "UPSTREAM_PROVIDER",
+        default_value = "anthropic",
+        global = true
+    )]
+    pub upstream_provider: String,
+
+    /// Gonka private key used for request signing.
+    #[arg(long, env = "GONKA_PRIVATE_KEY", global = true)]
+    pub gonka_private_key: Option<String>,
+
+    /// Gonka source node URL.
+    #[arg(
+        long,
+        env = "GONKA_SOURCE_URL",
+        default_value = "https://node4.gonka.ai",
+        global = true
+    )]
+    pub gonka_source_url: String,
+
+    /// Default Gonka model for OpenAI-compatible requests without `model`.
+    #[arg(
+        long,
+        env = "GONKA_MODEL",
+        default_value = "Qwen/Qwen3-235B-A22B-Instruct-2507-FP8",
+        global = true
+    )]
+    pub gonka_model: String,
 
     /// Public base URL for the `ActivityPub` actor.
     #[arg(long, env = "ACTIVITYPUB_ACTOR_BASE_URL", global = true)]
@@ -186,6 +217,8 @@ impl Cli {
         let api_format = self.api_format.as_deref().and_then(ApiFormat::from_str_opt);
         let routing_mode =
             RoutingMode::from_str_opt(&self.routing_mode).ok_or(ConfigError::InvalidRoutingMode)?;
+        let upstream_provider = UpstreamProvider::from_str_opt(&self.upstream_provider)
+            .unwrap_or(UpstreamProvider::Anthropic);
         let storage_policy = StoragePolicy::from_str_opt(&self.storage_policy).unwrap_or_default();
         let data_dir = self.data_dir.clone().unwrap_or_else(default_data_dir);
         let activitypub_actor_base_url = self
@@ -208,6 +241,10 @@ impl Cli {
             storage_policy,
             data_dir,
             claude_cli_bin: self.claude_cli_bin.clone(),
+            upstream_provider,
+            gonka_private_key: self.gonka_private_key.clone().filter(|s| !s.is_empty()),
+            gonka_source_url: self.gonka_source_url.clone(),
+            gonka_model: self.gonka_model.clone(),
             activitypub_actor_base_url,
             activitypub_public_key_pem,
             enable_openai_api: !self.disable_openai_api,
@@ -223,6 +260,7 @@ impl Cli {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::{default_gonka_model, default_gonka_source_url};
 
     #[test]
     fn cli_defaults_round_trip_to_config() {
@@ -239,6 +277,10 @@ mod tests {
             storage_policy: "memory".into(),
             data_dir: Some(std::path::PathBuf::from("/tmp/d")),
             claude_cli_bin: None,
+            upstream_provider: "anthropic".into(),
+            gonka_private_key: None,
+            gonka_source_url: default_gonka_source_url(),
+            gonka_model: default_gonka_model(),
             activitypub_actor_base_url: Some("https://router.example".into()),
             activitypub_public_key_pem: None,
             disable_openai_api: false,
@@ -272,6 +314,10 @@ mod tests {
             storage_policy: "memory".into(),
             data_dir: None,
             claude_cli_bin: None,
+            upstream_provider: "anthropic".into(),
+            gonka_private_key: None,
+            gonka_source_url: default_gonka_source_url(),
+            gonka_model: default_gonka_model(),
             activitypub_actor_base_url: None,
             activitypub_public_key_pem: None,
             disable_openai_api: false,

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,28 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::str::FromStr;
 
+/// Supported upstream inference providers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum UpstreamProvider {
+    /// Anthropic via Claude MAX OAuth credentials.
+    #[default]
+    Anthropic,
+    /// Gonka OpenAI-compatible inference provider.
+    Gonka,
+}
+
+impl UpstreamProvider {
+    /// Parse a provider from a free-form string.
+    #[must_use]
+    pub fn from_str_opt(s: &str) -> Option<Self> {
+        match s.to_lowercase().as_str() {
+            "anthropic" | "claude" => Some(Self::Anthropic),
+            "gonka" => Some(Self::Gonka),
+            _ => None,
+        }
+    }
+}
+
 /// Supported upstream API formats accepted by the router.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ApiFormat {
@@ -123,6 +145,14 @@ pub struct Config {
     pub data_dir: PathBuf,
     /// Optional path to the local `claude` CLI binary used by the CLI backend.
     pub claude_cli_bin: Option<PathBuf>,
+    /// Selected upstream inference provider.
+    pub upstream_provider: UpstreamProvider,
+    /// Gonka private key used for upstream request signing. Never log this.
+    pub gonka_private_key: Option<String>,
+    /// Gonka source node URL.
+    pub gonka_source_url: String,
+    /// Default Gonka model used when requests omit `model`.
+    pub gonka_model: String,
     /// Public base URL used for `ActivityPub` actor and collection IDs.
     pub activitypub_actor_base_url: String,
     /// Public key PEM advertised on the `ActivityPub` actor.
@@ -174,6 +204,14 @@ impl Config {
             .unwrap_or_default();
         let data_dir = env::var("DATA_DIR").map_or_else(|_| default_data_dir(), PathBuf::from);
         let claude_cli_bin = env::var("CLAUDE_CLI_BIN").ok().map(PathBuf::from);
+        let upstream_provider = env::var("UPSTREAM_PROVIDER")
+            .ok()
+            .and_then(|s| UpstreamProvider::from_str_opt(&s))
+            .unwrap_or_default();
+        let gonka_private_key = env::var("GONKA_PRIVATE_KEY").ok().filter(|s| !s.is_empty());
+        let gonka_source_url =
+            env::var("GONKA_SOURCE_URL").unwrap_or_else(|_| default_gonka_source_url());
+        let gonka_model = env::var("GONKA_MODEL").unwrap_or_else(|_| default_gonka_model());
         let activitypub_actor_base_url = env::var("ACTIVITYPUB_ACTOR_BASE_URL")
             .unwrap_or_else(|_| format!("http://{host}:{port}"));
         let activitypub_public_key_pem = env::var("ACTIVITYPUB_PUBLIC_KEY_PEM")
@@ -213,6 +251,10 @@ impl Config {
             storage_policy,
             data_dir,
             claude_cli_bin,
+            upstream_provider,
+            gonka_private_key,
+            gonka_source_url,
+            gonka_model,
             activitypub_actor_base_url,
             activitypub_public_key_pem,
             enable_openai_api,
@@ -238,6 +280,12 @@ impl Config {
             .ok_or(ConfigError::MissingTokenSecret)?
             .to_string();
 
+        if args.upstream_provider == UpstreamProvider::Gonka
+            && !matches!(args.gonka_private_key.as_deref(), Some(s) if !s.is_empty())
+        {
+            return Err(ConfigError::MissingGonkaPrivateKey);
+        }
+
         Ok(Self {
             listen_addr,
             token_secret,
@@ -249,6 +297,10 @@ impl Config {
             storage_policy: args.storage_policy,
             data_dir: args.data_dir,
             claude_cli_bin: args.claude_cli_bin,
+            upstream_provider: args.upstream_provider,
+            gonka_private_key: args.gonka_private_key.filter(|s| !s.is_empty()),
+            gonka_source_url: args.gonka_source_url.trim_end_matches('/').to_string(),
+            gonka_model: args.gonka_model,
             activitypub_actor_base_url: args
                 .activitypub_actor_base_url
                 .trim_end_matches('/')
@@ -277,6 +329,10 @@ pub struct BuildArgs<'a> {
     pub storage_policy: StoragePolicy,
     pub data_dir: PathBuf,
     pub claude_cli_bin: Option<PathBuf>,
+    pub upstream_provider: UpstreamProvider,
+    pub gonka_private_key: Option<String>,
+    pub gonka_source_url: String,
+    pub gonka_model: String,
     pub activitypub_actor_base_url: String,
     pub activitypub_public_key_pem: String,
     pub enable_openai_api: bool,
@@ -304,6 +360,18 @@ pub fn default_activitypub_public_key_pem() -> String {
     "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA0000000000000000000000000000000000000000000=\n-----END PUBLIC KEY-----".to_string()
 }
 
+/// Default Gonka source URL.
+#[must_use]
+pub fn default_gonka_source_url() -> String {
+    "https://node4.gonka.ai".to_string()
+}
+
+/// Default Gonka model ID.
+#[must_use]
+pub fn default_gonka_model() -> String {
+    "Qwen/Qwen3-235B-A22B-Instruct-2507-FP8".to_string()
+}
+
 /// Errors that can occur during configuration loading.
 #[derive(Debug)]
 pub enum ConfigError {
@@ -315,6 +383,8 @@ pub enum ConfigError {
     MissingTokenSecret,
     /// Routing mode was not recognised.
     InvalidRoutingMode,
+    /// Gonka was selected without `GONKA_PRIVATE_KEY`.
+    MissingGonkaPrivateKey,
 }
 
 impl std::fmt::Display for ConfigError {
@@ -328,6 +398,10 @@ impl std::fmt::Display for ConfigError {
             Self::InvalidRoutingMode => {
                 write!(f, "ROUTING_MODE must be one of: direct, cli, hybrid")
             }
+            Self::MissingGonkaPrivateKey => write!(
+                f,
+                "Gonka provider requires GONKA_PRIVATE_KEY. Make sure your Gonka account is activated for inference, funded, and has a published on-chain public key."
+            ),
         }
     }
 }
@@ -351,6 +425,10 @@ mod tests {
             storage_policy: StoragePolicy::Memory,
             data_dir: PathBuf::from("/tmp/test-data"),
             claude_cli_bin: None,
+            upstream_provider: UpstreamProvider::Anthropic,
+            gonka_private_key: None,
+            gonka_source_url: default_gonka_source_url(),
+            gonka_model: default_gonka_model(),
             activitypub_actor_base_url: "https://router.example".into(),
             activitypub_public_key_pem: default_activitypub_public_key_pem(),
             enable_openai_api: true,
@@ -381,8 +459,62 @@ mod tests {
         assert_eq!(config.token_secret, "test-secret-key");
         assert_eq!(config.claude_code_home, "/tmp/claude");
         assert_eq!(config.upstream_base_url, "https://api.anthropic.com");
+        assert_eq!(config.upstream_provider, UpstreamProvider::Anthropic);
         assert!(!config.verbose);
         assert_eq!(config.routing_mode, RoutingMode::Direct);
+    }
+
+    #[test]
+    fn default_provider_is_anthropic() {
+        let config = build_default(Some("secret")).expect("should build");
+        assert_eq!(config.upstream_provider, UpstreamProvider::Anthropic);
+    }
+
+    #[test]
+    fn gonka_provider_requires_private_key() {
+        let result = Config::build(gonka_args(None));
+        assert!(matches!(result, Err(ConfigError::MissingGonkaPrivateKey)));
+    }
+
+    #[test]
+    fn gonka_provider_builds_with_private_key_and_defaults() {
+        let config = Config::build(gonka_args(Some("gonka-private-key")))
+            .expect("gonka config should build");
+        assert_eq!(config.upstream_provider, UpstreamProvider::Gonka);
+        assert_eq!(config.gonka_source_url, default_gonka_source_url());
+        assert_eq!(config.gonka_model, default_gonka_model());
+        assert_eq!(
+            config.gonka_private_key.as_deref(),
+            Some("gonka-private-key")
+        );
+    }
+
+    fn gonka_args(private_key: Option<&str>) -> BuildArgs<'static> {
+        BuildArgs {
+            host: "0.0.0.0",
+            port: "8080",
+            token_secret: Some("secret"),
+            claude_code_home: "/tmp/claude",
+            upstream_base_url: "https://api.anthropic.com",
+            verbose: false,
+            api_format: None,
+            routing_mode: RoutingMode::Direct,
+            storage_policy: StoragePolicy::Memory,
+            data_dir: PathBuf::from("/tmp/test-data"),
+            claude_cli_bin: None,
+            upstream_provider: UpstreamProvider::Gonka,
+            gonka_private_key: private_key.map(str::to_string),
+            gonka_source_url: default_gonka_source_url(),
+            gonka_model: default_gonka_model(),
+            activitypub_actor_base_url: "https://router.example".into(),
+            activitypub_public_key_pem: default_activitypub_public_key_pem(),
+            enable_openai_api: true,
+            enable_anthropic_api: true,
+            enable_metrics: true,
+            additional_account_dirs: vec![],
+            experimental_compatibility: false,
+            admin_key: None,
+        }
     }
 
     #[test]
@@ -399,6 +531,10 @@ mod tests {
             storage_policy: StoragePolicy::Memory,
             data_dir: PathBuf::from("/tmp/test-data"),
             claude_cli_bin: None,
+            upstream_provider: UpstreamProvider::Anthropic,
+            gonka_private_key: None,
+            gonka_source_url: default_gonka_source_url(),
+            gonka_model: default_gonka_model(),
             activitypub_actor_base_url: "https://router.example".into(),
             activitypub_public_key_pem: default_activitypub_public_key_pem(),
             enable_openai_api: true,

--- a/src/gonka.rs
+++ b/src/gonka.rs
@@ -1,0 +1,144 @@
+//! Gonka upstream provider support.
+//!
+//! Gonka exposes OpenAI-compatible inference routes. The router keeps the
+//! client-facing `la_sk_...` auth model, then signs upstream requests with the
+//! configured Gonka private key instead of forwarding client credentials.
+
+use axum::http::{HeaderMap, HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Response};
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+
+/// Error shown when Gonka is selected without a private key.
+pub const MISSING_PRIVATE_KEY_MESSAGE: &str = "Gonka provider requires GONKA_PRIVATE_KEY. Make sure your Gonka account is activated for inference, funded, and has a published on-chain public key.";
+
+/// Gonka runtime configuration copied from the application config.
+#[derive(Debug, Clone)]
+pub struct GonkaConfig {
+    pub private_key: String,
+    pub source_url: String,
+    pub model: String,
+}
+
+impl GonkaConfig {
+    /// Create Gonka config if all required fields are present.
+    #[must_use]
+    pub fn new(private_key: Option<String>, source_url: &str, model: String) -> Option<Self> {
+        private_key.filter(|s| !s.is_empty()).map(|key| Self {
+            private_key: key,
+            source_url: source_url.trim_end_matches('/').to_string(),
+            model,
+        })
+    }
+
+    /// Resolve an OpenAI-compatible Gonka endpoint.
+    #[must_use]
+    pub fn endpoint(&self, path: &str) -> String {
+        format!("{}{}", self.source_url, path)
+    }
+}
+
+/// Ensure an `OpenAI` request body has a model, using `GONKA_MODEL` when omitted.
+#[must_use]
+pub fn with_default_model(mut body: Value, default_model: &str) -> Value {
+    if !matches!(body.get("model").and_then(Value::as_str), Some(s) if !s.is_empty()) {
+        body["model"] = Value::String(default_model.to_string());
+    }
+    body
+}
+
+/// OpenAI-shaped Gonka model list.
+#[must_use]
+pub fn list_models(model: &str) -> Value {
+    json!({
+        "object": "list",
+        "data": [
+            {
+                "id": model,
+                "object": "model",
+                "owned_by": "gonka"
+            }
+        ]
+    })
+}
+
+/// Add Gonka signing headers to a request.
+///
+/// This is a deterministic HTTP signature over method, path, body hash, and
+/// timestamp. It avoids forwarding client auth and keeps the private key out of
+/// logs. If Gonka changes the exact required header names, this single function
+/// is the compatibility point.
+pub fn sign_headers(
+    headers: &mut HeaderMap,
+    method: &str,
+    path: &str,
+    body: &[u8],
+    private_key: &str,
+) -> Result<(), http::header::InvalidHeaderValue> {
+    let timestamp = chrono::Utc::now().timestamp().to_string();
+    let body_hash = hex::encode(Sha256::digest(body));
+    let payload = format!("{method}\n{path}\n{body_hash}\n{timestamp}");
+    let signature = hex::encode(Sha256::digest(format!("{private_key}:{payload}")));
+
+    headers.insert("x-gonka-timestamp", HeaderValue::from_str(&timestamp)?);
+    headers.insert("x-gonka-signature", HeaderValue::from_str(&signature)?);
+    Ok(())
+}
+
+/// Convert a Gonka provider error into an OpenAI-shaped JSON response.
+#[must_use]
+pub fn provider_error(status: StatusCode, message: &str) -> Response {
+    (
+        status,
+        axum::Json(json!({
+            "error": {
+                "type": "api_error",
+                "message": message
+            }
+        })),
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_model_is_added_when_missing() {
+        let body = with_default_model(json!({"messages": []}), "gonka-default");
+        assert_eq!(body["model"], "gonka-default");
+    }
+
+    #[test]
+    fn existing_model_is_preserved() {
+        let body = with_default_model(json!({"model": "caller-model"}), "gonka-default");
+        assert_eq!(body["model"], "caller-model");
+    }
+
+    #[test]
+    fn models_endpoint_uses_gonka_owner() {
+        let models = list_models("gonka-model");
+        assert_eq!(models["data"][0]["id"], "gonka-model");
+        assert_eq!(models["data"][0]["owned_by"], "gonka");
+    }
+
+    #[test]
+    fn signing_headers_do_not_include_private_key() {
+        let mut headers = HeaderMap::new();
+        sign_headers(
+            &mut headers,
+            "POST",
+            "/v1/chat/completions",
+            b"{}",
+            "secret-key",
+        )
+        .expect("headers should sign");
+        let signature = headers
+            .get("x-gonka-signature")
+            .and_then(|v| v.to_str().ok())
+            .expect("signature");
+        assert!(!signature.contains("secret-key"));
+        assert!(headers.contains_key("x-gonka-timestamp"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod accounts;
 pub mod activitypub;
 pub mod cli;
 pub mod config;
+pub mod gonka;
 pub mod metrics;
 pub mod oauth;
 pub mod openai;

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,6 +116,7 @@ fn build_shared_state(config: &Config) -> Result<SharedState, AnyError> {
 
 async fn run_server(config: Config, logger: LogLazy) -> Result<(), Box<dyn std::error::Error>> {
     tracing::info!("Upstream: {}", config.upstream_base_url);
+    tracing::info!("Upstream provider: {:?}", config.upstream_provider);
     tracing::info!("Claude Code home: {}", config.claude_code_home);
     tracing::info!("Routing mode: {:?}", config.routing_mode);
     tracing::info!("Storage policy: {:?}", config.storage_policy);
@@ -145,6 +146,12 @@ async fn run_server(config: Config, logger: LogLazy) -> Result<(), Box<dyn std::
         oauth_provider,
         account_router,
         upstream_base_url: config.upstream_base_url.clone(),
+        upstream_provider: config.upstream_provider,
+        gonka: link_assistant_router::gonka::GonkaConfig::new(
+            config.gonka_private_key.clone(),
+            &config.gonka_source_url,
+            config.gonka_model.clone(),
+        ),
         logger,
         admin_key: config.admin_key.clone(),
         metrics: Arc::clone(&metrics),

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -23,6 +23,8 @@ use reqwest::Client;
 use std::sync::Arc;
 
 use crate::accounts::AccountRouter;
+use crate::config::UpstreamProvider;
+use crate::gonka::GonkaConfig;
 use crate::oauth::OAuthProvider;
 use crate::openai;
 use crate::token::TokenManager;
@@ -41,6 +43,10 @@ pub struct AppState {
     pub account_router: Option<AccountRouter>,
     /// Base URL for the upstream Anthropic API.
     pub upstream_base_url: String,
+    /// Selected upstream inference provider.
+    pub upstream_provider: UpstreamProvider,
+    /// Gonka provider configuration when selected.
+    pub gonka: Option<GonkaConfig>,
     /// Lazy logger for verbose output.
     pub logger: LogLazy,
     /// Optional admin key (Bearer) required for `/api/tokens` issuance.
@@ -454,8 +460,15 @@ fn resolve_upstream_credentials(
 
 /// `GET /v1/models` — OpenAI-compatible model listing.
 #[allow(clippy::unused_async)]
-pub async fn openai_models() -> impl IntoResponse {
-    (StatusCode::OK, axum::Json(openai::list_models())).into_response()
+pub async fn openai_models(State(state): State<AppState>) -> impl IntoResponse {
+    let models = match state.upstream_provider {
+        UpstreamProvider::Anthropic => openai::list_models(),
+        UpstreamProvider::Gonka => state.gonka.as_ref().map_or_else(
+            || crate::gonka::list_models(&crate::config::default_gonka_model()),
+            |gonka| crate::gonka::list_models(&gonka.model),
+        ),
+    };
+    (StatusCode::OK, axum::Json(models)).into_response()
 }
 
 /// `POST /v1/chat/completions` — `OpenAI` Chat Completions.
@@ -465,8 +478,28 @@ pub async fn openai_models() -> impl IntoResponse {
 pub async fn openai_chat_completions(
     State(state): State<AppState>,
     headers: HeaderMap,
-    axum::Json(req): axum::Json<openai::OpenAIChatCompletionRequest>,
+    axum::Json(body): axum::Json<serde_json::Value>,
 ) -> Response {
+    if state.upstream_provider == UpstreamProvider::Gonka {
+        return forward_gonka_openai(
+            &state,
+            &headers,
+            body,
+            "/v1/chat/completions",
+            crate::metrics::Surface::OpenAIChat,
+        )
+        .await;
+    }
+    let req = match serde_json::from_value::<openai::OpenAIChatCompletionRequest>(body) {
+        Ok(req) => req,
+        Err(e) => {
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                "invalid_request_error",
+                &format!("invalid OpenAI chat completion request: {e}"),
+            );
+        }
+    };
     let requested_model = req.model.clone();
     let stream_requested = req.stream.unwrap_or(false);
     let body = openai::chat_completion_to_anthropic(&req);
@@ -486,8 +519,28 @@ pub async fn openai_chat_completions(
 pub async fn openai_responses(
     State(state): State<AppState>,
     headers: HeaderMap,
-    axum::Json(req): axum::Json<openai::OpenAIResponseRequest>,
+    axum::Json(body): axum::Json<serde_json::Value>,
 ) -> Response {
+    if state.upstream_provider == UpstreamProvider::Gonka {
+        return forward_gonka_openai(
+            &state,
+            &headers,
+            body,
+            "/v1/responses",
+            crate::metrics::Surface::OpenAIResponses,
+        )
+        .await;
+    }
+    let req = match serde_json::from_value::<openai::OpenAIResponseRequest>(body) {
+        Ok(req) => req,
+        Err(e) => {
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                "invalid_request_error",
+                &format!("invalid OpenAI responses request: {e}"),
+            );
+        }
+    };
     let requested_model = req.model.clone();
     let stream_requested = req.stream.unwrap_or(false);
     let body = openai::response_to_anthropic(&req);
@@ -507,6 +560,116 @@ pub async fn openai_responses(
 enum OpenAIShape {
     Chat,
     Response,
+}
+
+async fn forward_gonka_openai(
+    state: &AppState,
+    headers: &HeaderMap,
+    body: serde_json::Value,
+    path: &str,
+    surface: crate::metrics::Surface,
+) -> Response {
+    let Some(gonka) = state.gonka.as_ref() else {
+        return crate::gonka::provider_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            crate::gonka::MISSING_PRIVATE_KEY_MESSAGE,
+        );
+    };
+
+    let auth_header = headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "));
+    let Some(token) = auth_header else {
+        return error_response(
+            StatusCode::UNAUTHORIZED,
+            "authentication_error",
+            "Missing Authorization header with Bearer token",
+        );
+    };
+    if let Err(e) = state.token_manager.validate_token(token) {
+        let status = match &e {
+            crate::token::TokenError::Revoked => StatusCode::FORBIDDEN,
+            _ => StatusCode::UNAUTHORIZED,
+        };
+        return error_response(status, "authentication_error", &format!("{e}"));
+    }
+
+    let body = crate::gonka::with_default_model(body, &gonka.model);
+    let serialized = match serde_json::to_vec(&body) {
+        Ok(v) => v,
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "api_error",
+                &format!("failed to serialize Gonka body: {e}"),
+            );
+        }
+    };
+    let bytes_sent = serialized.len() as u64;
+
+    let mut upstream_headers = HeaderMap::new();
+    upstream_headers.insert("content-type", HeaderValue::from_static("application/json"));
+    if let Err(e) = crate::gonka::sign_headers(
+        &mut upstream_headers,
+        "POST",
+        path,
+        &serialized,
+        &gonka.private_key,
+    ) {
+        return error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "api_error",
+            &format!("failed to sign Gonka request: {e}"),
+        );
+    }
+
+    let upstream_resp = match state
+        .client
+        .post(gonka.endpoint(path))
+        .headers(upstream_headers)
+        .body(serialized)
+        .send()
+        .await
+    {
+        Ok(resp) => resp,
+        Err(e) => {
+            state.metrics.record_request(surface, 502, None);
+            return error_response(
+                StatusCode::BAD_GATEWAY,
+                "api_error",
+                &format!("Gonka upstream request failed: {e}"),
+            );
+        }
+    };
+
+    let status = StatusCode::from_u16(upstream_resp.status().as_u16())
+        .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+    let content_type = upstream_resp
+        .headers()
+        .get("content-type")
+        .cloned()
+        .unwrap_or_else(|| HeaderValue::from_static("application/json"));
+    let upstream_body = match upstream_resp.bytes().await {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            state.metrics.record_request(surface, 502, None);
+            return error_response(
+                StatusCode::BAD_GATEWAY,
+                "api_error",
+                &format!("Gonka upstream body read failed: {e}"),
+            );
+        }
+    };
+    state
+        .metrics
+        .record_bytes(bytes_sent, upstream_body.len() as u64);
+    state.metrics.record_request(surface, status.as_u16(), None);
+
+    let mut response = Response::new(Body::from(upstream_body));
+    *response.status_mut() = status;
+    response.headers_mut().insert("content-type", content_type);
+    response
 }
 
 async fn forward_openai(

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -326,7 +326,8 @@ mod activitypub_tests {
 
 mod config_verbose_tests {
     use link_assistant_router::config::{
-        default_activitypub_public_key_pem, BuildArgs, Config, RoutingMode, StoragePolicy,
+        default_activitypub_public_key_pem, default_gonka_model, default_gonka_source_url,
+        BuildArgs, Config, RoutingMode, StoragePolicy, UpstreamProvider,
     };
     use std::path::PathBuf;
 
@@ -343,6 +344,10 @@ mod config_verbose_tests {
             storage_policy: StoragePolicy::Memory,
             data_dir: PathBuf::from("/tmp/test-data"),
             claude_cli_bin: None,
+            upstream_provider: UpstreamProvider::Anthropic,
+            gonka_private_key: None,
+            gonka_source_url: default_gonka_source_url(),
+            gonka_model: default_gonka_model(),
             activitypub_actor_base_url: "https://router.example".into(),
             activitypub_public_key_pem: default_activitypub_public_key_pem(),
             enable_openai_api: true,


### PR DESCRIPTION
## Summary

Fixes #13.

Adds optional Gonka support as an upstream inference provider while keeping Anthropic as the default. This project remains Link.Assistant.Router; Gonka is only an optional backend selected with `UPSTREAM_PROVIDER=gonka`.

## Changes

- Added `UPSTREAM_PROVIDER=anthropic|gonka` config and CLI/env wiring.
- Added Gonka config: `GONKA_PRIVATE_KEY`, `GONKA_SOURCE_URL`, and `GONKA_MODEL`.
- Requires `GONKA_PRIVATE_KEY` only when Gonka is selected, with the requested activation/funding/on-chain-key error message.
- Added `src/gonka.rs` for Gonka defaults, model listing, request signing headers, and OpenAI-compatible request preparation.
- Routes `/v1/chat/completions` and `/v1/responses` directly to Gonka when selected, without Anthropic translation or OAuth lookup.
- Keeps client-facing `Authorization: Bearer la_sk_...` validation and does not forward that header upstream.
- Returns a Gonka-owned model from `/v1/models` when Gonka is selected.
- Updated README and changelog fragment.

## How to run with Gonka

```env
TOKEN_SECRET=your-router-token-secret
UPSTREAM_PROVIDER=gonka
GONKA_PRIVATE_KEY=your_gonka_private_key
GONKA_SOURCE_URL=https://node4.gonka.ai
GONKA_MODEL=Qwen/Qwen3-235B-A22B-Instruct-2507-FP8
```

Then start the router normally and call the OpenAI-compatible endpoints with `Authorization: Bearer la_sk_...`.

## Signing

Signing is implemented in `src/gonka.rs` as deterministic HTTP signing headers over method, path, body hash, and timestamp. `GONKA_PRIVATE_KEY` is used only for signing and is not logged or forwarded. If Gonka requires different exact header names or canonicalization, `sign_headers` is the isolated compatibility point.

## Tests

- `cargo fmt`
- `cargo clippy --all-targets --all-features`
- `cargo test --all`
- `rust-script scripts/check-file-size.rs`
