### PR TITLE
fix: harden crates.io release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings
   # Support both CARGO_REGISTRY_TOKEN (cargo's native env var) and CARGO_TOKEN (for backwards compatibility)
-  CARGO_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
+  CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
 
 jobs:
   # === DETECT CHANGES - determines which jobs should run ===
@@ -293,7 +293,7 @@ jobs:
         if: steps.check.outputs.should_release == 'true'
         id: publish-crate
         env:
-          CARGO_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
         run: rust-script scripts/publish-crate.rs
 
       - name: Log in to GitHub Container Registry
@@ -331,7 +331,7 @@ jobs:
         if: steps.check.outputs.should_release == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: rust-script scripts/create-github-release.rs --release-version "${{ steps.current_version.outputs.version }}" --repository "${{ github.repository }}"
+        run: rust-script scripts/create-github-release.rs --release-version "${{ steps.current_version.outputs.version }}" --repository "${{ github.repository }}" --crates-io-url "https://crates.io/crates/link-assistant-router"
 
   # === MANUAL INSTANT RELEASE ===
   # Manual release via workflow_dispatch - only after CI passes
@@ -382,7 +382,7 @@ jobs:
         if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
         id: publish-crate
         env:
-          CARGO_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
         run: rust-script scripts/publish-crate.rs
 
       - name: Log in to GitHub Container Registry
@@ -420,7 +420,7 @@ jobs:
         if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: rust-script scripts/create-github-release.rs --release-version "${{ steps.version.outputs.new_version }}" --repository "${{ github.repository }}"
