### PR TITLE
feat(codex): detect token expiry via JWT exp and persist rotated token to disk

### DIFF
--- a/src/gemini.rs
+++ b/src/gemini.rs
@@ -282,6 +282,7 @@ async fn forward(
             crate::subscription::SubscriptionProvider::Gemini,
             disk_token,
             now_ms,
+            None,
         )
         .await;
 

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -115,6 +115,7 @@ fn encode_form(pairs: &[(&str, &str)]) -> String {
 struct RefreshResponse {
     access_token: Option<String>,
     refresh_token: Option<String>,
+    id_token: Option<String>,
     expires_in: Option<i64>,
 }
 
@@ -156,6 +157,12 @@ fn merge_refresh_response(
     now_ms: i64,
 ) -> Option<SubscriptionToken> {
     let access_token = resp.access_token.clone().filter(|s| !s.is_empty())?;
+    // Prefer the endpoint's `expires_in`; fall back to the new access token's JWT
+    // `exp` (Codex omits `expires_in`) so expiry is known for the next refresh.
+    let expires_at_ms = resp
+        .expires_in
+        .map(|secs| now_ms + secs * 1000)
+        .or_else(|| crate::subscription::jwt_exp_ms(&access_token));
     Some(SubscriptionToken {
         access_token,
         refresh_token: resp
@@ -163,9 +170,14 @@ fn merge_refresh_response(
             .clone()
             .filter(|s| !s.is_empty())
             .or_else(|| prev.refresh_token.clone()),
-        expires_at_ms: resp.expires_in.map(|secs| now_ms + secs * 1000),
+        expires_at_ms,
         account_id: prev.account_id.clone(),
         resource_url: prev.resource_url.clone(),
+        id_token: resp
+            .id_token
+            .clone()
+            .filter(|s| !s.is_empty())
+            .or_else(|| prev.id_token.clone()),
     })
 }
 
@@ -241,6 +253,20 @@ pub async fn refresh(
         .ok_or_else(|| RefreshError::Parse("response contained no access_token".to_string()))
 }
 
+/// Environment flag opting into writing a refreshed credential back to disk.
+pub const REFRESH_PERSIST_ENV: &str = "SUBSCRIPTION_REFRESH_PERSIST";
+
+/// Whether disk persistence of refreshed tokens is enabled via the environment.
+fn persist_enabled() -> bool {
+    std::env::var(REFRESH_PERSIST_ENV)
+        .ok()
+        .map(|v| {
+            let v = v.trim().to_ascii_lowercase();
+            v == "1" || v == "true" || v == "yes" || v == "on"
+        })
+        .unwrap_or(false)
+}
+
 /// Process-wide cache of refreshed subscription tokens, keyed by provider.
 ///
 /// Holds only in-memory copies obtained via OAuth refresh; vendor credential
@@ -265,6 +291,15 @@ impl TokenCache {
     /// 2. Otherwise reuse a cached refreshed token while it remains valid.
     /// 3. Otherwise exchange the refresh token and cache the result.
     ///
+    /// The refresh exchanges the freshest `refresh_token` we hold — the last
+    /// in-memory rotation if present, else the on-disk one — so single-use
+    /// rotation chains correctly across refreshes rather than replaying a stale
+    /// on-disk token.
+    ///
+    /// When `persist_to` is `Some` and `SUBSCRIPTION_REFRESH_PERSIST` is enabled,
+    /// a successful refresh is written back to the credential file so the rotated
+    /// `refresh_token` survives a process restart (like the vendor CLI does).
+    ///
     /// On refresh failure the (expired) disk token is returned unchanged so the
     /// caller can still attempt the upstream call and surface its error.
     pub async fn get_fresh(
@@ -273,6 +308,7 @@ impl TokenCache {
         provider: SubscriptionProvider,
         disk_token: SubscriptionToken,
         now_ms: i64,
+        persist_to: Option<&crate::subscription::SubscriptionReader>,
     ) -> SubscriptionToken {
         if !disk_token.is_expired(now_ms) {
             return disk_token;
@@ -280,9 +316,26 @@ impl TokenCache {
         if let Some(cached) = self.cached_valid(provider, now_ms) {
             return cached;
         }
-        match refresh(client, provider, &disk_token, now_ms).await {
+        // Chain rotation: refresh from the freshest refresh_token we know.
+        let prev = self
+            .cached_any(provider)
+            .filter(|token| token.refresh_token.is_some())
+            .unwrap_or_else(|| disk_token.clone());
+        match refresh(client, provider, &prev, now_ms).await {
             Ok(fresh) => {
                 self.store(provider, fresh.clone());
+                if let Some(reader) = persist_to {
+                    if persist_enabled() {
+                        match reader.persist_token(&fresh) {
+                            Ok(()) => tracing::info!(
+                                "refreshed and persisted {provider} subscription token"
+                            ),
+                            Err(e) => {
+                                tracing::warn!("persisting refreshed {provider} token failed: {e}")
+                            }
+                        }
+                    }
+                }
                 fresh
             }
             Err(e) => {
@@ -304,6 +357,13 @@ impl TokenCache {
             .cloned()
     }
 
+    /// The cached token for `provider` regardless of expiry (for its
+    /// most-recently-rotated `refresh_token`).
+    fn cached_any(&self, provider: SubscriptionProvider) -> Option<SubscriptionToken> {
+        let guard = self.inner.lock().ok()?;
+        guard.get(&provider).cloned()
+    }
+
     fn store(&self, provider: SubscriptionProvider, token: SubscriptionToken) {
         if let Ok(mut guard) = self.inner.lock() {
             guard.insert(provider, token);
@@ -322,6 +382,7 @@ mod tests {
             expires_at_ms: exp,
             account_id: Some("acct_1".into()),
             resource_url: Some("portal.qwen.ai".into()),
+            id_token: None,
         }
     }
 
@@ -348,6 +409,7 @@ mod tests {
         let resp = RefreshResponse {
             access_token: Some("new-access".into()),
             refresh_token: None,
+            id_token: None,
             expires_in: Some(3600),
         };
         let merged = merge_refresh_response(&prev, &resp, 1_000).unwrap();
@@ -365,6 +427,7 @@ mod tests {
         let resp = RefreshResponse {
             access_token: Some("new-access".into()),
             refresh_token: Some("r2".into()),
+            id_token: None,
             expires_in: None,
         };
         let merged = merge_refresh_response(&prev, &resp, 1_000).unwrap();
@@ -379,13 +442,44 @@ mod tests {
         assert!(merge_refresh_response(&prev, &resp, 1_000).is_none());
     }
 
+    #[test]
+    fn merge_carries_id_token_and_derives_expiry_from_jwt() {
+        use base64::Engine as _;
+        let enc = |b: &[u8]| base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(b);
+        // Codex omits `expires_in`; expiry must come from the new access JWT `exp`.
+        let access = format!("{}.{}.sig", enc(br#"{}"#), enc(br#"{"exp":5000}"#));
+        let prev = token(Some("r1"), Some(0));
+        let resp = RefreshResponse {
+            access_token: Some(access),
+            refresh_token: Some("r2".into()),
+            id_token: Some("idt".into()),
+            expires_in: None,
+        };
+        let merged = merge_refresh_response(&prev, &resp, 1_000).unwrap();
+        assert_eq!(merged.id_token.as_deref(), Some("idt"));
+        assert_eq!(merged.expires_at_ms, Some(5_000_000));
+        assert_eq!(merged.refresh_token.as_deref(), Some("r2"));
+    }
+
+    #[test]
+    fn persist_enabled_reads_env() {
+        // Default (unset in the test process) is off.
+        assert!(!persist_enabled());
+    }
+
     #[tokio::test]
     async fn get_fresh_returns_valid_disk_token_unchanged() {
         let cache = TokenCache::new();
         let client = reqwest::Client::new();
         let valid = token(Some("r1"), Some(10_000));
         let out = cache
-            .get_fresh(&client, SubscriptionProvider::Qwen, valid.clone(), 1_000)
+            .get_fresh(
+                &client,
+                SubscriptionProvider::Qwen,
+                valid.clone(),
+                1_000,
+                None,
+            )
             .await;
         assert_eq!(out.access_token, valid.access_token);
     }
@@ -400,11 +494,18 @@ mod tests {
             expires_at_ms: Some(10_000),
             account_id: None,
             resource_url: None,
+            id_token: None,
         };
         cache.store(SubscriptionProvider::Qwen, cached);
         let expired_disk = token(Some("r1"), Some(0));
         let out = cache
-            .get_fresh(&client, SubscriptionProvider::Qwen, expired_disk, 1_000)
+            .get_fresh(
+                &client,
+                SubscriptionProvider::Qwen,
+                expired_disk,
+                1_000,
+                None,
+            )
             .await;
         assert_eq!(out.access_token, "cached-access");
     }

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -134,6 +134,9 @@ pub struct SubscriptionToken {
     pub account_id: Option<String>,
     /// Per-token base URL override (Qwen `resource_url`).
     pub resource_url: Option<String>,
+    /// OpenID `id_token`, when the vendor file stores one (Codex). Kept so a
+    /// persisted refresh can rewrite the credential file faithfully.
+    pub id_token: Option<String>,
 }
 
 impl SubscriptionToken {
@@ -273,6 +276,48 @@ impl SubscriptionReader {
             ))
         }))
     }
+
+    /// Persist a refreshed token back to the credential file in the provider's
+    /// native format, so a rotated `refresh_token` survives a process restart
+    /// (mirroring how the vendor CLI keeps its own file current).
+    ///
+    /// Implemented for Codex (writes the `<CODEX_HOME>/auth.json` shape the codex
+    /// CLI uses); a no-op for providers whose CLI already maintains the file.
+    /// Requires the credential directory to be writable.
+    pub fn persist_token(&self, token: &SubscriptionToken) -> Result<(), SubscriptionError> {
+        match self.provider {
+            SubscriptionProvider::Codex => self.persist_codex(token),
+            _ => Ok(()),
+        }
+    }
+
+    fn persist_codex(&self, token: &SubscriptionToken) -> Result<(), SubscriptionError> {
+        let path = self.home.join("auth.json");
+        let last_refresh = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Nanos, true);
+        let doc = serde_json::json!({
+            "auth_mode": "chatgpt",
+            "OPENAI_API_KEY": serde_json::Value::Null,
+            "tokens": {
+                "id_token": token.id_token.clone().unwrap_or_default(),
+                "access_token": token.access_token,
+                "refresh_token": token.refresh_token.clone().unwrap_or_default(),
+                "account_id": token.account_id.clone().unwrap_or_default(),
+            },
+            "last_refresh": last_refresh,
+        });
+        let body = serde_json::to_vec_pretty(&doc).map_err(|e| {
+            SubscriptionError::ParseError(format!("serialize {}: {e}", path.display()))
+        })?;
+        // Atomic replace: write a sibling temp file, then rename over the target
+        // so a reader never observes a torn credential file.
+        let tmp = self.home.join("auth.json.tmp");
+        std::fs::write(&tmp, &body)
+            .map_err(|e| SubscriptionError::ReadError(format!("write {}: {e}", tmp.display())))?;
+        std::fs::rename(&tmp, &path).map_err(|e| {
+            SubscriptionError::ReadError(format!("rename into {}: {e}", path.display()))
+        })?;
+        Ok(())
+    }
 }
 
 /// Superset of every vendor credential layout. Each provider reads only the
@@ -352,6 +397,7 @@ impl RawCredentials {
                     expires_at_ms: block.expires_at,
                     account_id: None,
                     resource_url: None,
+                    id_token: None,
                 });
             }
         }
@@ -362,26 +408,27 @@ impl RawCredentials {
             expires_at_ms: self.expiry_date,
             account_id: None,
             resource_url: None,
+            id_token: None,
         })
     }
 
     fn codex_token(self) -> Option<SubscriptionToken> {
         let tokens = self.tokens.unwrap_or_default();
         let access = non_empty(tokens.access_token)?;
+        let id_token = non_empty(tokens.id_token);
         let account_id = non_empty(tokens.account_id)
             .or_else(|| non_empty(self.account_id))
-            .or_else(|| {
-                tokens
-                    .id_token
-                    .as_deref()
-                    .and_then(account_id_from_id_token)
-            });
+            .or_else(|| id_token.as_deref().and_then(account_id_from_id_token));
+        // Codex `auth.json` has no top-level `expiry_date`; derive expiry from the
+        // access token's JWT `exp` so `is_expired()` (and thus refresh) can fire.
+        let expires_at_ms = jwt_exp_ms(&access).or(self.expiry_date);
         Some(SubscriptionToken {
             access_token: access,
             refresh_token: non_empty(tokens.refresh_token),
-            expires_at_ms: self.expiry_date,
+            expires_at_ms,
             account_id,
             resource_url: None,
+            id_token,
         })
     }
 
@@ -393,6 +440,7 @@ impl RawCredentials {
             expires_at_ms: self.expiry_date,
             account_id: non_empty(self.account_id),
             resource_url: non_empty(self.resource_url),
+            id_token: None,
         })
     }
 }
