### PR TITLE
Add support docs and deployment templates

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-05-03T12:18:18.433Z for PR creation at branch issue-9-d545a925a750 for issue https://github.com/link-assistant/router/issues/9
-# Updated: 2026-05-09T06:46:09.721Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-03T12:18:18.433Z for PR creation at branch issue-9-d545a925a750 for issue https://github.com/link-assistant/router/issues/9
+# Updated: 2026-05-09T06:46:09.721Z

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,7 +909,7 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "link-assistant-router"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/README.md
+++ b/README.md
@@ -434,6 +434,23 @@ sudo systemctl status link-assistant-router
 journalctl -u link-assistant-router -f
 ```
 
+### Akash and Kubernetes
+
+Ready-to-edit deployment templates are included for hosted environments:
+
+- [Akash SDL](deploy/akash/deploy.yaml)
+- [Kubernetes manifests](deploy/k8s/router.yaml)
+
+Replace placeholder secrets, set `ACTIVITYPUB_ACTOR_BASE_URL` to the public
+router URL, and mount or provision Claude Code credentials at
+`CLAUDE_CODE_HOME` before exposing the service.
+
+## ForgeFed Integration
+
+The router exposes ActivityPub/ForgeFed endpoints for service discovery and
+problem-source federation. See [docs/forgefed.md](docs/forgefed.md) for the
+actor document, inbox, follow activity, and deployment verification steps.
+
 ## Token System
 
 The router uses JWT-based custom tokens with the `la_sk_` prefix.

--- a/changelog.d/20260509_000000_support_docs_templates.md
+++ b/changelog.d/20260509_000000_support_docs_templates.md
@@ -1,0 +1,3 @@
+### Added
+- Document ForgeFed integration endpoints and deployment verification steps.
+- Add Akash SDL and Kubernetes deployment templates for the router.

--- a/deploy/akash/deploy.yaml
+++ b/deploy/akash/deploy.yaml
@@ -1,0 +1,42 @@
+---
+version: "2.0"
+
+services:
+  router:
+    image: ghcr.io/link-assistant/router:latest
+    expose:
+      - port: 8080
+        as: 80
+        to:
+          - global: true
+    env:
+      - ROUTER_HOST=0.0.0.0
+      - ROUTER_PORT=8080
+      - CLAUDE_CODE_HOME=/data/claude
+      - DATA_DIR=/data/router
+      - ACTIVITYPUB_ACTOR_BASE_URL=https://router.example.com
+      - TOKEN_SECRET=replace-with-secure-secret
+      - ACTIVITYPUB_PUBLIC_KEY_PEM=replace-with-public-key-pem
+
+profiles:
+  compute:
+    router:
+      resources:
+        cpu:
+          units: 0.25
+        memory:
+          size: 512Mi
+        storage:
+          size: 2Gi
+  placement:
+    dcloud:
+      pricing:
+        router:
+          denom: uakt
+          amount: 1000
+
+deployment:
+  router:
+    dcloud:
+      profile: router
+      count: 1

--- a/deploy/k8s/router.yaml
+++ b/deploy/k8s/router.yaml
@@ -1,0 +1,124 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: link-assistant
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: link-assistant-router
+  namespace: link-assistant
+type: Opaque
+stringData:
+  TOKEN_SECRET: replace-with-secure-secret
+  ACTIVITYPUB_PUBLIC_KEY_PEM: |
+    -----BEGIN PUBLIC KEY-----
+    replace-with-public-key
+    -----END PUBLIC KEY-----
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: link-assistant-router-data
+  namespace: link-assistant
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: link-assistant-router
+  namespace: link-assistant
+  labels:
+    app.kubernetes.io/name: link-assistant-router
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: link-assistant-router
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: link-assistant-router
+    spec:
+      containers:
+        - name: router
+          image: ghcr.io/link-assistant/router:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: ROUTER_HOST
+              value: 0.0.0.0
+            - name: ROUTER_PORT
+              value: "8080"
+            - name: CLAUDE_CODE_HOME
+              value: /data/claude
+            - name: DATA_DIR
+              value: /data/router
+            - name: ACTIVITYPUB_ACTOR_BASE_URL
+              value: https://router.example.com
+            - name: TOKEN_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: link-assistant-router
+                  key: TOKEN_SECRET
+            - name: ACTIVITYPUB_PUBLIC_KEY_PEM
+              valueFrom:
+                secretKeyRef:
+                  name: link-assistant-router
+                  key: ACTIVITYPUB_PUBLIC_KEY_PEM
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 30
+          volumeMounts:
+            - name: router-data
+              mountPath: /data
+      volumes:
+        - name: router-data
+          persistentVolumeClaim:
+            claimName: link-assistant-router-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: link-assistant-router
+  namespace: link-assistant
+spec:
+  selector:
+    app.kubernetes.io/name: link-assistant-router
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: link-assistant-router
+  namespace: link-assistant
+spec:
+  rules:
+    - host: router.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: link-assistant-router
+                port:
+                  name: http

--- a/docs/forgefed.md
+++ b/docs/forgefed.md
@@ -1,0 +1,64 @@
+# ForgeFed Integration
+
+Link.Assistant.Router exposes a small ActivityPub/ForgeFed surface so coding
+problem sources can discover and address the router as a service actor.
+
+## Endpoints
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `/actor/code` | `GET` | Public service actor document |
+| `/inbox/code` | `POST` | Inbound ActivityStreams activities |
+| `/outbox/code` | `GET` | Local actor outbox collection |
+| `/actors/code/followers` | `GET` | Local followers collection |
+| `/activities/follow-problemsets-code-001` | `GET` | Follow activity targeting `problemsets.lefine.pro` |
+
+All successful ActivityPub responses use `application/activity+json`.
+
+## Configuration
+
+Set these values when the router is served from a public URL:
+
+| Variable | Description |
+|---|---|
+| `ACTIVITYPUB_ACTOR_BASE_URL` | Public origin used in actor, inbox, outbox, and activity IDs |
+| `ACTIVITYPUB_PUBLIC_KEY_PEM` | PEM public key advertised in the actor document |
+
+Example:
+
+```bash
+export ACTIVITYPUB_ACTOR_BASE_URL=https://router.example.com
+export ACTIVITYPUB_PUBLIC_KEY_PEM="$(cat public.pem)"
+export TOKEN_SECRET="$(openssl rand -hex 32)"
+link-assistant-router serve
+```
+
+## Discovery Check
+
+After deployment, verify the actor document:
+
+```bash
+curl -H 'Accept: application/activity+json' \
+  https://router.example.com/actor/code | jq .
+```
+
+The response should include:
+
+- `@context` containing `https://www.w3.org/ns/activitystreams` and
+  `https://forgefed.org/ns`
+- `type` set to `Service`
+- `inbox` set to the public `/inbox/code` URL
+- `publicKey.owner` matching the actor ID
+
+## Following Problem Sets
+
+The router publishes a reusable Follow activity for the public problemsets
+actor:
+
+```bash
+curl -H 'Accept: application/activity+json' \
+  https://router.example.com/activities/follow-problemsets-code-001 | jq .
+```
+
+Submit that activity to a compatible ForgeFed inbox when a remote problem source
+requires an explicit follow request.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -532,3 +532,38 @@ mod cli_parser_tests {
         assert!(!cli.disable_anthropic_api);
     }
 }