+        run: rust-script scripts/create-github-release.rs --release-version "${{ steps.version.outputs.new_version }}" --repository "${{ github.repository }}" --crates-io-url "https://crates.io/crates/link-assistant-router"
 
   # === MANUAL CHANGELOG PR ===
   changelog-pr:

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-03T12:18:18.433Z for PR creation at branch issue-9-d545a925a750 for issue https://github.com/link-assistant/router/issues/9
+# Updated: 2026-05-09T11:04:51.152Z

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,7 +963,7 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "link-assistant-router"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 A Rust-based API gateway that proxies Anthropic (Claude) APIs through a Claude MAX OAuth session, providing multi-tenant access via custom-issued tokens.
 
 [![CI/CD Pipeline](https://github.com/link-assistant/router/workflows/CI%2FCD%20Pipeline/badge.svg)](https://github.com/link-assistant/router/actions)
+[![crates.io](https://img.shields.io/crates/v/link-assistant-router.svg?label=crates.io)](https://crates.io/crates/link-assistant-router)
+[![docs.rs](https://img.shields.io/docsrs/link-assistant-router?label=docs.rs)](https://docs.rs/link-assistant-router)
 [![Rust Version](https://img.shields.io/badge/rust-1.70%2B-blue.svg)](https://www.rust-lang.org/)
 [![License: Unlicense](https://img.shields.io/badge/license-Unlicense-blue.svg)](http://unlicense.org/)
 

--- a/changelog.d/20260509_120000_release_badges_and_cargo_token_fallback.md
+++ b/changelog.d/20260509_120000_release_badges_and_cargo_token_fallback.md
@@ -1,0 +1,12 @@
+---
+bump: patch
+---
+
+### Fixed
+
+- Map both `CARGO_REGISTRY_TOKEN` and `CARGO_TOKEN` secrets into Cargo's native `CARGO_REGISTRY_TOKEN` environment variable in release jobs, keeping the crates.io publish fallback explicit and consistent.
+
+### Added
+
+- Add crates.io and docs.rs badges to the README, and include a crates.io badge/link in generated GitHub release notes.
+- Extend the release workflow invariant check to verify crates.io secret fallback, GHCR publishing, and release-note crates.io links.

--- a/docs/ci-cd/troubleshooting.md
+++ b/docs/ci-cd/troubleshooting.md
@@ -93,8 +93,8 @@ The "Publish to Crates.io" step fails with an error.
 ```yaml
 - name: Publish to Crates.io
   env:
-    CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN }}
-  run: node scripts/publish-crate.mjs
+    CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
+  run: rust-script scripts/publish-crate.rs
 ```
 
 #### "already uploaded" or "already exists"
@@ -129,8 +129,8 @@ The "Publish to Crates.io" step fails with an error.
 If using organization secrets with different names, map them in your workflow:
 ```yaml
 env:
-  # Map organization secret to the expected variable name
-  CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN }}
+  # Map either supported secret name to Cargo's native variable name.
+  CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
 ```
 
 ### Checking Secret Values
@@ -145,7 +145,7 @@ Secrets are masked in logs, but you can verify they're set:
       echo "WARNING: CARGO_REGISTRY_TOKEN is NOT set"
     fi
   env:
-    CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN }}
+    CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
 ```
 
 ### Reference
@@ -166,10 +166,10 @@ This template auto-detects the repository structure:
 If auto-detection fails, you can explicitly configure the Rust root:
 ```bash
 # Via environment variable
-RUST_ROOT=rust node scripts/publish-crate.mjs
+RUST_ROOT=rust rust-script scripts/publish-crate.rs
 
 # Via CLI argument
-node scripts/publish-crate.mjs --rust-root rust
+rust-script scripts/publish-crate.rs --rust-root rust
 ```
 
 ### Workflow Configuration
@@ -182,7 +182,7 @@ defaults:
 steps:
   - name: Publish to Crates.io
     working-directory: .  # Override for scripts that handle paths themselves
-    run: node rust/scripts/publish-crate.mjs
+    run: rust-script rust/scripts/publish-crate.rs
 ```
 
 ### Reference

--- a/scripts/check-release-workflow.rs
+++ b/scripts/check-release-workflow.rs
@@ -12,7 +12,7 @@ fn main() {
         "auto-release:",
         "manual-release:",
         "packages: write",
-        "CARGO_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}",
+        "CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}",
         "docker/login-action@v3",
         "docker/setup-buildx-action@v3",
         "docker/metadata-action@v5",
@@ -21,6 +21,7 @@ fn main() {
         "type=raw,value=latest",
         "type=raw,value=${{ steps.current_version.outputs.version }}",
         "type=raw,value=${{ steps.version.outputs.new_version }}",
+        "--crates-io-url \"https://crates.io/crates/link-assistant-router\"",
     ];
 
     let mut failures = Vec::new();
@@ -36,6 +37,28 @@ fn main() {
 
     if count_occurrences(&workflow, "docker/build-push-action@v6") < 2 {
         failures.push("auto and manual release jobs must both publish a Docker image".to_string());
+    }
+
+    if count_occurrences(
+        &workflow,
+        "CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}",
+    ) < 3
+    {
+        failures.push(
+            "workflow must map both CARGO_REGISTRY_TOKEN and CARGO_TOKEN secrets to Cargo's native CARGO_REGISTRY_TOKEN env var"
+                .to_string(),
+        );
+    }
+
+    if count_occurrences(
+        &workflow,
+        "--crates-io-url \"https://crates.io/crates/link-assistant-router\"",
+    ) < 2
+    {
+        failures.push(
+            "auto and manual GitHub releases must include the crates.io release badge/link"
+                .to_string(),
+        );
     }
 
     if failures.is_empty() {

--- a/scripts/create-github-release.rs
+++ b/scripts/create-github-release.rs
@@ -54,6 +54,13 @@ fn get_changelog_for_version(version: &str) -> String {
     }
 }
 
+fn crates_io_badge(url: &str) -> String {
+    format!(
+        "[![crates.io](https://img.shields.io/crates/v/link-assistant-router.svg?label=crates.io)]({})",
+        url
+    )
+}
+
 #[derive(Serialize)]
 struct ReleasePayload {
     tag_name: String,
@@ -88,9 +95,9 @@ fn main() {
 
     let mut release_notes = get_changelog_for_version(&version);
 
-    // Add crates.io link if provided
+    // Add crates.io badge/link if provided so release pages visibly show registry status.
     if let Some(url) = crates_io_url {
-        release_notes = format!("{}\n\n{}", url, release_notes);
+        release_notes = format!("{}\n\n{}", crates_io_badge(&url), release_notes);
     }
 
     // Create release using GitHub API with JSON input

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -1,0 +1,59 @@
+use std::fs;
+
+#[test]
+fn release_workflow_maps_crates_io_token_fallback_to_cargo_native_env() {
+    let workflow = fs::read_to_string(".github/workflows/release.yml")
+        .expect("release workflow should be readable");
+
+    let mapping =
+        "CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}";
+    assert!(
+        workflow.contains(mapping),
+        "release workflow should support both CARGO_REGISTRY_TOKEN and CARGO_TOKEN secrets"
+    );
+    assert_eq!(
+        workflow.matches(mapping).count(),
+        3,
+        "global env plus both publish jobs should use Cargo's native token variable"
+    );
+    assert!(
+        !workflow
+            .contains("CARGO_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}"),
+        "workflow should not map fallback secrets only to the non-native CARGO_TOKEN env var"
+    );
+}
+
+#[test]
+fn release_workflow_adds_crates_io_link_to_github_releases() {
+    let workflow = fs::read_to_string(".github/workflows/release.yml")
+        .expect("release workflow should be readable");
+    let release_script = fs::read_to_string("scripts/create-github-release.rs")
+        .expect("release script should be readable");
+
+    let crates_url_arg = "--crates-io-url \"https://crates.io/crates/link-assistant-router\"";
+    assert_eq!(
+        workflow.matches(crates_url_arg).count(),
+        2,
+        "auto and manual GitHub releases should include the crates.io package URL"
+    );
+    assert!(
+        release_script
+            .contains("https://img.shields.io/crates/v/link-assistant-router.svg?label=crates.io"),
+        "release notes should render a visible crates.io badge"
+    );
+}
+
+#[test]
+fn readme_exposes_release_status_badges() {
+    let readme = fs::read_to_string("README.md").expect("README should be readable");
+
+    assert!(
+        readme
+            .contains("https://img.shields.io/crates/v/link-assistant-router.svg?label=crates.io"),
+        "README should show the crates.io version badge"
+    );
+    assert!(
+        readme.contains("https://img.shields.io/docsrs/link-assistant-router?label=docs.rs"),
+        "README should show the docs.rs badge"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #21.

This PR hardens the Rust release pipeline around crates.io publication and makes release status easier to verify visually.

### Changes

- Map both `CARGO_REGISTRY_TOKEN` and `CARGO_TOKEN` secrets into Cargo's native `CARGO_REGISTRY_TOKEN` environment variable for auto and manual release publish steps.
- Add crates.io and docs.rs badges to `README.md`.
- Add a crates.io badge/link to generated GitHub Release notes via `--crates-io-url`.
- Extend `scripts/check-release-workflow.rs` and add `tests/release_workflow_test.rs` so token fallback, release-note crates.io links, and README badges are covered by automated checks.
- Refresh CI/CD troubleshooting docs to match the Rust `rust-script` scripts and fallback secret mapping.
- Keep `Cargo.lock` synced with the current `Cargo.toml` package version.

### Reproduction / Root Cause

The failure mode described in issue #21 is a release secret mismatch: workflows may have either `CARGO_REGISTRY_TOKEN` or `CARGO_TOKEN`, but Cargo's native variable is `CARGO_REGISTRY_TOKEN`. The previous workflow put the fallback into `CARGO_TOKEN`, which works only because the custom script checks both names; this PR maps fallback secrets into the native variable explicitly and verifies that invariant.

### Tests

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo test --test release_workflow_test`
- `cargo test --all-features`

Note: `rust-script scripts/check-release-workflow.rs` could not be run locally because `rust-script` is not installed in this environment; the new Rust integration test covers the same release workflow invariants directly.