### PR TITLE
feat: renew Claude credentials without the CLI, and publish a with-claude-cli image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -339,9 +339,34 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
+          target: runtime
           push: true
           tags: ${{ steps.docker-meta.outputs.tags }}
           labels: ${{ steps.docker-meta.outputs.labels }}
+
+      - name: Extract Docker metadata for the Claude CLI variant
+        if: steps.check.outputs.should_release == 'true'
+        id: docker-meta-claude-cli
+        uses: docker/metadata-action@v6
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+            ${{ env.DOCKERHUB_IMAGE }}
+          tags: |
+            type=raw,value=with-claude-cli
+            type=raw,value=${{ steps.current_version.outputs.version }}-with-claude-cli
+          labels: |
+            org.opencontainers.image.version=${{ steps.current_version.outputs.version }}
+
+      - name: Publish Claude CLI variant image to registries
+        if: steps.check.outputs.should_release == 'true'
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          target: with-claude-cli
+          push: true
+          tags: ${{ steps.docker-meta-claude-cli.outputs.tags }}
+          labels: ${{ steps.docker-meta-claude-cli.outputs.labels }}
 
       - name: Create GitHub Release
         if: steps.check.outputs.should_release == 'true'
@@ -443,9 +468,34 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
+          target: runtime
           push: true
           tags: ${{ steps.docker-meta.outputs.tags }}
           labels: ${{ steps.docker-meta.outputs.labels }}
+
+      - name: Extract Docker metadata for the Claude CLI variant
+        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
+        id: docker-meta-claude-cli
+        uses: docker/metadata-action@v6
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+            ${{ env.DOCKERHUB_IMAGE }}
+          tags: |
+            type=raw,value=with-claude-cli
+            type=raw,value=${{ steps.version.outputs.new_version }}-with-claude-cli
+          labels: |
+            org.opencontainers.image.version=${{ steps.version.outputs.new_version }}
+
+      - name: Publish Claude CLI variant image to registries
+        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          target: with-claude-cli
+          push: true
+          tags: ${{ steps.docker-meta-claude-cli.outputs.tags }}
+          labels: ${{ steps.docker-meta-claude-cli.outputs.labels }}
 
       - name: Create GitHub Release
         if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-07T15:49:54.328Z for PR creation at branch issue-48-1455108618b7 for issue https://github.com/link-assistant/router/issues/48

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-07T15:49:54.328Z for PR creation at branch issue-48-1455108618b7 for issue https://github.com/link-assistant/router/issues/48

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1341,7 +1341,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "link-assistant-router"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,13 @@ COPY src/ src/
 RUN touch src/lib.rs src/main.rs && \
     cargo build --release
 
-# Runtime stage
-FROM debian:bookworm-slim
+# Runtime base
+#
+# Deliberately minimal: no Claude CLI. The router refreshes an expired Claude
+# token itself by exchanging the `refreshToken` in the mounted credential file,
+# so `/data/claude` may stay read-only. Use the `with-claude-cli` stage below
+# when you need to *create* a credential inside the container.
+FROM debian:bookworm-slim AS runtime-base
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates && \
@@ -42,3 +47,37 @@ ENV CLAUDE_CODE_HOME=/data/claude
 EXPOSE 8080
 
 ENTRYPOINT ["link-assistant-router"]
+
+# Runtime stage with the Claude Code CLI (published as `:with-claude-cli`)
+#
+# Adds Node.js and `@anthropic-ai/claude-code` so a first-time login can be
+# performed inside the container:
+#
+#   docker run -it --entrypoint claude -v claude-home:/data/claude \
+#     ghcr.io/link-assistant/router:with-claude-cli /login
+#
+# `CLAUDE_CODE_HOME` must be writable in this image — `claude` writes
+# `/data/claude/.credentials.json`.
+FROM runtime-base AS with-claude-cli
+
+ARG NODE_MAJOR=22
+ARG CLAUDE_CODE_VERSION=latest
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl gnupg && \
+    curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - && \
+    apt-get install -y --no-install-recommends nodejs && \
+    npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" && \
+    npm cache clean --force && \
+    apt-get purge -y gnupg && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
+
+# `claude` stores its credential here; keep it writable in this image.
+ENV CLAUDE_CONFIG_DIR=/data/claude
+
+ENTRYPOINT ["link-assistant-router"]
+
+# Default stage. Kept last so a plain `docker build .` (and the release
+# workflow's default target) still produces the minimal image.
+FROM runtime-base AS runtime

--- a/README.md
+++ b/README.md
@@ -683,6 +683,62 @@ docker run -d \
 
 The Dockerfile sets `CLAUDE_CODE_HOME=/data/claude` by default, so mount your Claude Code session directory to `/data/claude`.
 
+### Credential lifecycle in a container
+
+The default image intentionally contains no Claude CLI. What it can and cannot do with a mounted credential:
+
+| Operation | Needs the Claude CLI in the image? | Mount mode |
+| --- | --- | --- |
+| Serve requests with a valid access token | No | `:ro` |
+| Renew an **expired** access token | No — the router exchanges the `refreshToken` itself | `:ro` |
+| **First-time login** (no credential file yet) | Yes | writable |
+
+Renewal happens in memory: the router exchanges the `refreshToken` stored in the mounted credential file against Anthropic's token endpoint and keeps the result in RAM. The credential file is never written to, which is why `:ro` keeps working across expiry — and why a restarted container refreshes again from the same file. The same mechanism already covers Codex, Gemini, and Qwen.
+
+Two things still require a real login: a directory with no credential file at all, and a `refreshToken` that has itself been revoked or expired.
+
+### Logging in from inside a container
+
+For a self-contained deployment, use the `with-claude-cli` image variant, which layers Node.js and the Claude Code CLI on top of the same router binary:
+
+```bash
+# Log in once into a named volume (interactive, needs a writable mount)
+docker run -it --rm \
+  --entrypoint claude \
+  -v claude-home:/data/claude \
+  ghcr.io/link-assistant/router:with-claude-cli /login
+
+# Then run the router against that volume
+docker run -d \
+  -p 8080:8080 \
+  -e TOKEN_SECRET=your-secure-secret \
+  -v claude-home:/data/claude \
+  ghcr.io/link-assistant/router:with-claude-cli
+```
+
+Both `ghcr.io/link-assistant/router:with-claude-cli` and `konard/link-assistant-router:with-claude-cli` are published alongside each release, plus version-pinned `<version>-with-claude-cli` tags.
+
+To build it yourself, target the stage directly:
+
+```bash
+docker build --target with-claude-cli -t link-assistant/router:with-claude-cli .
+```
+
+Or derive your own image from the published minimal one:
+
+```dockerfile
+FROM ghcr.io/link-assistant/router:latest
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl gnupg && \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get install -y --no-install-recommends nodejs && \
+    npm install -g @anthropic-ai/claude-code && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV CLAUDE_CONFIG_DIR=/data/claude
+```
+
 ### Docker Compose example
 
 ```yaml
@@ -696,6 +752,8 @@ services:
       TOKEN_SECRET: ${TOKEN_SECRET}
       ROUTER_PORT: "8080"
     volumes:
+      # `:ro` is enough: token renewal happens in memory. Drop `:ro` (and use
+      # the `with-claude-cli` image) if you want to log in from the container.
       - ${HOME}/.claude:/data/claude:ro
     restart: unless-stopped
 ```

