### PR TITLE
ci: publish release container to GitHub Packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,6 +247,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -292,8 +293,39 @@ jobs:
         if: steps.check.outputs.should_release == 'true'
         id: publish-crate
         env:
-          CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
+          CARGO_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
         run: rust-script scripts/publish-crate.rs
+
+      - name: Log in to GitHub Container Registry
+        if: steps.check.outputs.should_release == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: steps.check.outputs.should_release == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract Docker metadata
+        if: steps.check.outputs.should_release == 'true'
+        id: docker-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest
+            type=raw,value=${{ steps.current_version.outputs.version }}
+
+      - name: Publish Docker image to GitHub Packages
+        if: steps.check.outputs.should_release == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.docker-meta.outputs.tags }}
+          labels: ${{ steps.docker-meta.outputs.labels }}
 
       - name: Create GitHub Release
         if: steps.check.outputs.should_release == 'true'
@@ -316,6 +348,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -349,8 +382,39 @@ jobs:
         if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
         id: publish-crate
         env:
-          CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
+          CARGO_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
         run: rust-script scripts/publish-crate.rs
+
+      - name: Log in to GitHub Container Registry
+        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract Docker metadata
+        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
+        id: docker-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest
+            type=raw,value=${{ steps.version.outputs.new_version }}
+
+      - name: Publish Docker image to GitHub Packages
+        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.docker-meta.outputs.tags }}
+          labels: ${{ steps.docker-meta.outputs.labels }}
 
       - name: Create GitHub Release
         if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-05-03T12:18:18.433Z for PR creation at branch issue-9-d545a925a750 for issue https://github.com/link-assistant/router/issues/9
-# Updated: 2026-05-09T08:44:42.557Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-03T12:18:18.433Z for PR creation at branch issue-9-d545a925a750 for issue https://github.com/link-assistant/router/issues/9
+# Updated: 2026-05-09T08:44:42.557Z

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,7 +963,7 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "link-assistant-router"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/changelog.d/20260509_090000_publish_ghcr_container.md
+++ b/changelog.d/20260509_090000_publish_ghcr_container.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Added
+- Publish release Docker images to GitHub Container Registry alongside crates.io releases.

--- a/scripts/check-release-workflow.rs
+++ b/scripts/check-release-workflow.rs
@@ -1,0 +1,53 @@
+#!/usr/bin/env rust-script
+//! Validate release workflow publishing invariants.
+
+use std::fs;
+use std::process::exit;
+
+fn main() {
+    let workflow = fs::read_to_string(".github/workflows/release.yml")
+        .expect("failed to read .github/workflows/release.yml");
+
+    let required_snippets = [
+        "auto-release:",
+        "manual-release:",
+        "packages: write",
+        "CARGO_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}",
+        "docker/login-action@v3",
+        "docker/setup-buildx-action@v3",
+        "docker/metadata-action@v5",
+        "docker/build-push-action@v6",
+        "ghcr.io/${{ github.repository }}",
+        "type=raw,value=latest",
+        "type=raw,value=${{ steps.current_version.outputs.version }}",
+        "type=raw,value=${{ steps.version.outputs.new_version }}",
+    ];
+
+    let mut failures = Vec::new();
+    for snippet in required_snippets {
+        if !workflow.contains(snippet) {
+            failures.push(format!("missing required release workflow snippet: {snippet}"));
+        }
+    }
+
+    if count_occurrences(&workflow, "packages: write") < 2 {
+        failures.push("auto and manual release jobs must both grant packages: write".to_string());
+    }
+
+    if count_occurrences(&workflow, "docker/build-push-action@v6") < 2 {
+        failures.push("auto and manual release jobs must both publish a Docker image".to_string());
+    }
+
+    if failures.is_empty() {
+        println!("release workflow publishes crates and GHCR images");
+    } else {
+        for failure in failures {
+            eprintln!("Error: {failure}");
+        }
+        exit(1);
+    }
+}
+
+fn count_occurrences(haystack: &str, needle: &str) -> usize {
+    haystack.match_indices(needle).count()
+}


### PR DESCRIPTION
## Summary
- publish release Docker images to GitHub Container Registry for automatic and manual releases
- grant release jobs `packages: write` and tag images as `latest` plus the release version
- preserve crates.io publishing with `CARGO_REGISTRY_TOKEN` fallback and add a workflow invariant check
- sync `Cargo.lock` to the current crate version so packaging checks run from a clean tree

Fixes #17

## Testing
- `cargo fmt --check`
- `rust-script scripts/check-release-workflow.rs`
- `cargo clippy --all-targets --all-features`
- `cargo test --all-features --verbose`
- `rust-script scripts/check-file-size.rs`
- `cargo package --list`