@@ -402,6 +450,24 @@ impl RawCredentials {
 /// Codex stores the account id directly, but older/edge auth files only carry
 /// the `id_token`; its payload nests the id under
 /// `https://api.openai.com/auth.chatgpt_account_id` (or `chatgpt_account_id`).
+/// Decode a JWT's `exp` claim (Unix seconds) into epoch milliseconds.
+///
+/// Codex credential files carry expiry only inside the access/id token JWTs, so
+/// this lets the router know when a Codex token needs refreshing. Returns `None`
+/// for malformed tokens or a missing `exp`.
+pub(crate) fn jwt_exp_ms(token: &str) -> Option<i64> {
+    use base64::Engine as _;
+    let payload_b64 = token.split('.').nth(1)?;
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload_b64)
+        .ok()?;
+    let claims: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    claims
+        .get("exp")
+        .and_then(serde_json::Value::as_i64)
+        .map(|secs| secs * 1000)
+}
+
 fn account_id_from_id_token(id_token: &str) -> Option<String> {
     use base64::Engine as _;
     let payload_b64 = id_token.split('.').nth(1)?;
@@ -574,6 +640,7 @@ mod tests {
             expires_at_ms: Some(1000),
             account_id: None,
             resource_url: None,
+            id_token: None,
         };
         assert!(token.is_expired(2000));
         assert!(!token.is_expired(500));
@@ -595,5 +662,88 @@ mod tests {
         // Without the override env var set, falls back to <home>/<subdir>.
         let home = SubscriptionProvider::Codex.resolve_home("/home/alice");
         assert!(home.ends_with(".codex"));
+    }
+
+    /// Build an unsigned JWT carrying the given `exp` (Unix seconds).
+    fn jwt_with_exp(exp_secs: i64) -> String {
+        use base64::Engine as _;
+        let enc = |b: &[u8]| base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(b);
+        format!(
+            "{}.{}.sig",
+            enc(br#"{"alg":"none"}"#),
+            enc(format!(r#"{{"exp":{exp_secs}}}"#).as_bytes())
+        )
+    }
+
+    #[test]
+    fn jwt_exp_ms_decodes_exp_claim() {
+        assert_eq!(jwt_exp_ms(&jwt_with_exp(1_700)), Some(1_700_000));
+        assert_eq!(jwt_exp_ms("not-a-jwt"), None);
+        assert_eq!(jwt_exp_ms(""), None);
+    }
+
+    #[test]
+    fn codex_token_derives_expiry_from_access_jwt() {
+        let dir = tempdir();
+        let access = jwt_with_exp(2_000);
+        let auth = serde_json::json!({
+            "auth_mode": "chatgpt",
+            "OPENAI_API_KEY": serde_json::Value::Null,
+            "tokens": {
+                "id_token": "idt",
+                "access_token": access,
+                "refresh_token": "rt0",
+                "account_id": "acct_1",
+            },
+            "last_refresh": "2026-01-01T00:00:00Z",
+        });
+        fs::write(dir.join("auth.json"), serde_json::to_vec(&auth).unwrap()).unwrap();
+        let reader = SubscriptionReader::new(SubscriptionProvider::Codex, &dir);
+        let token = reader.read_token().unwrap();
+        // Expiry comes from the access-token JWT `exp`, not a missing top-level field.
+        assert_eq!(token.expires_at_ms, Some(2_000_000));
+        assert!(token.is_expired(2_000_001));
+        assert!(!token.is_expired(1_999_999));
+        assert_eq!(token.refresh_token.as_deref(), Some("rt0"));
+        assert_eq!(token.id_token.as_deref(), Some("idt"));
+        assert_eq!(token.account_id.as_deref(), Some("acct_1"));
+    }
+
+    #[test]
+    fn persist_codex_roundtrips_rotated_token() {
+        let dir = tempdir();
+        let reader = SubscriptionReader::new(SubscriptionProvider::Codex, &dir);
+        let rotated = SubscriptionToken {
+            access_token: jwt_with_exp(9_000),
+            refresh_token: Some("rt1".into()),
+            expires_at_ms: Some(9_000_000),
+            account_id: Some("acct_1".into()),
+            resource_url: None,
+            id_token: Some("idt2".into()),
+        };
+        reader.persist_token(&rotated).unwrap();
+        // No stray temp file remains after the atomic rename.
+        assert!(!dir.join("auth.json.tmp").exists());
+        let reread = reader.read_token().unwrap();
+        assert_eq!(reread.refresh_token.as_deref(), Some("rt1"));
+        assert_eq!(reread.id_token.as_deref(), Some("idt2"));
+        assert_eq!(reread.account_id.as_deref(), Some("acct_1"));
+        assert_eq!(reread.expires_at_ms, Some(9_000_000));
+    }
+
+    #[test]
+    fn persist_token_is_noop_for_non_codex() {
+        let dir = tempdir();
+        let reader = SubscriptionReader::new(SubscriptionProvider::Qwen, &dir);
+        let token = SubscriptionToken {
+            access_token: "a".into(),
+            refresh_token: Some("r".into()),
+            expires_at_ms: None,
+            account_id: None,
+            resource_url: None,
+            id_token: None,
+        };
+        reader.persist_token(&token).unwrap();
+        assert!(!dir.join("auth.json").exists());
     }
 }

--- a/src/subscription_proxy.rs
+++ b/src/subscription_proxy.rs
@@ -77,12 +77,12 @@ pub async fn forward_subscription_openai(
             );
         }
     };
-    // Refresh in memory if the on-disk token has expired; vendor files stay
-    // read-only.
+    // Refresh if the on-disk token has expired, persisting the rotated token back
+    // to the credential file when SUBSCRIPTION_REFRESH_PERSIST is enabled.
     let now_ms = chrono::Utc::now().timestamp_millis();
     let sub_token = state
         .subscription_cache
-        .get_fresh(&state.client, provider, disk_token, now_ms)
+        .get_fresh(&state.client, provider, disk_token, now_ms, Some(reader))
         .await;
 
     let stream_requested = body
@@ -538,6 +538,7 @@ mod tests {
             expires_at_ms: None,
             account_id: Some("acct_9".into()),
             resource_url: None,
+            id_token: None,
         };
         let headers = subscription_headers(SubscriptionProvider::Codex, &token);
         assert!(
@@ -555,6 +556,7 @@ mod tests {
             expires_at_ms: None,
             account_id: Some("acct_9".into()),
             resource_url: None,
+            id_token: None,
         };
         let headers = subscription_headers(SubscriptionProvider::Codex, &token);
         // The Codex backend gates newer models behind a recent client version
@@ -593,6 +595,7 @@ mod tests {
             expires_at_ms: None,
             account_id: None,
             resource_url: None,
+            id_token: None,
         };
         assert!(subscription_headers(SubscriptionProvider::Qwen, &token).is_empty());
     }


### PR DESCRIPTION
The router shipped in-memory OAuth refresh (src/refresh.rs) wired into the codex
path, but it never fired for Codex and could not survive a restart:

1. Expiry was never detected. codex_token() set expires_at_ms from a non-existent
   top-level `expiry_date`, so a Codex auth.json (which carries expiry only inside
   the access/id-token JWTs) always yielded expires_at_ms=None -> is_expired() was
   always false -> get_fresh() always returned the on-disk token and never
   refreshed. When the ~10-day access_token hit its exp, every request 401'd until
   the credential file was replaced by hand.
2. Refresh was in-memory only. Codex refresh_tokens are single-use and rotate on
   every refresh, so after a process restart the router re-read the stale on-disk
   refresh_token (already invalidated by the earlier rotation) and refresh failed.

Changes:
- subscription.rs: add jwt_exp_ms() and derive Codex expires_at_ms from the access
  token's JWT exp (falling back to expiry_date). Carry id_token on SubscriptionToken.
  Add SubscriptionReader::persist_token()/persist_codex() writing the codex auth.json
  shape ({auth_mode, tokens:{id_token,access_token,refresh_token,account_id},
  last_refresh}) atomically (tmp + rename).
- refresh.rs: RefreshResponse/merge carry id_token; expiry falls back to the new
  access JWT exp when the endpoint omits expires_in. get_fresh() chains rotation
  from the freshest known refresh_token and, when SUBSCRIPTION_REFRESH_PERSIST is
  enabled and a reader is provided, persists the rotated credential back to disk.
- subscription_proxy.rs: pass the reader so the codex path persists; gemini.rs: None.

Persistence is opt-in (SUBSCRIPTION_REFRESH_PERSIST) and requires a writable
credential dir; the default stays read-only/in-memory. Adds unit tests for
jwt_exp_ms, JWT-derived expiry, and the persist round-trip. 124 tests pass.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