--- a/changelog.d/20260807_180000_issue_48_claude_credential_lifecycle.md
+++ b/changelog.d/20260807_180000_issue_48_claude_credential_lifecycle.md
@@ -1,0 +1,22 @@
+### Added
+
+- Router-driven refresh for Claude subscription tokens. An expired
+  `~/.claude` access token is now renewed by exchanging the `refreshToken`
+  from the nested `claudeAiOauth` block against Anthropic's token endpoint,
+  the same way `src/refresh.rs` already handled Codex, Gemini, and Qwen. The
+  result is kept **in memory only**, so a container whose `CLAUDE_CODE_HOME`
+  is mounted read-only keeps working past expiry without a Claude CLI inside
+  the image (#48).
+- A `with-claude-cli` image variant that layers Node.js and the Claude Code
+  CLI on top of the runtime image, published on each release as
+  `:with-claude-cli` and `:<version>-with-claude-cli` on both GHCR and Docker
+  Hub. It makes a first-time `claude /login` possible from inside a
+  container; the default image stays minimal.
+
+### Documentation
+
+- README and `docs/use-cases/self-hosting.md` now state which credential
+  operations work with a read-only `CLAUDE_CODE_HOME` mount (serving
+  requests, renewing an expired token) and which need a writable one plus the
+  CLI (first-time login), and include a derived-image recipe for adding the
+  CLI to the published minimal image.

--- a/docs/use-cases/self-hosting.md
+++ b/docs/use-cases/self-hosting.md
@@ -94,6 +94,18 @@ The router starts and serves `/health` with **no subscription mounted at all**,
 so it can be deployed before credentials are provisioned; requests then fail at
 the upstream rather than at startup.
 
+The mount can stay read-only across token expiry: the router exchanges the
+`refreshToken` in the credential file for a new access token in memory and
+never writes the file back. The image carries no Claude CLI, so the one thing
+it cannot do with a read-only mount is a **first-time login** — for that, use
+the `with-claude-cli` image variant with a writable mount:
+
+```bash
+docker run -it --rm --entrypoint claude \
+  -v claude-home:/data/claude \
+  ghcr.io/link-assistant/router:with-claude-cli /login
+```
+
 ### Corporate host
 
 Nothing external is required — no database, no message broker. State is JSON
@@ -103,7 +115,7 @@ under `DATA_DIR` and, when `AUDIT_LOG` is set, an append-only JSONL file:
 | --- | --- | --- |
 | `$DATA_DIR` | issued-token records (id, label, expiry, budget, usage) | yes — losing it loses revocation state |
 | `$AUDIT_LOG` | one line per proxied request | ship to your log collector |
-| `$CLAUDE_CODE_HOME` | the vendor session, read-only | never — it is the vendor's |
+| `$CLAUDE_CODE_HOME` | the vendor session; read-only unless you log in from the container | never — it is the vendor's |
 
 `STORAGE_POLICY=memory` keeps tokens in memory only, for ephemeral test
 deployments where nothing should survive a restart.

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -2,16 +2,28 @@
 //!
 //! Reads Claude Code session credentials from the filesystem to obtain
 //! the OAuth bearer token for upstream API requests.
+//!
+//! The credential file is never written back to: when the access token has
+//! expired, [`OAuthProvider::get_fresh_token`] exchanges the stored
+//! `refreshToken` via [`crate::refresh`] and keeps the result in memory. That
+//! is what lets a container whose `CLAUDE_CODE_HOME` is mounted read-only
+//! survive token expiry without a Claude CLI inside the image.
 
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
+
+use crate::subscription::SubscriptionToken;
 
 /// Cached OAuth credentials.
 #[derive(Clone)]
 pub struct OAuthProvider {
     claude_code_home: PathBuf,
     cached_token: Arc<RwLock<Option<String>>>,
+    /// Token supplied through [`OAuthProvider::set_token`] rather than read
+    /// from disk. Kept separate from `cached_token` so a refresh-aware read
+    /// can still prefer an explicitly configured token over the file.
+    manual_token: Arc<RwLock<Option<String>>>,
 }
 
 /// Structure of the Claude Code OAuth credentials file.
@@ -34,6 +46,12 @@ struct ClaudeCredentials {
     /// The OAuth bearer token, alternative field name (flat layout).
     #[serde(alias = "oauthToken", alias = "oauth_token")]
     oauth_token: Option<String>,
+    /// The OAuth refresh token (flat layout).
+    #[serde(alias = "refreshToken", alias = "refresh_token")]
+    refresh_token: Option<String>,
+    /// Expiration timestamp in milliseconds since the Unix epoch (flat layout).
+    #[serde(alias = "expiresAt", alias = "expires_at", alias = "expiryDate")]
+    expires_at: Option<i64>,
     /// Nested OAuth block written by the Claude Code CLI.
     #[serde(alias = "claudeAiOauth", alias = "claude_ai_oauth")]
     claude_ai_oauth: Option<OAuthBlock>,
@@ -48,28 +66,47 @@ struct OAuthBlock {
     /// The OAuth bearer token (alternative field name).
     #[serde(alias = "oauthToken", alias = "oauth_token")]
     oauth_token: Option<String>,
+    /// The OAuth refresh token used to obtain a new access token.
+    #[serde(alias = "refreshToken", alias = "refresh_token")]
+    refresh_token: Option<String>,
     /// Expiration timestamp in milliseconds since the Unix epoch, if present.
     #[serde(alias = "expiresAt", alias = "expires_at")]
     expires_at: Option<i64>,
 }
 
 impl ClaudeCredentials {
-    /// Extract the bearer token, preferring the nested Claude Code block.
-    fn extract_token(&self) -> Option<&str> {
-        let nested = self.claude_ai_oauth.as_ref().and_then(|b| {
-            b.access_token
-                .as_deref()
-                .or(b.oauth_token.as_deref())
-                .filter(|t| !t.is_empty())
-        });
-        nested
-            .or_else(|| self.access_token.as_deref().filter(|t| !t.is_empty()))
-            .or_else(|| self.oauth_token.as_deref().filter(|t| !t.is_empty()))
-    }
+    /// Normalize into a [`SubscriptionToken`], preferring the nested Claude
+    /// Code block.
+    ///
+    /// The access token, refresh token, and expiry are taken from whichever
+    /// layout supplied the access token, so a stale flat `refreshToken` is
+    /// never paired with a nested access token.
+    fn into_subscription_token(self) -> Option<SubscriptionToken> {
+        fn non_empty(value: Option<String>) -> Option<String> {
+            value.filter(|v| !v.is_empty())
+        }
 
-    /// Expiration time in milliseconds since the Unix epoch, if known.
-    fn expires_at_ms(&self) -> Option<i64> {
-        self.claude_ai_oauth.as_ref().and_then(|b| b.expires_at)
+        if let Some(block) = self.claude_ai_oauth {
+            if let Some(access) =
+                non_empty(block.access_token).or_else(|| non_empty(block.oauth_token))
+            {
+                return Some(SubscriptionToken {
+                    access_token: access,
+                    refresh_token: non_empty(block.refresh_token),
+                    expires_at_ms: block.expires_at,
+                    account_id: None,
+                    resource_url: None,
+                });
+            }
+        }
+        let access = non_empty(self.access_token).or_else(|| non_empty(self.oauth_token))?;
+        Some(SubscriptionToken {
+            access_token: access,
+            refresh_token: non_empty(self.refresh_token),
+            expires_at_ms: self.expires_at,
+            account_id: None,
+            resource_url: None,
+        })
     }
 }
 
@@ -80,6 +117,7 @@ impl OAuthProvider {
         Self {
             claude_code_home: PathBuf::from(claude_code_home),
             cached_token: Arc::new(RwLock::new(None)),
+            manual_token: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -110,6 +148,21 @@ impl OAuthProvider {
     /// Searches through known credential file locations and extracts the
     /// access token.
     fn read_token_from_files(&self) -> Result<String, OAuthError> {
+        Ok(self.read_subscription_token()?.access_token)
+    }
+
+    /// Read the full Claude credential — access token, `refreshToken`, and
+    /// expiry — from the first credential file that yields one.
+    ///
+    /// Unlike [`Self::get_token`] this always hits the filesystem, so a
+    /// credential file refreshed by an outside process (a Claude CLI on the
+    /// host, a re-mounted secret) is picked up rather than served from cache.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OAuthError`] when no credential file exists, one cannot be
+    /// read, or none contains an access token.
+    pub fn read_subscription_token(&self) -> Result<SubscriptionToken, OAuthError> {
         for path in self.credential_paths() {
             if let Some(token) = Self::try_read_credential_file(&path)? {
                 return Ok(token);
@@ -122,7 +175,7 @@ impl OAuthProvider {
     }
 
     /// Try to read a single credential file and extract the token.
-    fn try_read_credential_file(path: &Path) -> Result<Option<String>, OAuthError> {
+    fn try_read_credential_file(path: &Path) -> Result<Option<SubscriptionToken>, OAuthError> {
         if !path.exists() {
             return Ok(None);
         }
@@ -137,18 +190,27 @@ impl OAuthProvider {
 
         // Prefer the nested `claudeAiOauth` block (real Claude Code layout),
         // then fall back to the flat `accessToken`/`oauthToken` fields.
-        if let Some(token) = creds.extract_token() {
-            if let Some(exp_ms) = creds.expires_at_ms() {
+        if let Some(token) = creds.into_subscription_token() {
+            if let Some(exp_ms) = token.expires_at_ms {
                 let now_ms = chrono::Utc::now().timestamp_millis();
                 if exp_ms <= now_ms {
-                    tracing::warn!(
-                        "Claude Code OAuth token in {} expired at {exp_ms} (now {now_ms}); \
-                         upstream requests may fail until you re-authenticate with `claude`.",
-                        path.display()
-                    );
+                    if token.refresh_token.is_some() {
+                        tracing::debug!(
+                            "Claude Code OAuth token in {} expired at {exp_ms} (now {now_ms}); \
+                             the router will exchange its refresh token in memory.",
+                            path.display()
+                        );
+                    } else {
+                        tracing::warn!(
+                            "Claude Code OAuth token in {} expired at {exp_ms} (now {now_ms}) \
+                             and stores no refresh token; upstream requests may fail until you \
+                             re-authenticate with `claude`.",
+                            path.display()
+                        );
+                    }
                 }
             }
-            return Ok(Some(token.to_string()));
+            return Ok(Some(token));
         }
 
         Ok(None)
@@ -186,8 +248,59 @@ impl OAuthProvider {
         self.get_token()
     }
 
+    /// Get a non-expired OAuth token, exchanging the stored `refreshToken`
+    /// when the on-disk access token has expired.
+    ///
+    /// Resolution order:
+    /// 1. A token set explicitly via [`Self::set_token`].
+    /// 2. The credential file, re-read on every call so an externally
+    ///    refreshed file wins over anything cached here.
+    /// 3. `cache`, which refreshes via Anthropic's token endpoint and keeps
+    ///    the result in memory — the credential file is never written to.
+    ///
+    /// This is what allows a container with no Claude CLI (and a read-only
+    /// `CLAUDE_CODE_HOME` mount) to keep serving requests past token expiry.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OAuthError`] when no token can be read from disk and none was
+    /// set manually. A failed *refresh* is not an error: the expired disk
+    /// token is returned so the upstream can surface its own error.
+    pub async fn get_fresh_token(
+        &self,
+        client: &reqwest::Client,
+        cache: &crate::refresh::TokenCache,
+    ) -> Result<String, OAuthError> {
+        if let Ok(guard) = self.manual_token.read() {
+            if let Some(ref token) = *guard {
+                return Ok(token.clone());
+            }
+        }
+
+        let disk_token = match self.read_subscription_token() {
+            Ok(token) => token,
+            // No readable credential file: fall back to whatever `get_token`
+            // can produce (a previously cached read) and its error otherwise.
+            Err(e) => return self.get_token().map_err(|_| e),
+        };
+
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        let fresh = cache
+            .get_fresh(
+                client,
+                crate::subscription::SubscriptionProvider::Claude,
+                disk_token,
+                now_ms,
+            )
+            .await;
+        Ok(fresh.access_token)
+    }
+
     /// Manually set the OAuth token (useful for testing or direct configuration).
     pub fn set_token(&self, token: &str) {
+        if let Ok(mut guard) = self.manual_token.write() {
+            *guard = Some(token.to_string());
+        }
         if let Ok(mut guard) = self.cached_token.write() {
             *guard = Some(token.to_string());
         }
@@ -282,6 +395,130 @@ mod tests {
         .unwrap();
         let provider = OAuthProvider::new(dir.to_str().unwrap());
         assert_eq!(provider.get_token().unwrap(), "sk-ant-oat-expired");
+    }
+
+    #[test]
+    fn test_reads_refresh_token_and_expiry_from_nested_block() {
+        // The refresh token is what lets a container renew without the CLI,
+        // so it must survive the read alongside the access token.
+        let dir = tempdir();
+        fs::write(
+            dir.join(".credentials.json"),
+            r#"{"claudeAiOauth":{"accessToken":"sk-ant-oat-x","refreshToken":"sk-ant-ort-y","expiresAt":1700000000000}}"#,
+        )
+        .unwrap();
+        let token = OAuthProvider::new(dir.to_str().unwrap())
+            .read_subscription_token()
+            .expect("should read credential");
+        assert_eq!(token.access_token, "sk-ant-oat-x");
+        assert_eq!(token.refresh_token.as_deref(), Some("sk-ant-ort-y"));
+        assert_eq!(token.expires_at_ms, Some(1_700_000_000_000));
+    }
+
+    #[test]
+    fn test_flat_layout_refresh_token_is_read() {
+        let dir = tempdir();
+        fs::write(
+            dir.join("credentials.json"),
+            r#"{"accessToken":"flat-access","refreshToken":"flat-refresh","expiresAt":42}"#,
+        )
+        .unwrap();
+        let token = OAuthProvider::new(dir.to_str().unwrap())
+            .read_subscription_token()
+            .unwrap();
+        assert_eq!(token.refresh_token.as_deref(), Some("flat-refresh"));
+        assert_eq!(token.expires_at_ms, Some(42));
+    }
+
+    #[test]
+    fn test_nested_block_does_not_borrow_flat_refresh_token() {
+        // Mixing a nested access token with a flat refresh token would send a
+        // mismatched pair to the token endpoint.
+        let dir = tempdir();
+        fs::write(
+            dir.join("credentials.json"),
+            r#"{"accessToken":"flat","refreshToken":"flat-refresh","claudeAiOauth":{"accessToken":"nested"}}"#,
+        )
+        .unwrap();
+        let token = OAuthProvider::new(dir.to_str().unwrap())
+            .read_subscription_token()
+            .unwrap();
+        assert_eq!(token.access_token, "nested");
+        assert_eq!(token.refresh_token, None);
+    }
+
+    #[tokio::test]
+    async fn test_get_fresh_token_returns_unexpired_disk_token() {
+        let dir = tempdir();
+        fs::write(
+            dir.join(".credentials.json"),
+            r#"{"claudeAiOauth":{"accessToken":"sk-ant-oat-valid","refreshToken":"r","expiresAt":99999999999999}}"#,
+        )
+        .unwrap();
+        let provider = OAuthProvider::new(dir.to_str().unwrap());
+        let token = provider
+            .get_fresh_token(&reqwest::Client::new(), &crate::refresh::TokenCache::new())
+            .await
+            .unwrap();
+        assert_eq!(token, "sk-ant-oat-valid");
+    }
+
+    #[tokio::test]
+    async fn test_get_fresh_token_prefers_manual_token() {
+        // An explicitly configured token must win over the credential file and
+        // must never trigger a network refresh.
+        let dir = tempdir();
+        fs::write(
+            dir.join(".credentials.json"),
+            r#"{"claudeAiOauth":{"accessToken":"from-disk","expiresAt":1}}"#,
+        )
+        .unwrap();
+        let provider = OAuthProvider::new(dir.to_str().unwrap());
+        provider.set_token("manual");
+        let token = provider
+            .get_fresh_token(&reqwest::Client::new(), &crate::refresh::TokenCache::new())
+            .await
+            .unwrap();
+        assert_eq!(token, "manual");
+    }
+
+    #[tokio::test]
+    async fn test_get_fresh_token_uses_cached_refresh_result() {
+        // With a valid cached token the expired disk token is never sent
+        // upstream and no refresh request is made.
+        let dir = tempdir();
+        fs::write(
+            dir.join(".credentials.json"),
+            r#"{"claudeAiOauth":{"accessToken":"expired","refreshToken":"r","expiresAt":1}}"#,
+        )
+        .unwrap();
+        let cache = crate::refresh::TokenCache::new();
+        cache.store_refreshed(
+            crate::subscription::SubscriptionProvider::Claude,
+            "primary",
+            SubscriptionToken {
+                access_token: "refreshed".into(),
+                refresh_token: Some("r".into()),
+                expires_at_ms: Some(i64::MAX),
+                account_id: None,
+                resource_url: None,
+            },
+        );
+        let provider = OAuthProvider::new(dir.to_str().unwrap());
+        let token = provider
+            .get_fresh_token(&reqwest::Client::new(), &cache)
+            .await
+            .unwrap();
+        assert_eq!(token, "refreshed");
+    }
+
+    #[tokio::test]
+    async fn test_get_fresh_token_errors_without_credentials() {
+        let provider = OAuthProvider::new("/tmp/nonexistent-claude-dir-fresh");
+        let result = provider
+            .get_fresh_token(&reqwest::Client::new(), &crate::refresh::TokenCache::new())
+            .await;
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -238,7 +238,7 @@ pub async fn proxy_handler(State(state): State<AppState>, req: Request) -> impl 
 
     // Get the real OAuth token (multi-account aware).
     let (oauth_token, selected_account) =
-        match resolve_upstream_credentials(&state, &routing_context) {
+        match resolve_upstream_credentials(&state, &routing_context).await {
             Ok(pair) => pair,
             Err(e) => {
                 tracing::error!("Failed to resolve upstream credentials: {e}");
@@ -427,15 +427,34 @@ pub(crate) fn build_upstream_headers(
 ///
 /// When `state.account_router` is set we delegate to the multi-account
 /// router; otherwise we fall back to the single-account legacy provider.
-fn resolve_upstream_credentials(
+///
+/// Either way an expired access token is refreshed in memory via
+/// `state.subscription_cache` — the vendor credential file is never written
+/// back to, so a read-only `CLAUDE_CODE_HOME` mount survives expiry without a
+/// Claude CLI in the image.
+async fn resolve_upstream_credentials(
     state: &AppState,
     context: &RoutingContext,
 ) -> Result<(String, Option<String>), Box<dyn std::error::Error + Send + Sync>> {
     if let Some(router) = state.account_router.as_ref() {
-        let sel = router.select_with_context(context)?;
-        return Ok((sel.token, Some(sel.name)));
+        let sel = router.select_subscription(context)?;
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        let token = state
+            .subscription_cache
+            .get_fresh_for(
+                &state.client,
+                router.provider(),
+                &sel.name,
+                sel.token,
+                now_ms,
+            )
+            .await;
+        return Ok((token.access_token, Some(sel.name)));
     }
-    let token = state.oauth_provider.get_token()?;
+    let token = state
+        .oauth_provider
+        .get_fresh_token(&state.client, &state.subscription_cache)
+        .await?;
     Ok((token, None))
 }
 
@@ -699,7 +718,7 @@ async fn forward_openai(
 
     // Resolve OAuth credentials.
     let (oauth_token, selected_account) =
-        match resolve_upstream_credentials(state, &routing_context) {
+        match resolve_upstream_credentials(state, &routing_context).await {
             Ok(p) => p,
             Err(e) => {
                 tracing::error!("openai: upstream credentials unavailable: {e}");

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -207,6 +207,28 @@ pub async fn refresh(
     prev: &SubscriptionToken,
     now_ms: i64,
 ) -> Result<SubscriptionToken, RefreshError> {
+    refresh_at(
+        client,
+        refresh_config(provider).token_url,
+        provider,
+        prev,
+        now_ms,
+    )
+    .await
+}
+
+/// [`refresh`] against an explicit token endpoint.
+///
+/// Only the URL is overridden — client id, body encoding, and response
+/// handling stay exactly as they are in production, so a test pointing this at
+/// a stub server exercises the real request shape.
+async fn refresh_at(
+    client: &reqwest::Client,
+    token_url: &str,
+    provider: SubscriptionProvider,
+    prev: &SubscriptionToken,
+    now_ms: i64,
+) -> Result<SubscriptionToken, RefreshError> {
     let config = refresh_config(provider);
     let refresh_token = prev
         .refresh_token
@@ -230,7 +252,7 @@ pub async fn refresh(
             if let Some(secret) = client_secret.as_deref() {
                 body["client_secret"] = serde_json::Value::String(secret.to_string());
             }
-            client.post(config.token_url).json(&body)
+            client.post(token_url).json(&body)
         }
         BodyStyle::Form => {
             let mut form = vec![
@@ -242,7 +264,7 @@ pub async fn refresh(
                 form.push(("client_secret", secret));
             }
             client
-                .post(config.token_url)
+                .post(token_url)
                 .header("content-type", "application/x-www-form-urlencoded")
                 .body(encode_form(&form))
         }
@@ -400,6 +422,123 @@ mod tests {
         assert_eq!(claude.client_id, CLAUDE_CLIENT_ID);
         assert!(claude.client_secret_env.is_none());
         assert_eq!(claude.style, BodyStyle::Json);
+    }
+
+    /// Serve one JSON response on loopback and hand back the request that was
+    /// received, so a test can assert the exact refresh body sent upstream.
+    async fn stub_token_endpoint(
+        response_body: &'static str,
+    ) -> (String, tokio::task::JoinHandle<(String, String)>) {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}/v1/oauth/token", listener.local_addr().unwrap());
+        let handle = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut raw = Vec::new();
+            let mut buf = [0u8; 2048];
+            // Read until the body (after the blank line) is fully present.
+            loop {
+                let n = socket.read(&mut buf).await.unwrap();
+                raw.extend_from_slice(&buf[..n]);
+                let text = String::from_utf8_lossy(&raw);
+                if n == 0
+                    || text
+                        .split_once("\r\n\r\n")
+                        .is_some_and(|(_, b)| !b.is_empty())
+                {
+                    break;
+                }
+            }
+            let request = String::from_utf8_lossy(&raw).to_string();
+            let (head, body) = request.split_once("\r\n\r\n").unwrap();
+            socket
+                .write_all(
+                    format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{response_body}",
+                        response_body.len()
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .unwrap();
+            socket.flush().await.unwrap();
+            (head.to_string(), body.to_string())
+        });
+        (url, handle)
+    }
+
+    #[tokio::test]
+    async fn claude_refresh_exchanges_the_refresh_token_and_never_touches_disk() {
+        // The container case from issue #48: the on-disk Claude token has
+        // expired and there is no Claude CLI to renew it.
+        let (url, server) = stub_token_endpoint(
+            r#"{"access_token":"sk-ant-oat-new","refresh_token":"sk-ant-ort-new","expires_in":3600}"#,
+        )
+        .await;
+
+        let expired = SubscriptionToken {
+            access_token: "sk-ant-oat-old".into(),
+            refresh_token: Some("sk-ant-ort-old".into()),
+            expires_at_ms: Some(1),
+            account_id: None,
+            resource_url: None,
+        };
+        let fresh = refresh_at(
+            &reqwest::Client::new(),
+            &url,
+            SubscriptionProvider::Claude,
+            &expired,
+            10_000,
+        )
+        .await
+        .expect("claude refresh should succeed");
+
+        assert_eq!(fresh.access_token, "sk-ant-oat-new");
+        assert_eq!(fresh.refresh_token.as_deref(), Some("sk-ant-ort-new"));
+        assert_eq!(fresh.expires_at_ms, Some(10_000 + 3_600_000));
+
+        let (head, body) = server.await.unwrap();
+        assert!(head.starts_with("POST /v1/oauth/token"));
+        let sent: serde_json::Value = serde_json::from_str(&body).expect("json body");
+        assert_eq!(sent["grant_type"], "refresh_token");
+        assert_eq!(sent["refresh_token"], "sk-ant-ort-old");
+        assert_eq!(sent["client_id"], CLAUDE_CLIENT_ID);
+        // Claude's public client takes no secret.
+        assert!(sent.get("client_secret").is_none());
+    }
+
+    #[tokio::test]
+    async fn claude_refresh_result_is_cached_and_reused() {
+        // A single exchange must serve subsequent requests: the stub answers
+        // once, so a second refresh attempt would hang/fail instead.
+        let (url, server) =
+            stub_token_endpoint(r#"{"access_token":"cached-once","expires_in":3600}"#).await;
+        let expired = SubscriptionToken {
+            access_token: "expired".into(),
+            refresh_token: Some("r".into()),
+            expires_at_ms: Some(1),
+            account_id: None,
+            resource_url: None,
+        };
+        let client = reqwest::Client::new();
+        let fresh = refresh_at(
+            &client,
+            &url,
+            SubscriptionProvider::Claude,
+            &expired,
+            10_000,
+        )
+        .await
+        .unwrap();
+
+        let cache = TokenCache::new();
+        cache.store_refreshed(SubscriptionProvider::Claude, "primary", fresh);
+        let reused = cache
+            .get_fresh(&client, SubscriptionProvider::Claude, expired, 20_000)
+            .await;
+        assert_eq!(reused.access_token, "cached-once");
+        server.await.unwrap();
     }
 
     #[tokio::test]

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -7,9 +7,13 @@
 //! in each vendor's open-source CLI) and caches the result **in memory only**.
 //!
 //! This is the same behavior `ProxyPal` relies on so the proxy keeps working even
-//! when the vendor CLI is not running to refresh its own credential file. Claude
-//! is intentionally excluded — it is served by [`crate::oauth`], which already
-//! re-reads the credential file the Claude CLI keeps current.
+//! when the vendor CLI is not running to refresh its own credential file.
+//!
+//! Claude is included here too: the runtime container image ships no Claude CLI,
+//! so nothing else would keep `~/.claude/.credentials.json` current. The
+//! `refreshToken` stored in the nested `claudeAiOauth` block is exchanged the
+//! same way, and the result stays in memory — the credential file is never
+//! written back to, so a read-only mount keeps working across expiry.
 //!
 //! Secrets (access/refresh tokens) are never logged.
 
@@ -47,33 +51,49 @@ struct RefreshConfig {
 /// Environment variable for the Gemini (Google) OAuth client secret.
 pub const GEMINI_CLIENT_SECRET_ENV: &str = "GEMINI_OAUTH_CLIENT_SECRET";
 
-/// Refresh parameters for a provider, or `None` when the router does not drive
-/// the OAuth refresh itself (Claude).
-const fn refresh_config(provider: SubscriptionProvider) -> Option<RefreshConfig> {
+/// Public OAuth client id of the Claude Code CLI.
+///
+/// Same value the CLI embeds; used only for the `refresh_token` grant, which
+/// needs no client secret.
+pub const CLAUDE_CLIENT_ID: &str = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+
+/// Anthropic's OAuth token endpoint.
+pub const CLAUDE_TOKEN_URL: &str = "https://console.anthropic.com/v1/oauth/token";
+
+/// Refresh parameters for a provider. Every subscription provider now has a
+/// public OAuth client, so this is total.
+const fn refresh_config(provider: SubscriptionProvider) -> RefreshConfig {
     match provider {
+        // The Claude Code CLI's public OAuth client (no client secret). Lets a
+        // container renew an expired `~/.claude` token without the CLI.
+        SubscriptionProvider::Claude => RefreshConfig {
+            token_url: CLAUDE_TOKEN_URL,
+            client_id: CLAUDE_CLIENT_ID,
+            client_secret_env: None,
+            style: BodyStyle::Json,
+        },
         // The Codex CLI's public OAuth client (no client secret).
-        SubscriptionProvider::Codex => Some(RefreshConfig {
+        SubscriptionProvider::Codex => RefreshConfig {
             token_url: "https://auth.openai.com/oauth/token",
             client_id: "app_EMoamEEZ73f0CkXaXp7hrann",
             client_secret_env: None,
             style: BodyStyle::Json,
-        }),
+        },
         // The gemini-cli public OAuth client. Google requires a client secret;
         // it is read from the environment rather than embedded in the binary.
-        SubscriptionProvider::Gemini => Some(RefreshConfig {
+        SubscriptionProvider::Gemini => RefreshConfig {
             token_url: "https://oauth2.googleapis.com/token",
             client_id: "681255809395-oo8ft2oprdrnp9e3aqf6av3hmdib135j.apps.googleusercontent.com",
             client_secret_env: Some(GEMINI_CLIENT_SECRET_ENV),
             style: BodyStyle::Form,
-        }),
+        },
         // The qwen-code CLI's public OAuth client (no client secret).
-        SubscriptionProvider::Qwen => Some(RefreshConfig {
+        SubscriptionProvider::Qwen => RefreshConfig {
             token_url: "https://chat.qwen.ai/api/v1/oauth2/token",
             client_id: "f0304373b74a44d2b584a3fb70ca9e56",
             client_secret_env: None,
             style: BodyStyle::Form,
-        }),
-        SubscriptionProvider::Claude => None,
+        },
     }
 }
 
@@ -121,7 +141,11 @@ struct RefreshResponse {
 /// Errors that can occur while refreshing a subscription token.
 #[derive(Debug)]
 pub enum RefreshError {
-    /// The provider does not support router-driven refresh (Claude).
+    /// The provider does not support router-driven refresh.
+    ///
+    /// No provider reports this today — every subscription provider has a
+    /// public OAuth client — but it is kept so callers matching on this enum
+    /// keep compiling.
     Unsupported,
     /// The token had no `refresh_token` to exchange.
     NoRefreshToken,
@@ -183,7 +207,7 @@ pub async fn refresh(
     prev: &SubscriptionToken,
     now_ms: i64,
 ) -> Result<SubscriptionToken, RefreshError> {
-    let config = refresh_config(provider).ok_or(RefreshError::Unsupported)?;
+    let config = refresh_config(provider);
     let refresh_token = prev
         .refresh_token
         .as_deref()
@@ -307,6 +331,20 @@ impl TokenCache {
         }
     }
 
+    /// Seed the cache with an already-refreshed token for `provider`/`account`.
+    ///
+    /// Used by callers that obtained a token outside [`Self::get_fresh_for`]
+    /// (and by tests) so a subsequent lookup reuses it instead of exchanging
+    /// the refresh token again.
+    pub fn store_refreshed(
+        &self,
+        provider: SubscriptionProvider,
+        account: &str,
+        token: SubscriptionToken,
+    ) {
+        self.store_for(provider, account, token);
+    }
+
     fn cached_valid_for(
         &self,
         provider: SubscriptionProvider,
@@ -343,10 +381,37 @@ mod tests {
 
     #[test]
     fn config_present_for_subscription_providers() {
-        assert!(refresh_config(SubscriptionProvider::Codex).is_some());
-        assert!(refresh_config(SubscriptionProvider::Gemini).is_some());
-        assert!(refresh_config(SubscriptionProvider::Qwen).is_some());
-        assert!(refresh_config(SubscriptionProvider::Claude).is_none());
+        assert_eq!(
+            refresh_config(SubscriptionProvider::Codex).token_url,
+            "https://auth.openai.com/oauth/token"
+        );
+        assert_eq!(
+            refresh_config(SubscriptionProvider::Gemini).client_secret_env,
+            Some(GEMINI_CLIENT_SECRET_ENV)
+        );
+        assert_eq!(
+            refresh_config(SubscriptionProvider::Qwen).style,
+            BodyStyle::Form
+        );
+        // Claude is refreshed by the router too: the runtime image has no
+        // Claude CLI to keep the credential file current.
+        let claude = refresh_config(SubscriptionProvider::Claude);
+        assert_eq!(claude.token_url, CLAUDE_TOKEN_URL);
+        assert_eq!(claude.client_id, CLAUDE_CLIENT_ID);
+        assert!(claude.client_secret_env.is_none());
+        assert_eq!(claude.style, BodyStyle::Json);
+    }
+
+    #[tokio::test]
+    async fn claude_refresh_requires_a_refresh_token() {
+        // Without a `refreshToken` in `claudeAiOauth` there is nothing to
+        // exchange; the error must be explicit rather than `Unsupported`.
+        let client = reqwest::Client::new();
+        let no_refresh = token(None, Some(0));
+        let err = refresh(&client, SubscriptionProvider::Claude, &no_refresh, 1_000)
+            .await
+            .expect_err("must fail without a refresh token");
+        assert!(matches!(err, RefreshError::NoRefreshToken));
     }
 
     #[test]

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -363,7 +363,7 @@ fn quoted_value<'a>(line: &'a str, key: &str) -> Option<&'a str> {
 /// closes that gap; see issue #48.
 #[test]
 fn dockerfile_offers_a_claude_cli_variant_without_bloating_the_default_image() {
-    let dockerfile = fs::read_to_string("Dockerfile").expect("Dockerfile should be readable");
+    let dockerfile = read_lf("Dockerfile");
 
     assert!(
         dockerfile.contains("AS with-claude-cli"),
@@ -396,8 +396,7 @@ fn dockerfile_offers_a_claude_cli_variant_without_bloating_the_default_image() {
 
 #[test]
 fn release_workflow_publishes_both_the_default_and_claude_cli_images() {
-    let workflow = fs::read_to_string(".github/workflows/release.yml")
-        .expect("release workflow should be readable");
+    let workflow = read_lf(".github/workflows/release.yml");
 
     assert_eq!(
         workflow.matches("target: runtime").count(),
@@ -419,6 +418,16 @@ fn release_workflow_publishes_both_the_default_and_claude_cli_images() {
         2,
         "the Claude CLI variant should also get a version-pinned tag"
     );
+}
+
+/// Read a repository file with line endings normalised to `\n`.
+///
+/// A Windows checkout may convert these files to CRLF, which would otherwise
+/// break the newline-anchored matching below.
+fn read_lf(path: &str) -> String {
+    fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("{path} should be readable: {e}"))
+        .replace("\r\n", "\n")
 }
 
 /// Extract the instructions of the named Dockerfile stage.

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -183,13 +183,13 @@ fn release_workflow_publishes_synced_docker_hub_image_after_crate() {
     );
     assert_eq!(
         workflow.matches("docker/metadata-action@v6").count(),
-        2,
-        "auto and manual release jobs should derive Docker metadata once for both registries"
+        4,
+        "auto and manual release jobs should derive Docker metadata for the default and Claude CLI images"
     );
     assert_eq!(
         workflow.matches("docker/build-push-action@v7").count(),
-        2,
-        "auto and manual release jobs should push Docker images"
+        4,
+        "auto and manual release jobs should push the default and Claude CLI images"
     );
 
     let auto_publish = workflow
@@ -356,4 +356,85 @@ fn quoted_value<'a>(line: &'a str, key: &str) -> Option<&'a str> {
     let rest = line.strip_prefix(key)?.trim_start();
     let rest = rest.strip_prefix('=')?.trim_start();
     rest.strip_prefix('"')?.strip_suffix('"')
+}
+
+/// The runtime image has no Claude CLI, so a container cannot perform a
+/// first-time `claude` login. The published `:with-claude-cli` variant is what
+/// closes that gap; see issue #48.
+#[test]
+fn dockerfile_offers_a_claude_cli_variant_without_bloating_the_default_image() {
+    let dockerfile = fs::read_to_string("Dockerfile").expect("Dockerfile should be readable");
+
+    assert!(
+        dockerfile.contains("AS with-claude-cli"),
+        "Dockerfile should define a `with-claude-cli` stage so a container can run `claude` login"
+    );
+    assert!(
+        dockerfile.contains("@anthropic-ai/claude-code"),
+        "the `with-claude-cli` stage should install the Claude Code CLI"
+    );
+
+    let default_stage = dockerfile_stage(&dockerfile, "runtime-base")
+        .expect("Dockerfile should define the minimal `runtime-base` stage");
+    assert!(
+        !default_stage.contains("nodejs") && !default_stage.contains("claude-code"),
+        "the default runtime stage should stay minimal: no Node.js and no Claude CLI"
+    );
+
+    // The last stage is what a bare `docker build .` produces, so the minimal
+    // image must come last or every default build would ship the CLI.
+    let last_stage_name = dockerfile
+        .rsplit("\nFROM ")
+        .next()
+        .and_then(|stage| stage.split_whitespace().nth(2))
+        .expect("Dockerfile should end with a named stage");
+    assert_eq!(
+        last_stage_name, "runtime",
+        "the minimal `runtime` stage must be last so a default build does not include the Claude CLI"
+    );
+}
+
+#[test]
+fn release_workflow_publishes_both_the_default_and_claude_cli_images() {
+    let workflow = fs::read_to_string(".github/workflows/release.yml")
+        .expect("release workflow should be readable");
+
+    assert_eq!(
+        workflow.matches("target: runtime").count(),
+        2,
+        "auto and manual release jobs should pin the default image to the minimal `runtime` stage"
+    );
+    assert_eq!(
+        workflow.matches("target: with-claude-cli").count(),
+        2,
+        "auto and manual release jobs should also build the Claude CLI variant"
+    );
+    assert_eq!(
+        workflow.matches("type=raw,value=with-claude-cli").count(),
+        2,
+        "the Claude CLI variant should get a floating `with-claude-cli` tag"
+    );
+    assert_eq!(
+        workflow.matches("-with-claude-cli\n").count(),
+        2,
+        "the Claude CLI variant should also get a version-pinned tag"
+    );
+}
+
+/// Extract the instructions of the named Dockerfile stage.
+///
+/// Comments are dropped: the block documenting the *next* stage sits inside
+/// this stage's text and would otherwise be mistaken for its content.
+fn dockerfile_stage(dockerfile: &str, name: &str) -> Option<String> {
+    let marker = format!("AS {name}\n");
+    let start = dockerfile.find(&marker)? + marker.len();
+    let rest = &dockerfile[start..];
+    let end = rest.find("\nFROM ").unwrap_or(rest.len());
+    Some(
+        rest[..end]
+            .lines()
+            .filter(|line| !line.trim_start().starts_with('#'))
+            .collect::<Vec<_>>()
+            .join("\n"),
+    )
 }


### PR DESCRIPTION
Closes #48.

The runtime image declared `CLAUDE_CODE_HOME=/data/claude` but nothing in it could populate or renew that credential: there is no `claude` CLI in the image, the README mounts the directory `:ro`, and `src/refresh.rs` explicitly excluded Claude (`SubscriptionProvider::Claude => None`) on the assumption that the CLI would keep the file current. In a container that assumption does not hold, so an expired token was terminal.

This implements all three suggestions from the issue, plus the mount-mode documentation.

## 1. Router-driven Claude refresh (no CLI needed)

`src/refresh.rs` now has a `RefreshConfig` for Claude, using the Claude Code CLI's public OAuth client — client id `9d1c250a-e61b-44d9-88ed-5944d1962f5e` against `https://console.anthropic.com/v1/oauth/token`. Both values are the ones already recorded as **[VERIFIED]** in this repo's own `docs/case-studies/issue-37/online-research.md`, and this is "Plan 1" from `solution-plans.md`.

`src/oauth.rs` now reads `refreshToken`/`expiresAt` out of the credential file — from the nested `claudeAiOauth` block or the flat layout, never mixing fields across the two — and `get_fresh_token()` resolves in order: manual `set_token` → on-disk token if unexpired → cached refresh result → a fresh exchange. `resolve_upstream_credentials` in `src/proxy.rs` became `async` to call it.

The refreshed token is held **in memory only**; the vendor's credential file is never written back, so a `:ro` mount keeps working across expiry.

## 2. `with-claude-cli` image variant

The `Dockerfile` splits into `runtime-base` → `with-claude-cli` (Node.js + `@anthropic-ai/claude-code`) → `runtime`. The minimal stage is deliberately **last**, so `docker build .` and any untargeted build still produce the small image; the release workflow now passes an explicit `target:` for each and publishes `:with-claude-cli` and `:<version>-with-claude-cli`.

## 3. Documented derived-image recipe + mount modes

README gains a `FROM ghcr.io/link-assistant/router:latest` recipe and this table, mirrored in `docs/use-cases/self-hosting.md`:

| Operation | Needs the Claude CLI in the image? | Mount mode |
| --- | --- | --- |
| Serve with a valid token | No | `:ro` |
| Renew an expired token | No — the router exchanges `refreshToken` | `:ro` |
| First-time login | Yes | writable |

## Reproduction and tests

The failure is "an expired credential file plus no CLI." The verifying test creates exactly that and asserts the router recovers on its own:

- `claude_refresh_exchanges_the_refresh_token_and_never_touches_disk` — an expired `SubscriptionToken` is refreshed against a loopback stub token endpoint; the test asserts the real request shape (`grant_type=refresh_token`, the stored refresh token, `client_id == CLAUDE_CLIENT_ID`, no client secret) and the new access token and computed expiry. A `refresh_at()` seam overrides only the URL, so client id, body encoding and response handling are the production ones.
- `claude_refresh_result_is_cached_and_reused` — the stub answers once, so a second exchange would fail; proves the result is cached.
- 7 tests in `src/oauth.rs` covering nested/flat refresh-token reads, no cross-layout field mixing, unexpired-disk-token passthrough, and `set_token` precedence.
- `dockerfile_offers_a_claude_cli_variant_without_bloating_the_default_image` — asserts the CLI stage exists, the default stage carries neither Node.js nor the CLI, and that the last stage is `runtime` (the regression that would silently make `docker build .` ship the fat image).
- `release_workflow_publishes_both_the_default_and_claude_cli_images`.

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` (247 tests) all pass locally.