+
+mod support_docs_tests {
+    use std::fs;
+
+    #[test]
+    fn forgefed_docs_describe_public_actor_and_inbox() {
+        let docs = fs::read_to_string("docs/forgefed.md").expect("forgefed docs should exist");
+
+        assert!(docs.contains("/actor/code"));
+        assert!(docs.contains("/inbox/code"));
+        assert!(docs.contains("https://forgefed.org/ns"));
+        assert!(docs.contains("ACTIVITYPUB_ACTOR_BASE_URL"));
+    }
+
+    #[test]
+    fn akash_template_exposes_router_and_required_configuration() {
+        let sdl = fs::read_to_string("deploy/akash/deploy.yaml").expect("akash SDL should exist");
+
+        assert!(sdl.contains("version: \"2.0\""));
+        assert!(sdl.contains("port: 8080"));
+        assert!(sdl.contains("TOKEN_SECRET=replace-with-secure-secret"));
+        assert!(sdl.contains("ACTIVITYPUB_ACTOR_BASE_URL=https://router.example.com"));
+    }
+
+    #[test]
+    fn kubernetes_template_includes_deployment_service_and_health_probes() {
+        let manifest =
+            fs::read_to_string("deploy/k8s/router.yaml").expect("k8s manifest should exist");
+
+        assert!(manifest.contains("kind: Deployment"));
+        assert!(manifest.contains("kind: Service"));
+        assert!(manifest.contains("path: /health"));
+        assert!(manifest.contains("ACTIVITYPUB_PUBLIC_KEY_PEM"));
+    }
+}


### PR DESCRIPTION
## Summary
- document ForgeFed/ActivityPub integration endpoints and verification steps
- add Akash SDL and Kubernetes deployment templates
- link the new support docs from the README and add a changelog fragment

Fixes #15

## Testing
- cargo fmt --all -- --check
- cargo test --test integration_test support_docs_tests --verbose
- cargo clippy --all-targets --all-features
- cargo test --all-features --verbose
- rust-script scripts/check-file-size.rs