### PR TITLE
feat(admin): model admin access as a scoped JWT and close the open default

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-08-07T15:44:19.862Z for PR creation at branch issue-47-0560ebdac190 for issue https://github.com/link-assistant/router/issues/47
+# Updated: 2026-08-07T19:29:21.451Z

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,7 +1370,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "link-assistant-router"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,17 +34,11 @@ RUN touch src/lib.rs src/main.rs && \
 # when you need to *create* a credential inside the container.
 FROM debian:bookworm-slim AS runtime-base
 
-# `POST /api/login` (issue #47) drives the Claude Code CLI on a PTY inside this
-# container, so the CLI — and the Node runtime it needs — must be present. Set
-# `--disable-login-api` if you authorize by mounting a credential file instead.
+# TLS roots only. `POST /api/login` (issue #47) drives the Claude Code CLI on a
+# PTY, so that surface needs the `with-claude-cli` stage below; this base image
+# stays minimal for the mounted-credential deployment.
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates curl gnupg && \
-    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
-    apt-get install -y --no-install-recommends nodejs && \
-    npm install -g @anthropic-ai/claude-code && \
-    npm cache clean --force && \
-    apt-get purge -y gnupg && \
-    apt-get autoremove -y && \
+    apt-get install -y --no-install-recommends ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/target/release/link-assistant-router /usr/local/bin/link-assistant-router

--- a/README.md
+++ b/README.md
@@ -298,9 +298,10 @@ Claude Code will work exactly as normal, with all requests transparently proxied
 | Endpoint | Method | Description |
 |---|---|---|
 | `/health` | GET | Health check, returns `ok` |
-| `/api/tokens` | POST | Issue a new custom token |
+| `/api/tokens` | POST | (admin) Issue a new custom token |
 | `/api/tokens/list` | GET | (admin) List every persisted token |
 | `/api/tokens/revoke` | POST | (admin) Revoke a token by id |
+| `/api/tokens/rotate` | POST | (admin) Issue a replacement admin token and revoke the caller's own |
 | `/api/providers` | GET/POST | (admin) List or upsert OpenAI-compatible upstream providers |
 | `/api/providers/{name}` | GET/DELETE | (admin) Show or delete one provider |
 
@@ -417,6 +418,7 @@ Issue a new custom JWT token.
 |---|---|---|---|
 | `ttl_hours` | integer | 24 | Token lifetime in hours |
 | `label` | string | `""` | Optional human-readable label |
+| `scope` | string | `""` | `"admin"` mints a credential that also unlocks the admin endpoints; omit for an ordinary client token |
 
 **Response:**
 
@@ -632,7 +634,8 @@ The HTTP API accepts the same shape at `POST /api/providers`:
 | `--login-session-ttl-secs` / `LOGIN_SESSION_TTL_SECS` | `900` | How long a pending login waits for its code before expiring |
 | `--login-max-sessions` / `LOGIN_MAX_SESSIONS` | `4` | Maximum simultaneously pending logins; beyond it, `429` |
 | `--experimental-compatibility` / `EXPERIMENTAL_COMPATIBILITY` | off | XML history, model spoofing and other community-proxy behaviours |
-| `--admin-key` / `TOKEN_ADMIN_KEY` | (open) | Bearer key required for `/api/tokens*` admin endpoints |
+| `--admin-key` / `TOKEN_ADMIN_KEY` | — | Flat bootstrap Bearer key accepted by `/api/tokens*` alongside admin-scoped tokens |
+| `--allow-anonymous-admin` / `ALLOW_ANONYMOUS_ADMIN` | off | Opt back into unauthenticated `/api/tokens*` access (**not recommended**) |
 | `--mpp-enable` / `MPP_ENABLE` | off | Return MPP `402 Payment Required` challenges on OpenAI endpoints |
 | `--mpp-amount` / `MPP_AMOUNT` | `0.00` | Per-request MPP charge amount |
 | `--mpp-currency` / `MPP_CURRENCY` | `USD` | Currency or asset for MPP charges |
@@ -859,9 +862,60 @@ Tokens are standard HS256 JWTs with the `la_sk_` prefix. The JWT payload contain
   "sub": "550e8400-e29b-41d4-a716-446655440000",
   "iat": 1710806400,
   "exp": 1710892800,
-  "label": "my-token"
+  "label": "my-token",
+  "scope": "admin"
 }
 ```
+
+`scope` is absent (or empty) on an ordinary client token and `"admin"` on an
+administrative one — see [Admin access](#admin-access).
+
+### Admin access
+
+The `/api/tokens*` endpoints — and every other endpoint marked *(admin)* above
+— are **closed by default**. Three things can open them:
+
+1. **An admin-scoped token.** It is an ordinary `la_sk_…` JWT carrying
+   `"scope": "admin"`, so it expires, has an identity (`sub`), shows up in
+   `tokens list`, and can be revoked and rotated like any other token.
+
+   ```bash
+   # CLI
+   link-assistant-router tokens issue --admin --ttl-hours 168 --label ops
+   # HTTP (from an existing admin credential)
+   curl -s -X POST http://localhost:8080/api/tokens \
+     -H "Authorization: Bearer $ADMIN" -H "Content-Type: application/json" \
+     -d '{"ttl_hours": 168, "label": "ops", "scope": "admin"}' | jq -r .token
+   ```
+
+   Rotation is a single step — mint the replacement and revoke the credential
+   that asked for it:
+
+   ```bash
+   link-assistant-router tokens rotate <sub> --ttl-hours 168 --label ops
+   curl -s -X POST http://localhost:8080/api/tokens/rotate \
+     -H "Authorization: Bearer $ADMIN" -H "Content-Type: application/json" -d '{}' | jq .
+   ```
+
+2. **The flat `--admin-key` / `TOKEN_ADMIN_KEY`.** Still supported unchanged as
+   a bootstrap and compatibility credential for deployments that configure
+   everything externally, and now compared in constant time. It carries no
+   identity or expiry, so it cannot rotate itself (`/api/tokens/rotate` answers
+   `400`); prefer an admin-scoped token for day-to-day use.
+
+3. **Nothing at all** — only if you pass `--allow-anonymous-admin`
+   (`ALLOW_ANONYMOUS_ADMIN=1`). This restores the historical wide-open
+   behaviour and is logged as a warning at startup.
+
+When neither an admin key nor an active admin token exists, the router mints
+one on startup and prints it **once**:
+
+```
+Admin token (shown once, store it now): la_sk_eyJ0eXAi...
+```
+
+A client token presented to an admin endpoint is rejected: authorisation is by
+scope, not by "any valid token".
 
 ### Per-token request budget
 

--- a/README.md
+++ b/README.md
@@ -712,6 +712,7 @@ The default image intentionally contains no Claude CLI. What it can and cannot d
 | Serve requests with a valid access token | No | `:ro` |
 | Renew an **expired** access token | No — the router exchanges the `refreshToken` itself | `:ro` |
 | **First-time login** (no credential file yet) | Yes | writable |
+| `POST /api/login` (remote login over HTTP) | Yes — it drives `claude setup-token` | writable |
 
 Renewal happens in memory: the router exchanges the `refreshToken` stored in the mounted credential file against Anthropic's token endpoint and keeps the result in RAM. The credential file is never written to, which is why `:ro` keeps working across expiry — and why a restarted container refreshes again from the same file. The same mechanism already covers Codex, Gemini, and Qwen.
 

--- a/changelog.d/20260807_190000_issue_49_scoped_admin_tokens.md
+++ b/changelog.d/20260807_190000_issue_49_scoped_admin_tokens.md
@@ -1,0 +1,51 @@
+---
+bump: minor
+---
+
+### Security
+
+- The `/api/tokens*` admin surface is **closed by default**
+  ([#49](https://github.com/link-assistant/router/issues/49)). Previously
+  `is_admin_authorised` returned `true` whenever `TOKEN_ADMIN_KEY` was unset, so
+  a deployment that had not configured an admin key answered `200` to an
+  unauthenticated `POST /api/tokens` — anyone who could reach the port could
+  mint a token that spends the subscription and list every token already issued.
+  The default bind address is `0.0.0.0`, so in a container with a published port
+  that was reachable from outside the host. An unauthenticated admin request is
+  now `401`.
+- The flat `TOKEN_ADMIN_KEY` is compared with a constant-time digest comparison
+  instead of `==`, so a wrong key no longer leaks how many bytes matched.
+
+### Added
+
+- Admin access is now modelled as a **scoped token** rather than a flat shared
+  secret. An admin credential is an ordinary `la_sk_…` JWT carrying
+  `"scope": "admin"`, validated on the same code path as every other token, so
+  it has an identity (`sub`), an expiry, a record in `tokens list`, and full
+  revocation semantics.
+- `tokens issue --admin` (CLI) and `{"scope": "admin"}` on `POST /api/tokens`
+  (HTTP) mint one.
+- Rotation in a single step — mint the replacement and revoke the credential
+  that asked for it: `tokens rotate <sub>` (CLI) and `POST /api/tokens/rotate`
+  (HTTP). The flat key has no subject to revoke, so it cannot rotate itself and
+  gets `400`.
+- When no admin credential is configured, the router generates one on first
+  start, prints it once (`Admin token (shown once, store it now): la_sk_…`) and
+  persists its record — a fresh deployment is usable without being open.
+- `--allow-anonymous-admin` / `ALLOW_ANONYMOUS_ADMIN` explicitly restores the
+  historical open behaviour for deployments that depend on it. It warns at
+  startup, and `doctor` reports the admin surface as `OPEN` when it is set.
+
+### Changed
+
+- The flat `--admin-key` / `TOKEN_ADMIN_KEY` keeps working unchanged as a
+  bootstrap and compatibility credential — it is the only way to provision the
+  first credential in a deployment configured entirely from the outside.
+- `tokens list` gained a `scope` column (`client` for ordinary tokens).
+
+### Documentation
+
+- README gained an *Admin access* section and rows for `/api/tokens/rotate`,
+  the `scope` field and `--allow-anonymous-admin`;
+  `docs/use-cases/self-hosting.md` and `docs/use-cases/remote-login.md` now
+  describe the closed default and the bootstrap token instead of the open one.

--- a/docs/use-cases/remote-login.md
+++ b/docs/use-cases/remote-login.md
@@ -114,9 +114,10 @@ With it disabled the routes are not registered at all, and requests to them are
 ## Requirements
 
 * **The CLI must exist in the image.** The flow drives `claude setup-token` by
-  default; the published image ships the Claude Code CLI and Node for exactly
-  this reason. Point it elsewhere with `--login-cli-command` /
-  `--login-cli-args` if you drive something else.
+  default, so in Docker use the `with-claude-cli` image variant — it ships the
+  Claude Code CLI and Node for exactly this reason, while the default image
+  stays minimal for mounted-credential deployments. Point it elsewhere with
+  `--login-cli-command` / `--login-cli-args` if you drive something else.
 * **`CLAUDE_CODE_HOME` must be writable.** This is checked *before* the URL is
   returned, so a read-only mount fails immediately rather than after the human
   has already finished the browser step.

--- a/docs/use-cases/remote-login.md
+++ b/docs/use-cases/remote-login.md
@@ -96,10 +96,10 @@ free a slot early.
 ## Who may call this
 
 These endpoints start a process inside your deployment, so they are **admin**
-endpoints: when `TOKEN_ADMIN_KEY` is set they require it as a Bearer credential,
-exactly like `/api/tokens/list`. When it is unset they are open, like the rest
-of the admin surface — see [self-hosting.md](self-hosting.md), which explains
-why you should set it.
+endpoints: they require an admin credential as a Bearer token, exactly like
+`/api/tokens/list` — either an admin-scoped `la_sk_…` token or the flat
+`TOKEN_ADMIN_KEY`. They are closed when neither is presented; see
+[self-hosting.md](self-hosting.md) for how to obtain one.
 
 If you authorize by mounting a credential file and never want this surface,
 remove it entirely:

--- a/docs/use-cases/self-hosting.md
+++ b/docs/use-cases/self-hosting.md
@@ -10,7 +10,7 @@ This document covers that scenario: where the process runs, what it needs on
 disk, and — most importantly — **who can reach the endpoint that mints tokens**.
 
 Every claim below is asserted by
-`experiments/issue-45/test-deployment-hardening.sh` (**16 passed, 0 failed**),
+`experiments/issue-45/test-deployment-hardening.sh` (**18 passed, 0 failed**),
 which needs no subscription: all of it concerns the router's own auth surface,
 so no request reaches an upstream.
 

--- a/docs/use-cases/self-hosting.md
+++ b/docs/use-cases/self-hosting.md
@@ -16,25 +16,43 @@ so no request reaches an upstream.
 
 ## The one thing to get right
 
-`POST /api/tokens` mints `la_sk_…` tokens that spend your subscription. **When
-`TOKEN_ADMIN_KEY` is unset, that endpoint is open** — anyone who can reach the
-port can mint themselves a working token, and list every token you have issued:
+`POST /api/tokens` mints `la_sk_…` tokens that spend your subscription, so it —
+and every other `/api/tokens*` endpoint — is **closed by default**. An
+unauthenticated call is refused:
 
 ```console
 $ curl -X POST http://router:8080/api/tokens -d '{"ttl_hours":1,"label":"anyone"}'
-{"token":"la_sk_…","ttl_hours":1,"label":"anyone", …}      # 200, no credential sent
+{"error":{"type":"authentication_error", …}}              # 401, no credential sent
 ```
 
-The default bind address is `0.0.0.0`, so in a container with a published port
-this is reachable from outside the host. Set an admin key:
+Historically the endpoint was open whenever `TOKEN_ADMIN_KEY` was unset — the
+default bind address is `0.0.0.0`, so in a container with a published port
+anyone who could reach it could mint themselves a working token and list every
+token you had issued. That default is gone.
+
+If you configure nothing, the router mints an admin credential on first start
+and prints it once:
+
+```
+Admin token (shown once, store it now): la_sk_eyJ0eXAi...
+```
+
+That token is an ordinary `la_sk_…` JWT with `"scope": "admin"`: it expires, it
+is listed by `tokens list`, and it can be revoked or rotated
+(`POST /api/tokens/rotate` mints a replacement and revokes the caller's own
+subject in one step). Issue more with `tokens issue --admin` or
+`{"scope":"admin"}`.
+
+The flat key still works as a bootstrap credential when you provision
+everything externally, and is now compared in constant time:
 
 ```bash
 TOKEN_ADMIN_KEY="$(openssl rand -hex 32)"
 ```
 
-With it set, issuing, listing and revoking all require it as a Bearer
-credential; a missing or wrong key is `401`, and a rejected revoke is a **no-op**
-— an outsider cannot cancel a running task's token:
+Either way, issuing, listing and revoking all require a credential as a Bearer
+token; a missing or wrong one is `401`, and a rejected revoke is a **no-op** —
+an outsider cannot cancel a running task's token:
 
 | Request | Result |
 | --- | --- |
@@ -42,12 +60,17 @@ credential; a missing or wrong key is `401`, and a rejected revoke is a **no-op*
 | `GET /api/tokens/list` with no key | `401` |
 | `POST /api/tokens/revoke` with no key | `401`, and the token stays valid |
 | any of the above with `Authorization: Bearer $TOKEN_ADMIN_KEY` | `200` |
+| any of the above with an admin-scoped `la_sk_…` token | `200` |
+
+`--allow-anonymous-admin` (`ALLOW_ANONYMOUS_ADMIN=1`) restores the old open
+behaviour. It exists only so an existing deployment that depends on it is not
+broken by an upgrade; do not use it on a reachable port.
 
 ### The two secrets are not interchangeable
 
 | Secret | Held by | Grants |
 | --- | --- | --- |
-| `TOKEN_ADMIN_KEY` | the operator | minting, listing, revoking task tokens |
+| `TOKEN_ADMIN_KEY` or an admin-scoped token | the operator | minting, listing, revoking task tokens |
 | `la_sk_…` task token | one task | proxied inference, within that token's TTL and budget |
 
 They do not substitute for each other: a task token presented to
@@ -141,9 +164,10 @@ One token per task keeps the audit trail attributable — see
 ## Checklist before exposing the port
 
 - [ ] `TOKEN_SECRET` set to a random value, not a default.
-- [ ] `TOKEN_ADMIN_KEY` set — otherwise `/api/tokens` is open.
+- [ ] An admin credential in hand — the bootstrap token printed at first start,
+      or `TOKEN_ADMIN_KEY` set. Never `--allow-anonymous-admin`.
 - [ ] `ROUTER_HOST=127.0.0.1`, or a published port restricted to loopback,
-      unless the admin key is set and TLS terminates in front.
+      unless an admin credential is required and TLS terminates in front.
 - [ ] `AUDIT_LOG` pointed somewhere durable.
 - [ ] The subscription directory mounted **read-only**.
 - [ ] Tokens issued with a `--max-requests` budget and a short TTL.

--- a/experiments/issue-45/test-deployment-hardening.sh
+++ b/experiments/issue-45/test-deployment-hardening.sh
@@ -73,17 +73,26 @@ docker image inspect "$IMAGE" >/dev/null 2>&1 ||
 start la-router-open "$OPEN_PORT" && check "starts with no subscription mounted" ok ||
   check "starts with no subscription mounted" "never became healthy"
 
-# --- TOKEN_ADMIN_KEY unset: the admin surface is OPEN ----------------------
+# --- TOKEN_ADMIN_KEY unset: the admin surface is CLOSED (issue #49) --------
 OPEN_ISSUE=$(curl -s -o /tmp/issue45-open.json -w '%{http_code}' \
   -X POST "http://127.0.0.1:$OPEN_PORT/api/tokens" \
   -H 'Content-Type: application/json' -d '{"ttl_hours":1,"label":"unauthenticated"}')
-expect_status "without TOKEN_ADMIN_KEY anyone can mint a token" 200 "$OPEN_ISSUE"
+expect_status "without an admin credential nobody can mint a token" 401 "$OPEN_ISSUE"
 OPEN_TOKEN=$(python3 -c 'import json;print(json.load(open("/tmp/issue45-open.json")).get("token",""))')
-[[ "$OPEN_TOKEN" == la_sk_* ]] && check "the unauthenticated mint really returns a usable token" ok ||
-  check "the unauthenticated mint really returns a usable token" "no la_sk_ token"
+[[ -z "$OPEN_TOKEN" ]] && check "the rejected mint returns no token" ok ||
+  check "the rejected mint returns no token" "got $OPEN_TOKEN"
 
 OPEN_LIST=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:$OPEN_PORT/api/tokens/list")
-expect_status "without TOKEN_ADMIN_KEY the token list is readable" 200 "$OPEN_LIST"
+expect_status "without an admin credential the token list is not readable" 401 "$OPEN_LIST"
+
+# The router mints a bootstrap admin token instead and prints it once.
+BOOTSTRAP=$(docker logs la-router-open 2>&1 | sed -n 's/.*Admin token (shown once, store it now): //p' | tail -1)
+[[ "$BOOTSTRAP" == la_sk_* ]] && check "a bootstrap admin token is printed at startup" ok ||
+  check "a bootstrap admin token is printed at startup" "no token in the logs"
+
+BOOTSTRAP_LIST=$(curl -s -o /dev/null -w '%{http_code}' \
+  -H "Authorization: Bearer $BOOTSTRAP" "http://127.0.0.1:$OPEN_PORT/api/tokens/list")
+expect_status "the bootstrap admin token opens the admin surface" 200 "$BOOTSTRAP_LIST"
 
 # --- TOKEN_ADMIN_KEY set: every admin route requires it --------------------
 start la-router-keyed "$KEYED_PORT" -e "TOKEN_ADMIN_KEY=$ADMIN_KEY" ||

--- a/experiments/issue-45/test-deployment-hardening.sh
+++ b/experiments/issue-45/test-deployment-hardening.sh
@@ -6,8 +6,8 @@
 # of the admin surface a use case in its own right, so the claims in the
 # self-hosting document are asserted here rather than assumed:
 #
-#   * with TOKEN_ADMIN_KEY unset, /api/tokens mints tokens to anyone who can
-#     reach the port (documented as the single most important hardening step),
+#   * with TOKEN_ADMIN_KEY unset, /api/tokens refuses anonymous callers and the
+#     router prints a one-off bootstrap admin token instead (issue #49),
 #   * with TOKEN_ADMIN_KEY set, issuing/listing/revoking require the key,
 #   * an admin key is NOT a proxy credential and a task token is NOT an admin
 #     credential — the two surfaces do not accept each other's secrets,

--- a/src/admin_auth.rs
+++ b/src/admin_auth.rs
@@ -1,0 +1,133 @@
+//! Authorisation decision for the administrative endpoints.
+//!
+//! Kept separate from [`crate::proxy`] so the rule can be exercised directly by
+//! unit tests without standing up an [`crate::app_state::AppState`], and so the
+//! HTTP layer holds nothing but header plumbing.
+
+use crate::token::{TokenManager, constant_time_eq};
+
+/// Decide whether a caller may touch the administrative endpoints.
+///
+/// Two credentials are accepted, in this order:
+///
+/// 1. an admin-scoped `la_sk_…` JWT (see [`crate::token::ADMIN_SCOPE`]) —
+///    identified, expiring, revocable, and rotatable;
+/// 2. the flat `TOKEN_ADMIN_KEY` bootstrap secret, compared in constant time.
+///    It is kept because it is the only way to provision the *first* credential
+///    in a deployment that configures everything externally.
+///
+/// When neither is presented the request is refused, unless the operator
+/// explicitly opted out with `--allow-anonymous-admin`. That default is the
+/// inverse of the historical behaviour, where an unconfigured admin key left
+/// the token-administration endpoints wide open.
+#[must_use]
+pub fn admin_access_granted(
+    manager: &TokenManager,
+    provided: Option<&str>,
+    admin_key: Option<&str>,
+    allow_anonymous: bool,
+) -> bool {
+    if let Some(provided) = provided {
+        if manager.validate_admin_token(provided).is_ok() {
+            return true;
+        }
+        if let Some(required) = admin_key
+            && constant_time_eq(provided, required)
+        {
+            return true;
+        }
+    }
+    allow_anonymous
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::token::{IssueRequest, TokenError};
+
+    fn manager() -> TokenManager {
+        TokenManager::new("secret-for-admin-auth-tests")
+    }
+
+    /// Reproduces the issue: with no admin key configured, an unauthenticated
+    /// request used to be authorised (`POST /api/tokens` answered `200`).
+    #[test]
+    fn unauthenticated_request_is_refused_when_no_credential_is_configured() {
+        assert!(!admin_access_granted(&manager(), None, None, false));
+    }
+
+    #[test]
+    fn unauthenticated_request_is_refused_when_an_admin_key_is_configured() {
+        assert!(!admin_access_granted(
+            &manager(),
+            None,
+            Some("s3cret"),
+            false
+        ));
+    }
+
+    #[test]
+    fn anonymous_access_requires_an_explicit_opt_out() {
+        assert!(admin_access_granted(&manager(), None, None, true));
+    }
+
+    #[test]
+    fn admin_scoped_token_is_accepted() {
+        let mgr = manager();
+        let token = mgr
+            .issue_admin_token(1, "ops")
+            .expect("should issue admin token");
+        assert!(admin_access_granted(&mgr, Some(&token), None, false));
+    }
+
+    #[test]
+    fn ordinary_client_token_is_rejected() {
+        let mgr = manager();
+        let token = mgr.issue_token(1, "client").expect("should issue");
+        assert!(matches!(
+            mgr.validate_admin_token(&token),
+            Err(TokenError::InsufficientScope)
+        ));
+        assert!(!admin_access_granted(&mgr, Some(&token), None, false));
+    }
+
+    #[test]
+    fn revoked_admin_token_is_rejected() {
+        let mgr = manager();
+        let token = mgr.issue_admin_token(1, "ops").expect("should issue");
+        let claims = mgr.validate_token(&token).expect("should validate");
+        mgr.revoke_token(&claims.sub).expect("should revoke");
+        assert!(!admin_access_granted(&mgr, Some(&token), None, false));
+    }
+
+    #[test]
+    fn expired_admin_token_is_rejected() {
+        let mgr = manager();
+        let token = mgr
+            .issue(&IssueRequest {
+                ttl_hours: -1,
+                label: "stale",
+                scope: crate::token::ADMIN_SCOPE,
+                ..IssueRequest::default()
+            })
+            .expect("should issue");
+        assert!(!admin_access_granted(&mgr, Some(&token), None, false));
+    }
+
+    #[test]
+    fn flat_admin_key_still_works_as_a_bootstrap_credential() {
+        let mgr = manager();
+        assert!(admin_access_granted(
+            &mgr,
+            Some("s3cret"),
+            Some("s3cret"),
+            false
+        ));
+        assert!(!admin_access_granted(
+            &mgr,
+            Some("wrong"),
+            Some("s3cret"),
+            false
+        ));
+    }
+}

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -46,8 +46,12 @@ pub struct AppState {
     pub provider_store: ProviderStore,
     /// Lazy logger for verbose output.
     pub logger: LogLazy,
-    /// Optional admin key (Bearer) required for `/api/tokens` issuance.
+    /// Optional flat bootstrap admin key (Bearer) accepted by the admin
+    /// endpoints alongside admin-scoped `la_sk_…` tokens.
     pub admin_key: Option<String>,
+    /// Whether the admin endpoints stay open to unauthenticated callers.
+    /// Defaults to `false`; set only by an explicit `--allow-anonymous-admin`.
+    pub allow_anonymous_admin: bool,
     /// Live metrics counter handle.
     pub metrics: Arc<crate::metrics::Metrics>,
     /// Append-only per-token audit log (disabled unless a path is configured).

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -30,6 +30,20 @@ use crate::config::{
     default_activitypub_public_key_pem, default_data_dir,
 };
 
+/// Parse a boolean switch that may also arrive from the environment.
+///
+/// Clap's plain `bool` accepts only `true`/`false` from an env var, which makes
+/// the `=1` spelling used throughout the deployment docs a hard startup error.
+fn parse_truthy(value: &str) -> Result<bool, String> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Ok(true),
+        "0" | "false" | "no" | "off" | "" => Ok(false),
+        other => Err(format!(
+            "expected a boolean (1/0, true/false), got '{other}'"
+        )),
+    }
+}
+
 /// Top-level CLI parser.
 #[derive(Debug, LinoParser)]
 #[command(
@@ -281,7 +295,19 @@ pub struct Cli {
     ///
     /// Off by default. Without it, a deployment that configures no admin
     /// credential mints a one-off admin token at startup and prints it once.
-    #[arg(long, env = "ALLOW_ANONYMOUS_ADMIN", global = true)]
+    ///
+    /// Accepted as a bare flag, and from the environment as `1`/`0`,
+    /// `true`/`false`, `yes`/`no` or `on`/`off` — clap's plain `bool` would
+    /// reject the `=1` spelling every other switch in the deployment docs uses.
+    #[arg(
+        long,
+        env = "ALLOW_ANONYMOUS_ADMIN",
+        global = true,
+        num_args = 0..=1,
+        default_value_t = false,
+        default_missing_value = "true",
+        value_parser = parse_truthy,
+    )]
     pub allow_anonymous_admin: bool,
 
     /// Enable MPP 402 charge challenges on OpenAI-compatible endpoints.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -271,9 +271,18 @@ pub struct Cli {
     #[arg(long, env = "EXPERIMENTAL_COMPATIBILITY", global = true)]
     pub experimental_compatibility: bool,
 
-    /// Bearer key required by `/api/tokens` and admin endpoints.
+    /// Flat bootstrap Bearer key accepted by the admin endpoints alongside
+    /// admin-scoped `la_sk_...` tokens.
     #[arg(long, env = "TOKEN_ADMIN_KEY", global = true)]
     pub admin_key: Option<String>,
+
+    /// Leave the admin endpoints (`/api/tokens*`, `/api/providers*`,
+    /// `/api/login*`) open to unauthenticated callers.
+    ///
+    /// Off by default. Without it, a deployment that configures no admin
+    /// credential mints a one-off admin token at startup and prints it once.
+    #[arg(long, env = "ALLOW_ANONYMOUS_ADMIN", global = true)]
+    pub allow_anonymous_admin: bool,
 
     /// Enable MPP 402 charge challenges on OpenAI-compatible endpoints.
     #[arg(long, env = "MPP_ENABLE", global = true)]
@@ -370,6 +379,19 @@ pub enum TokenOp {
         /// Omit for an unlimited token.
         #[arg(long)]
         max_requests: Option<u64>,
+        /// Issue an administrative token (`scope: admin`) that unlocks the
+        /// admin endpoints instead of only the inference proxy.
+        #[arg(long)]
+        admin: bool,
+    },
+    /// Replace an administrative token: issue a new one and revoke the old.
+    Rotate {
+        /// Subject id (`sub`) of the admin token being replaced.
+        id: String,
+        #[arg(long, default_value_t = 24)]
+        ttl_hours: i64,
+        #[arg(long, default_value = "")]
+        label: String,
     },
     /// List all known tokens.
     List,
@@ -519,6 +541,7 @@ impl Cli {
             account_request_limits: self.account_request_limits.clone(),
             experimental_compatibility: self.experimental_compatibility,
             admin_key: self.admin_key.clone().filter(|s| !s.is_empty()),
+            allow_anonymous_admin: self.allow_anonymous_admin,
             login: crate::login::LoginConfig {
                 enabled: !self.disable_login_api,
                 command: self.login_cli_command.clone(),
@@ -589,6 +612,7 @@ mod tests {
             account_request_limits: vec![],
             experimental_compatibility: false,
             admin_key: None,
+            allow_anonymous_admin: false,
             mpp_enable: false,
             mpp_amount: "0.00".into(),
             mpp_currency: "USD".into(),
@@ -653,6 +677,7 @@ mod tests {
             account_request_limits: vec![],
             experimental_compatibility: false,
             admin_key: None,
+            allow_anonymous_admin: false,
             mpp_enable: false,
             mpp_amount: "0.00".into(),
             mpp_currency: "USD".into(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -236,10 +236,13 @@ pub struct Config {
     /// Whether to enable experimental compatibility features (spoofing,
     /// XML history reconstruction, etc.). Off by default.
     pub experimental_compatibility: bool,
-    /// Whether to require a Bearer token on the `/api/tokens` issue endpoint.
-    /// When a `TOKEN_ADMIN_KEY` is set the issue endpoint demands it; otherwise
-    /// issuance is open (matching the legacy behaviour).
+    /// Optional flat bootstrap admin key accepted by the admin endpoints in
+    /// addition to admin-scoped `la_sk_…` tokens.
     pub admin_key: Option<String>,
+    /// Explicit opt-out that leaves the admin endpoints open to
+    /// unauthenticated callers. Off by default: a deployment with no admin
+    /// credential configured mints a bootstrap one at startup instead.
+    pub allow_anonymous_admin: bool,
     /// Optional MPP charge settings for OpenAI-compatible endpoints.
     pub mpp: crate::mpp::MppConfig,
     /// Interactive login API settings (`/api/login`).
@@ -364,6 +367,8 @@ impl Config {
         let experimental_compatibility = env::var("EXPERIMENTAL_COMPATIBILITY")
             .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"));
         let admin_key = env::var("TOKEN_ADMIN_KEY").ok().filter(|s| !s.is_empty());
+        let allow_anonymous_admin = env::var("ALLOW_ANONYMOUS_ADMIN")
+            .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"));
         let login = crate::login::LoginConfig {
             enabled: env::var("ENABLE_LOGIN_API").map_or(true, |v| {
                 !matches!(v.as_str(), "0" | "false" | "FALSE" | "off")
@@ -418,6 +423,7 @@ impl Config {
             account_request_limits,
             experimental_compatibility,
             admin_key,
+            allow_anonymous_admin,
             mpp,
             login,
         })
@@ -485,6 +491,7 @@ impl Config {
             account_request_limits: args.account_request_limits,
             experimental_compatibility: args.experimental_compatibility,
             admin_key: args.admin_key,
+            allow_anonymous_admin: args.allow_anonymous_admin,
             mpp: args.mpp,
             login: crate::login::LoginConfig {
                 claude_code_home: PathBuf::from(args.claude_code_home),
@@ -527,6 +534,7 @@ pub struct BuildArgs<'a> {
     pub account_request_limits: Vec<usize>,
     pub experimental_compatibility: bool,
     pub admin_key: Option<String>,
+    pub allow_anonymous_admin: bool,
     pub mpp: crate::mpp::MppConfig,
     /// Interactive login settings. `claude_code_home` is overwritten by
     /// [`Config::build`] so the login flow always writes where the router reads.
@@ -729,6 +737,7 @@ mod tests {
             account_request_limits: vec![],
             experimental_compatibility: false,
             admin_key: None,
+            allow_anonymous_admin: false,
             mpp: default_mpp_config(),
             login: crate::login::LoginConfig::default(),
         })
@@ -868,6 +877,7 @@ mod tests {
             account_request_limits: vec![],
             experimental_compatibility: false,
             admin_key: None,
+            allow_anonymous_admin: false,
             mpp: default_mpp_config(),
             login: crate::login::LoginConfig::default(),
         }
@@ -907,6 +917,7 @@ mod tests {
             account_request_limits: vec![],
             experimental_compatibility: false,
             admin_key: None,
+            allow_anonymous_admin: false,
             mpp: default_mpp_config(),
             login: crate::login::LoginConfig::default(),
         });

--- a/src/config.rs
+++ b/src/config.rs
@@ -704,8 +704,12 @@ impl std::error::Error for ConfigError {}
 mod tests {
     use super::*;
 
-    fn build_default(secret: Option<&str>) -> Result<Config, ConfigError> {
-        Config::build(BuildArgs {
+    fn build_default(secret: Option<&'static str>) -> Result<Config, ConfigError> {
+        Config::build(default_args(secret))
+    }
+
+    fn default_args(secret: Option<&'static str>) -> BuildArgs<'static> {
+        BuildArgs {
             host: "0.0.0.0",
             port: "8080",
             token_secret: secret,
@@ -740,7 +744,7 @@ mod tests {
             allow_anonymous_admin: false,
             mpp: default_mpp_config(),
             login: crate::login::LoginConfig::default(),
-        })
+        }
     }
 
     #[test]
@@ -885,43 +889,9 @@ mod tests {
 
     #[test]
     fn test_config_invalid_port() {
-        let result = Config::build(BuildArgs {
-            host: "0.0.0.0",
-            port: "not-a-number",
-            token_secret: Some("secret"),
-            claude_code_home: "/tmp/claude",
-            upstream_base_url: "https://api.anthropic.com",
-            verbose: false,
-            api_format: None,
-            routing_mode: RoutingMode::Direct,
-            storage_policy: StoragePolicy::Memory,
-            data_dir: PathBuf::from("/tmp/test-data"),
-            claude_cli_bin: None,
-            upstream_provider: UpstreamProvider::Anthropic,
-            gonka_private_key: None,
-            gonka_source_url: default_gonka_source_url(),
-            gonka_model: default_gonka_model(),
-            bridge_model: None,
-            audit_log: None,
-            crater: default_crater_config("https://router.example"),
-            openai_compatible: default_openai_compatible_config(),
-            activitypub_actor_base_url: "https://router.example".into(),
-            activitypub_public_key_pem: default_activitypub_public_key_pem(),
-            enable_openai_api: true,
-            enable_anthropic_api: true,
-            enable_metrics: true,
-            additional_account_dirs: vec![],
-            account_routing_strategy: SelectionStrategy::default(),
-            account_cooldown_secs: 60,
-            session_affinity_ttl_secs: 3600,
-            account_request_limits: vec![],
-            experimental_compatibility: false,
-            admin_key: None,
-            allow_anonymous_admin: false,
-            mpp: default_mpp_config(),
-            login: crate::login::LoginConfig::default(),
-        });
-        assert!(result.is_err());
+        let mut args = default_args(Some("secret"));
+        args.port = "not-a-number";
+        assert!(Config::build(args).is_err());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod accounts;
 pub mod activitypub;
+pub mod admin_auth;
 pub mod anthropic_bridge;
 pub mod anthropic_stream;
 pub mod app_state;

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ use link_assistant_router::providers::{ProviderStore, ProviderUpsert};
 use link_assistant_router::proxy::{self, AppState};
 use link_assistant_router::storage::{TokenStore, build_token_store};
 use link_assistant_router::subscription::{SubscriptionProvider, SubscriptionReader};
-use link_assistant_router::token::TokenManager;
+use link_assistant_router::token::{ADMIN_SCOPE, IssueRequest, TokenManager};
 use link_assistant_router::token_admin;
 use log_lazy::{LogLazy, levels};
 use tower_http::trace::TraceLayer;
@@ -148,6 +148,59 @@ fn build_shared_state(config: &Config) -> Result<SharedState, AnyError> {
     Ok((store, account_router))
 }
 
+/// TTL of the admin token minted on first start, in hours (one year).
+const BOOTSTRAP_ADMIN_TTL_HOURS: i64 = 24 * 365;
+
+/// Label recorded on the auto-generated bootstrap admin token.
+const BOOTSTRAP_ADMIN_LABEL: &str = "bootstrap-admin";
+
+/// Make sure the deployment starts with a closed, reachable admin surface.
+///
+/// A fresh deployment that configures no admin credential would otherwise
+/// have to choose between "open to everyone" and "impossible to administer".
+/// Instead we mint one admin-scoped token and print it once — the pattern used
+/// by most self-hosted services. Nothing is minted when the operator already
+/// provisioned a credential externally (`TOKEN_ADMIN_KEY`), when a usable
+/// admin token already exists in the store, or when anonymous admin access was
+/// explicitly opted into.
+fn announce_admin_access(config: &Config, token_manager: &TokenManager) {
+    if config.allow_anonymous_admin {
+        tracing::warn!(
+            "--allow-anonymous-admin is set: /api/tokens*, /api/providers* and /api/login* accept unauthenticated requests"
+        );
+        return;
+    }
+    if config.admin_key.is_some() {
+        tracing::info!("Admin access: TOKEN_ADMIN_KEY configured (bootstrap credential)");
+        return;
+    }
+    match token_manager.has_active_admin_token() {
+        Ok(true) => {
+            tracing::info!("Admin access: existing admin token found in the token store");
+            return;
+        }
+        Ok(false) => {}
+        Err(e) => {
+            tracing::warn!("could not inspect the token store for admin tokens: {e}");
+            return;
+        }
+    }
+    match token_manager.issue_admin_token(BOOTSTRAP_ADMIN_TTL_HOURS, BOOTSTRAP_ADMIN_LABEL) {
+        Ok(token) => {
+            // Printed to stdout as well as the log: this value is shown once
+            // and never recoverable afterwards (only its metadata is stored).
+            println!("─────────────────────────────────────────────────────────────");
+            println!("Admin token (shown once, store it now):");
+            println!("  {token}");
+            println!("Use it as: Authorization: Bearer <token>");
+            println!("Rotate it with: link-assistant-router tokens rotate <id>");
+            println!("─────────────────────────────────────────────────────────────");
+            tracing::info!("Generated a bootstrap admin token; admin endpoints are closed");
+        }
+        Err(e) => tracing::error!("failed to generate a bootstrap admin token: {e}"),
+    }
+}
+
 async fn run_server(config: Config, logger: LogLazy) -> Result<(), Box<dyn std::error::Error>> {
     tracing::info!("Upstream: {}", config.upstream_base_url);
     tracing::info!("Upstream provider: {:?}", config.upstream_provider);
@@ -171,6 +224,7 @@ async fn run_server(config: Config, logger: LogLazy) -> Result<(), Box<dyn std::
     }
 
     let token_manager = TokenManager::with_store(&config.token_secret, store);
+    announce_admin_access(&config, &token_manager);
     let oauth_provider = OAuthProvider::new(&config.claude_code_home);
     let metrics = Arc::new(Metrics::default());
     let provider_store = ProviderStore::open(&config.data_dir, &config.token_secret)?;
@@ -230,6 +284,7 @@ async fn run_server(config: Config, logger: LogLazy) -> Result<(), Box<dyn std::
         provider_store,
         logger,
         admin_key: config.admin_key.clone(),
+        allow_anonymous_admin: config.allow_anonymous_admin,
         metrics: Arc::clone(&metrics),
         activitypub_actor_base_url: config.activitypub_actor_base_url.clone(),
         activitypub_public_key_pem: config.activitypub_public_key_pem.clone(),
@@ -250,6 +305,7 @@ async fn run_server(config: Config, logger: LogLazy) -> Result<(), Box<dyn std::
         .route("/api/tokens", post(token_admin::issue_token))
         .route("/api/tokens/list", get(token_admin::list_tokens))
         .route("/api/tokens/revoke", post(token_admin::revoke_token))
+        .route("/api/tokens/rotate", post(token_admin::rotate_admin_token))
         .route(
             "/api/providers",
             get(provider_proxy::list_providers).post(provider_proxy::upsert_provider),
@@ -358,9 +414,31 @@ fn run_tokens(config: &Config, op: &TokenOp) -> ExitCode {
             label,
             account,
             max_requests,
-        } => match mgr.issue_token_full(*ttl_hours, label, account.as_deref(), *max_requests) {
+            admin,
+        } => match mgr.issue(&IssueRequest {
+            ttl_hours: *ttl_hours,
+            label,
+            account: account.as_deref(),
+            max_requests: *max_requests,
+            scope: if *admin { ADMIN_SCOPE } else { "" },
+        }) {
             Ok(t) => {
                 println!("{t}");
+                ExitCode::SUCCESS
+            }
+            Err(e) => {
+                eprintln!("error: {e}");
+                ExitCode::from(1)
+            }
+        },
+        TokenOp::Rotate {
+            id,
+            ttl_hours,
+            label,
+        } => match mgr.rotate_admin_token(id, *ttl_hours, label) {
+            Ok(t) => {
+                println!("{t}");
+                eprintln!("revoked {id}");
                 ExitCode::SUCCESS
             }
             Err(e) => {
@@ -371,16 +449,21 @@ fn run_tokens(config: &Config, op: &TokenOp) -> ExitCode {
         TokenOp::List => match mgr.list_tokens() {
             Ok(records) => {
                 println!(
-                    "{:<36}  {:<10}  {:<10}  {:<8}  {:<13}  label",
-                    "id", "issued_at", "expires_at", "revoked", "requests"
+                    "{:<36}  {:<10}  {:<10}  {:<8}  {:<13}  {:<6}  label",
+                    "id", "issued_at", "expires_at", "revoked", "requests", "scope"
                 );
                 for r in records {
                     let requests = r.max_requests.map_or_else(
                         || format!("{}/-", r.used_requests),
                         |max| format!("{}/{max}", r.used_requests),
                     );
+                    let scope = if r.scope.is_empty() {
+                        "client"
+                    } else {
+                        r.scope.as_str()
+                    };
                     println!(
-                        "{:<36}  {:<10}  {:<10}  {:<8}  {:<13}  {}",
+                        "{:<36}  {:<10}  {:<10}  {:<8}  {:<13}  {scope:<6}  {}",
                         r.id, r.issued_at, r.expires_at, r.revoked, requests, r.label
                     );
                 }
@@ -631,6 +714,14 @@ fn run_doctor(config: &Config) -> ExitCode {
             "set"
         } else {
             "<unset>"
+        }
+    );
+    println!(
+        "admin_endpoints        : {}",
+        if config.allow_anonymous_admin {
+            "OPEN (--allow-anonymous-admin)"
+        } else {
+            "closed (admin key or admin-scoped token required)"
         }
     );
     println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,8 +190,7 @@ fn announce_admin_access(config: &Config, token_manager: &TokenManager) {
             // Printed to stdout as well as the log: this value is shown once
             // and never recoverable afterwards (only its metadata is stored).
             println!("─────────────────────────────────────────────────────────────");
-            println!("Admin token (shown once, store it now):");
-            println!("  {token}");
+            println!("Admin token (shown once, store it now): {token}");
             println!("Use it as: Authorization: Bearer <token>");
             println!("Rotate it with: link-assistant-router tokens rotate <id>");
             println!("─────────────────────────────────────────────────────────────");

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -72,30 +72,15 @@ pub async fn health() -> impl IntoResponse {
 
 /// Decide whether a request may touch the administrative endpoints.
 ///
-/// Two credentials are accepted, in this order:
-///
-/// 1. an admin-scoped `la_sk_…` JWT (see [`crate::token::ADMIN_SCOPE`]) —
-///    identified, expiring, revocable, and rotatable;
-/// 2. the flat `TOKEN_ADMIN_KEY` bootstrap secret, compared in constant time.
-///    It is kept because it is the only way to provision the *first*
-///    credential in a deployment that configures everything externally.
-///
-/// When neither is presented the request is refused, unless the operator
-/// explicitly opted out with `--allow-anonymous-admin`. That default is the
-/// inverse of the historical behaviour, where an unconfigured admin key left
-/// the token-administration endpoints wide open.
+/// Thin HTTP wrapper over [`crate::admin_auth::admin_access_granted`], which
+/// documents and tests the rule itself.
 pub(crate) fn is_admin_authorised(state: &AppState, headers: &HeaderMap) -> bool {
-    if let Some(provided) = extract_bearer_token(headers) {
-        if state.token_manager.validate_admin_token(provided).is_ok() {
-            return true;
-        }
-        if let Some(required) = state.admin_key.as_deref()
-            && crate::token::constant_time_eq(provided, required)
-        {
-            return true;
-        }
-    }
-    state.allow_anonymous_admin
+    crate::admin_auth::admin_access_granted(
+        &state.token_manager,
+        extract_bearer_token(headers),
+        state.admin_key.as_deref(),
+        state.allow_anonymous_admin,
+    )
 }
 
 /// Bearer credential presented for an administrative request, if any.

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -70,12 +70,37 @@ pub async fn health() -> impl IntoResponse {
     (StatusCode::OK, "ok")
 }
 
+/// Decide whether a request may touch the administrative endpoints.
+///
+/// Two credentials are accepted, in this order:
+///
+/// 1. an admin-scoped `la_sk_…` JWT (see [`crate::token::ADMIN_SCOPE`]) —
+///    identified, expiring, revocable, and rotatable;
+/// 2. the flat `TOKEN_ADMIN_KEY` bootstrap secret, compared in constant time.
+///    It is kept because it is the only way to provision the *first*
+///    credential in a deployment that configures everything externally.
+///
+/// When neither is presented the request is refused, unless the operator
+/// explicitly opted out with `--allow-anonymous-admin`. That default is the
+/// inverse of the historical behaviour, where an unconfigured admin key left
+/// the token-administration endpoints wide open.
 pub(crate) fn is_admin_authorised(state: &AppState, headers: &HeaderMap) -> bool {
-    let Some(required) = state.admin_key.as_deref() else {
-        return true;
-    };
-    let provided = extract_bearer_token(headers);
-    provided == Some(required)
+    if let Some(provided) = extract_bearer_token(headers) {
+        if state.token_manager.validate_admin_token(provided).is_ok() {
+            return true;
+        }
+        if let Some(required) = state.admin_key.as_deref()
+            && crate::token::constant_time_eq(provided, required)
+        {
+            return true;
+        }
+    }
+    state.allow_anonymous_admin
+}
+
+/// Bearer credential presented for an administrative request, if any.
+pub(crate) fn extract_admin_bearer(headers: &HeaderMap) -> Option<&str> {
+    extract_bearer_token(headers)
 }
 
 fn extract_bearer_token(headers: &HeaderMap) -> Option<&str> {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -795,6 +795,33 @@ mod tests {
     }
 
     #[test]
+    fn stores_persist_the_admin_scope() {
+        let dir = tempdir().unwrap();
+        let mut admin = sample_record("admin");
+        admin.scope = crate::token::ADMIN_SCOPE.to_string();
+
+        let text_path = dir.path().join("tokens.lino");
+        let text = TextTokenStore::open(&text_path).unwrap();
+        text.put(admin.clone()).unwrap();
+        text.put(sample_record("client")).unwrap();
+        let text = TextTokenStore::open(&text_path).unwrap();
+        assert_eq!(
+            text.get("admin").unwrap().unwrap().scope,
+            crate::token::ADMIN_SCOPE
+        );
+        assert!(text.get("client").unwrap().unwrap().scope.is_empty());
+
+        let bin_path = dir.path().join("tokens.bin");
+        let bin = BinaryTokenStore::open(&bin_path).unwrap();
+        bin.put(admin).unwrap();
+        let bin = BinaryTokenStore::open(&bin_path).unwrap();
+        assert_eq!(
+            bin.get("admin").unwrap().unwrap().scope,
+            crate::token::ADMIN_SCOPE
+        );
+    }
+
+    #[test]
     fn dual_store_writes_both() {
         let dir = tempdir().unwrap();
         let text = Arc::new(TextTokenStore::open(dir.path().join("a.lino")).unwrap());

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -66,6 +66,12 @@ pub struct TokenRecord {
     /// Number of upstream requests already made with this token.
     #[serde(default)]
     pub used_requests: u64,
+    /// Privilege scope carried by the token. Empty (the default) means an
+    /// ordinary client token that may only proxy inference; `"admin"` marks a
+    /// credential that also unlocks the administrative endpoints. See
+    /// [`crate::token::ADMIN_SCOPE`].
+    #[serde(default)]
+    pub scope: String,
 }
 
 /// Errors a [`TokenStore`] can return.
@@ -476,6 +482,11 @@ fn encode_lino<'a>(records: impl IntoIterator<Item = &'a TokenRecord>) -> String
             out.push_str(&rec.used_requests.to_string());
             out.push(')');
         }
+        if !rec.scope.is_empty() {
+            out.push_str(" (scope ");
+            write_quoted(&mut out, &rec.scope);
+            out.push(')');
+        }
         out.push_str(")\n");
     }
     out
@@ -533,6 +544,7 @@ fn parse_record_line(line: &str) -> Result<TokenRecord, String> {
     let mut account: Option<String> = None;
     let mut max_requests: Option<u64> = None;
     let mut used_requests: u64 = 0;
+    let mut scope = String::new();
     while let Some(field) = tokens.next_paren_group() {
         let mut inner = LinoTokens::new(field);
         let key = inner
@@ -586,6 +598,9 @@ fn parse_record_line(line: &str) -> Result<TokenRecord, String> {
                     .parse()
                     .map_err(|e: std::num::ParseIntError| e.to_string())?;
             }
+            "scope" => {
+                scope = inner.next_string().unwrap_or_default();
+            }
             other => return Err(format!("unknown field: {other}")),
         }
     }
@@ -598,6 +613,7 @@ fn parse_record_line(line: &str) -> Result<TokenRecord, String> {
         account,
         max_requests,
         used_requests,
+        scope,
     })
 }
 
@@ -734,6 +750,7 @@ mod tests {
             account: Some("primary".into()),
             max_requests: None,
             used_requests: 0,
+            scope: String::new(),
         }
     }
 
@@ -836,6 +853,7 @@ mod tests {
             account: None,
             max_requests: Some(100),
             used_requests: 7,
+            scope: crate::token::ADMIN_SCOPE.to_string(),
         };
         let s = encode_lino(std::iter::once(&rec));
         let parsed = decode_lino(&s).unwrap();

--- a/src/token.rs
+++ b/src/token.rs
@@ -19,6 +19,13 @@ use crate::storage::{MemoryTokenStore, StorageError, TokenRecord, TokenStore};
 /// Prefix for all router-issued custom tokens.
 pub const TOKEN_PREFIX: &str = "la_sk_";
 
+/// Scope claim marking a token as an administrative credential.
+///
+/// A token carrying this scope unlocks the administrative endpoints
+/// (`/api/tokens*`, `/api/providers*`, `/api/login*`) in addition to the
+/// inference proxy. Tokens issued without a scope may only proxy inference.
+pub const ADMIN_SCOPE: &str = "admin";
+
 /// JWT claims stored inside each custom token.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct TokenClaims {
@@ -31,6 +38,37 @@ pub struct TokenClaims {
     /// Optional label for this token.
     #[serde(default)]
     pub label: String,
+    /// Privilege scope. Empty means an ordinary client token; [`ADMIN_SCOPE`]
+    /// marks an administrative credential.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub scope: String,
+}
+
+impl TokenClaims {
+    /// Whether these claims carry the administrative scope.
+    #[must_use]
+    pub fn is_admin(&self) -> bool {
+        self.scope == ADMIN_SCOPE
+    }
+}
+
+/// Parameters for [`TokenManager::issue`].
+///
+/// Grouped into a struct because issuance now varies along five independent
+/// axes (TTL, label, account pin, request budget, scope) and a positional
+/// argument list at that width is easy to mis-order at the call site.
+#[derive(Debug, Default, Clone)]
+pub struct IssueRequest<'a> {
+    /// Time-to-live in hours.
+    pub ttl_hours: i64,
+    /// Human-readable label recorded alongside the token.
+    pub label: &'a str,
+    /// Optional strict account binding (multi-account mode).
+    pub account: Option<&'a str>,
+    /// Optional cap on upstream requests; `None` means unlimited.
+    pub max_requests: Option<u64>,
+    /// Privilege scope; empty for an ordinary client token.
+    pub scope: &'a str,
 }
 
 /// Manages creation, validation, and revocation of custom tokens.
@@ -96,6 +134,41 @@ impl TokenManager {
         account: Option<&str>,
         max_requests: Option<u64>,
     ) -> Result<String, jsonwebtoken::errors::Error> {
+        self.issue(&IssueRequest {
+            ttl_hours,
+            label,
+            account,
+            max_requests,
+            scope: "",
+        })
+    }
+
+    /// Issue an administrative token.
+    ///
+    /// The result is an ordinary `la_sk_…` JWT that additionally carries
+    /// `"scope": "admin"`, so it validates on exactly the same code path as a
+    /// client token — same signature check, same expiry, same revocation —
+    /// while being distinguishable from one that may only proxy inference.
+    pub fn issue_admin_token(
+        &self,
+        ttl_hours: i64,
+        label: &str,
+    ) -> Result<String, jsonwebtoken::errors::Error> {
+        self.issue(&IssueRequest {
+            ttl_hours,
+            label,
+            account: None,
+            max_requests: None,
+            scope: ADMIN_SCOPE,
+        })
+    }
+
+    /// Issue a token described by [`IssueRequest`].
+    pub fn issue(&self, request: &IssueRequest<'_>) -> Result<String, jsonwebtoken::errors::Error> {
+        let ttl_hours = request.ttl_hours;
+        let label = request.label;
+        let account = request.account;
+        let max_requests = request.max_requests;
         let now = Utc::now();
         let exp = now + Duration::hours(ttl_hours);
         let claims = TokenClaims {
@@ -103,6 +176,7 @@ impl TokenManager {
             iat: now.timestamp(),
             exp: exp.timestamp(),
             label: label.to_string(),
+            scope: request.scope.to_string(),
         };
         let jwt = encode(
             &Header::default(),
@@ -120,6 +194,7 @@ impl TokenManager {
             account: account.map(String::from),
             max_requests,
             used_requests: 0,
+            scope: claims.scope.clone(),
         };
         if let Err(e) = self.store.put(record) {
             tracing::warn!("token store put failed: {e}");
@@ -183,6 +258,53 @@ impl TokenManager {
         Ok(token_data.claims)
     }
 
+    /// Validate a token and require that it carries [`ADMIN_SCOPE`].
+    ///
+    /// Returns [`TokenError::InsufficientScope`] for a token that is otherwise
+    /// valid but was issued without the administrative scope, so a leaked
+    /// client token can never be replayed against the admin endpoints.
+    pub fn validate_admin_token(&self, token: &str) -> Result<TokenClaims, TokenError> {
+        let claims = self.validate_token(token)?;
+        if claims.is_admin() {
+            Ok(claims)
+        } else {
+            Err(TokenError::InsufficientScope)
+        }
+    }
+
+    /// Whether at least one usable administrative token exists.
+    ///
+    /// "Usable" means recorded, not revoked, and not yet expired. Boot uses
+    /// this to decide whether a deployment already has a way in before
+    /// minting a bootstrap credential.
+    pub fn has_active_admin_token(&self) -> Result<bool, TokenError> {
+        let now = Utc::now().timestamp();
+        Ok(self.list_tokens()?.iter().any(|record| {
+            record.scope == ADMIN_SCOPE && !record.revoked && record.expires_at > now
+        }))
+    }
+
+    /// Rotate an administrative token: issue a replacement and revoke the old
+    /// one in a single step.
+    ///
+    /// This is the operation a flat shared secret cannot express — "new token,
+    /// old one expired" — and is why the admin credential is modelled as a
+    /// JWT with a `sub` in the first place. The replacement is issued *before*
+    /// the old subject is revoked so a storage failure cannot leave the
+    /// deployment with no admin credential at all.
+    pub fn rotate_admin_token(
+        &self,
+        current_sub: &str,
+        ttl_hours: i64,
+        label: &str,
+    ) -> Result<String, TokenError> {
+        let replacement = self
+            .issue_admin_token(ttl_hours, label)
+            .map_err(|e| TokenError::Invalid(e.to_string()))?;
+        self.revoke_token(current_sub)?;
+        Ok(replacement)
+    }
+
     /// Revoke a token by its subject ID. Idempotent.
     pub fn revoke_token(&self, token_id: &str) -> Result<(), TokenError> {
         match self.store.revoke(token_id) {
@@ -199,6 +321,26 @@ impl TokenManager {
     }
 }
 
+/// Compare two secrets without leaking their contents through timing.
+///
+/// Both sides are hashed with SHA-256 first, so the comparison always runs
+/// over 32 bytes and neither the length nor the position of the first
+/// differing byte is observable. The fold over the whole digest is what makes
+/// it constant-time; a plain `==` on the raw strings (which is what the flat
+/// `TOKEN_ADMIN_KEY` path used to do) short-circuits on the first mismatch.
+#[must_use]
+pub fn constant_time_eq(a: &str, b: &str) -> bool {
+    use sha2::{Digest, Sha256};
+
+    let left = Sha256::digest(a.as_bytes());
+    let right = Sha256::digest(b.as_bytes());
+    let mut diff = 0u8;
+    for (x, y) in left.iter().zip(right.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
 /// Errors related to token operations.
 #[derive(Debug)]
 pub enum TokenError {
@@ -210,6 +352,8 @@ pub enum TokenError {
     Revoked,
     /// Token is otherwise invalid.
     Invalid(String),
+    /// Token is valid but lacks the privilege scope the operation requires.
+    InsufficientScope,
     /// Token has reached its per-token request budget (`max_requests`).
     LimitExceeded,
     /// Storage backend failure.
@@ -225,6 +369,9 @@ impl std::fmt::Display for TokenError {
             Self::Expired => write!(f, "Token has expired"),
             Self::Revoked => write!(f, "Token has been revoked"),
             Self::Invalid(msg) => write!(f, "Invalid token: {msg}"),
+            Self::InsufficientScope => {
+                write!(f, "Token does not carry the '{ADMIN_SCOPE}' scope")
+            }
             Self::LimitExceeded => {
                 write!(f, "Token has reached its request limit")
             }

--- a/src/token.rs
+++ b/src/token.rs
@@ -194,7 +194,7 @@ impl TokenManager {
             account: account.map(String::from),
             max_requests,
             used_requests: 0,
-            scope: claims.scope.clone(),
+            scope: claims.scope,
         };
         if let Err(e) = self.store.put(record) {
             tracing::warn!("token store put failed: {e}");
@@ -542,5 +542,89 @@ mod tests {
         let mgr3 = TokenManager::with_store("k", store3);
         let r = mgr3.validate_token(&tok);
         assert!(matches!(r, Err(TokenError::Revoked)));
+    }
+
+    #[test]
+    fn test_admin_scope_is_carried_by_claims_and_records() {
+        let mgr = test_manager();
+        let token = mgr.issue_admin_token(1, "ops").expect("should issue");
+        let claims = mgr.validate_token(&token).expect("should validate");
+        assert!(claims.is_admin());
+        assert_eq!(claims.scope, ADMIN_SCOPE);
+
+        let records = mgr.list_tokens().expect("should list");
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].scope, ADMIN_SCOPE);
+    }
+
+    #[test]
+    fn test_client_tokens_carry_no_scope() {
+        let mgr = test_manager();
+        let token = mgr.issue_token(1, "client").expect("should issue");
+        let claims = mgr.validate_token(&token).expect("should validate");
+        assert!(!claims.is_admin());
+        assert!(claims.scope.is_empty());
+        assert!(matches!(
+            mgr.validate_admin_token(&token),
+            Err(TokenError::InsufficientScope)
+        ));
+    }
+
+    #[test]
+    fn test_has_active_admin_token_tracks_revocation_and_expiry() {
+        let mgr = test_manager();
+        assert!(!mgr.has_active_admin_token().expect("should query"));
+
+        mgr.issue_token(1, "client").expect("should issue");
+        assert!(
+            !mgr.has_active_admin_token().expect("should query"),
+            "client tokens must not satisfy the admin-credential check"
+        );
+
+        mgr.issue(&IssueRequest {
+            ttl_hours: -1,
+            label: "stale",
+            scope: ADMIN_SCOPE,
+            ..IssueRequest::default()
+        })
+        .expect("should issue");
+        assert!(
+            !mgr.has_active_admin_token().expect("should query"),
+            "expired admin tokens must not count"
+        );
+
+        let token = mgr.issue_admin_token(1, "ops").expect("should issue");
+        assert!(mgr.has_active_admin_token().expect("should query"));
+
+        let claims = mgr.validate_token(&token).expect("should validate");
+        mgr.revoke_token(&claims.sub).expect("should revoke");
+        assert!(!mgr.has_active_admin_token().expect("should query"));
+    }
+
+    #[test]
+    fn test_rotate_admin_token_issues_a_replacement_and_revokes_the_old_one() {
+        let mgr = test_manager();
+        let old = mgr.issue_admin_token(1, "ops").expect("should issue");
+        let old_claims = mgr.validate_token(&old).expect("should validate");
+
+        let new = mgr
+            .rotate_admin_token(&old_claims.sub, 2, "ops-rotated")
+            .expect("should rotate");
+
+        let new_claims = mgr.validate_admin_token(&new).expect("should validate");
+        assert_eq!(new_claims.label, "ops-rotated");
+        assert_ne!(new_claims.sub, old_claims.sub);
+        assert!(matches!(mgr.validate_token(&old), Err(TokenError::Revoked)));
+        assert!(mgr.has_active_admin_token().expect("should query"));
+    }
+
+    #[test]
+    fn test_constant_time_eq_matches_string_equality() {
+        assert!(constant_time_eq("", ""));
+        assert!(constant_time_eq("s3cret", "s3cret"));
+        assert!(!constant_time_eq("s3cret", "s3crev"));
+        // Length differences must not short-circuit into a match.
+        assert!(!constant_time_eq("s3cret", "s3cre"));
+        assert!(!constant_time_eq("s3cre", "s3cret"));
     }
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -298,6 +298,18 @@ impl TokenManager {
         ttl_hours: i64,
         label: &str,
     ) -> Result<String, TokenError> {
+        // `revoke_token` is idempotent and reports nothing for an unknown id,
+        // so check first: a typo must not hand back a fresh credential while
+        // silently leaving the old one live.
+        if !self
+            .list_tokens()?
+            .iter()
+            .any(|record| record.id == current_sub)
+        {
+            return Err(TokenError::Invalid(format!(
+                "unknown token id {current_sub}"
+            )));
+        }
         let replacement = self
             .issue_admin_token(ttl_hours, label)
             .map_err(|e| TokenError::Invalid(e.to_string()))?;
@@ -616,6 +628,18 @@ mod tests {
         assert_ne!(new_claims.sub, old_claims.sub);
         assert!(matches!(mgr.validate_token(&old), Err(TokenError::Revoked)));
         assert!(mgr.has_active_admin_token().expect("should query"));
+    }
+
+    #[test]
+    fn test_rotate_admin_token_rejects_an_unknown_subject() {
+        let mgr = test_manager();
+        let live = mgr.issue_admin_token(1, "ops").expect("should issue");
+
+        assert!(mgr.rotate_admin_token("not-an-id", 1, "typo").is_err());
+        // The existing credential must survive a failed rotation, and no
+        // replacement may have been handed out.
+        assert!(mgr.validate_admin_token(&live).is_ok());
+        assert_eq!(mgr.list_tokens().expect("should list").len(), 1);
     }
 
     #[test]

--- a/src/token_admin.rs
+++ b/src/token_admin.rs
@@ -16,7 +16,8 @@ use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
 
-use crate::proxy::{AppState, error_response, is_admin_authorised};
+use crate::proxy::{AppState, error_response, extract_admin_bearer, is_admin_authorised};
+use crate::token::{ADMIN_SCOPE, IssueRequest};
 
 /// Token issuance endpoint.
 ///
@@ -41,13 +42,22 @@ pub async fn issue_token(
 
     let ttl = req.ttl_hours.unwrap_or(24);
     let label = req.label.unwrap_or_default();
+    let scope = req.scope.unwrap_or_default();
+    if !scope.is_empty() && scope != ADMIN_SCOPE {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_request_error",
+            &format!("unknown scope '{scope}'; expected '{ADMIN_SCOPE}' or none"),
+        );
+    }
 
-    match state.token_manager.issue_token_full(
-        ttl,
-        &label,
-        req.account.as_deref(),
-        req.max_requests,
-    ) {
+    match state.token_manager.issue(&IssueRequest {
+        ttl_hours: ttl,
+        label: &label,
+        account: req.account.as_deref(),
+        max_requests: req.max_requests,
+        scope: &scope,
+    }) {
         Ok(token) => {
             state.metrics.record_token_issued();
             (
@@ -58,6 +68,7 @@ pub async fn issue_token(
                     "label": label,
                     "account": req.account,
                     "max_requests": req.max_requests,
+                    "scope": scope,
                 })),
             )
                 .into_response()
@@ -123,6 +134,61 @@ pub async fn revoke_token(
     }
 }
 
+/// Rotate the admin token used to make this call.
+///
+/// Issues a replacement admin token and revokes the caller's own `sub` in one
+/// step — "new token, old one expired". The caller must authenticate with an
+/// admin-scoped JWT: the flat `TOKEN_ADMIN_KEY` has no subject to revoke, so
+/// it cannot rotate itself and gets HTTP 400 instead.
+pub async fn rotate_admin_token(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    axum::Json(req): axum::Json<RotateTokenRequest>,
+) -> impl IntoResponse {
+    let Some(bearer) = extract_admin_bearer(&headers) else {
+        return error_response(
+            StatusCode::UNAUTHORIZED,
+            "authentication_error",
+            "admin Bearer token required",
+        );
+    };
+    let Ok(claims) = state.token_manager.validate_admin_token(bearer) else {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_request_error",
+            "rotation requires an admin-scoped token; the flat admin key has no subject to revoke",
+        );
+    };
+
+    let ttl = req.ttl_hours.unwrap_or(24);
+    let label = req.label.unwrap_or_else(|| claims.label.clone());
+    match state
+        .token_manager
+        .rotate_admin_token(&claims.sub, ttl, &label)
+    {
+        Ok(token) => {
+            state.metrics.record_token_issued();
+            state.metrics.record_token_revoked();
+            (
+                StatusCode::OK,
+                axum::Json(serde_json::json!({
+                    "token": token,
+                    "ttl_hours": ttl,
+                    "label": label,
+                    "scope": ADMIN_SCOPE,
+                    "revoked": claims.sub,
+                })),
+            )
+                .into_response()
+        }
+        Err(e) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "api_error",
+            &format!("Failed to rotate admin token: {e}"),
+        ),
+    }
+}
+
 /// Request body for the token issuance endpoint.
 #[derive(serde::Deserialize)]
 pub struct IssueTokenRequest {
@@ -135,6 +201,18 @@ pub struct IssueTokenRequest {
     /// Optional cap on the number of upstream requests the token may make.
     /// `None` (omitted) means unlimited.
     pub max_requests: Option<u64>,
+    /// Privilege scope. Omit (or empty) for an ordinary client token; pass
+    /// `"admin"` to mint a credential that also unlocks the admin endpoints.
+    pub scope: Option<String>,
+}
+
+/// Request body for the admin rotation endpoint. All fields are optional.
+#[derive(serde::Deserialize, Default)]
+pub struct RotateTokenRequest {
+    /// TTL of the replacement token in hours (default: 24).
+    pub ttl_hours: Option<i64>,
+    /// Label for the replacement token; defaults to the current token's label.
+    pub label: Option<String>,
 }
 
 /// Request body for the token revocation endpoint.

--- a/tests/admin_endpoints_test.rs
+++ b/tests/admin_endpoints_test.rs
@@ -1,0 +1,343 @@
+//! End-to-end HTTP coverage of the administrative surface (issue #49).
+//!
+//! The unit tests in `src/admin_auth.rs` pin the authorisation *rule*; this
+//! file pins the thing the issue actually reported — that a real router
+//! process, started with no admin key, answered `200` to an unauthenticated
+//! `POST /api/tokens`. It boots the released binary on a loopback port and
+//! speaks HTTP to it, so nothing about the wiring between the rule and the
+//! routes is assumed.
+//!
+//! Unix only: the harness sends SIGTERM to shut the child down.
+#![cfg(unix)]
+
+use std::io::{BufRead, BufReader};
+use std::net::TcpListener;
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+/// A router process on its own port, killed when the test ends.
+struct Router {
+    child: Child,
+    port: u16,
+    /// The bootstrap admin token the router printed at startup, if any.
+    bootstrap_token: Option<String>,
+    _data_dir: tempfile::TempDir,
+}
+
+impl Drop for Router {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn free_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .expect("should bind an ephemeral port")
+        .local_addr()
+        .expect("should have a local address")
+        .port()
+}
+
+impl Router {
+    fn start(extra_env: &[(&str, &str)]) -> Self {
+        let data_dir = tempfile::tempdir().expect("temp data dir");
+        let port = free_port();
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_link-assistant-router"));
+        cmd.arg("serve")
+            .env("TOKEN_SECRET", "admin-endpoint-test-secret")
+            .env("ROUTER_HOST", "127.0.0.1")
+            .env("ROUTER_PORT", port.to_string())
+            .env("STORAGE_POLICY", "text")
+            .env("DATA_DIR", data_dir.path())
+            // Keep the subscription-less start quiet and self-contained.
+            .env("CLAUDE_CODE_HOME", data_dir.path().join("claude"))
+            .env("DISABLE_LOGIN_API", "true")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null());
+        for (k, v) in extra_env {
+            cmd.env(k, v);
+        }
+        let mut child = cmd.spawn().expect("router should start");
+
+        // Pump stdout on its own thread. With an admin key configured the
+        // router prints no bootstrap token at all, so scanning for the line
+        // inline would block until the process exits — i.e. forever.
+        let stdout = child.stdout.take().expect("piped stdout");
+        let lines = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&lines);
+        std::thread::spawn(move || {
+            for line in BufReader::new(stdout).lines().map_while(Result::ok) {
+                sink.lock().expect("stdout lock").push(line);
+            }
+        });
+
+        let mut router = Self {
+            child,
+            port,
+            bootstrap_token: None,
+            _data_dir: data_dir,
+        };
+        router.await_health();
+        // The banner is printed before the listener binds, so by the time
+        // `/health` answers everything we care about has been captured.
+        router.bootstrap_token = lines
+            .lock()
+            .expect("stdout lock")
+            .iter()
+            .find_map(|line| line.split("store it now): ").nth(1))
+            .map(|token| token.trim().to_string());
+        router
+    }
+
+    fn await_health(&self) {
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while Instant::now() < deadline {
+            if ureq_get(&self.url("/health"), None).is_some() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        panic!("router never became healthy on port {}", self.port);
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("http://127.0.0.1:{}{path}", self.port)
+    }
+}
+
+/// Minimal blocking HTTP helpers — the test only needs a status and a body,
+/// and the crate's `reqwest` is async-only in this context.
+fn ureq_get(url: &str, bearer: Option<&str>) -> Option<(u16, String)> {
+    http_request("GET", url, bearer, None)
+}
+
+fn ureq_post(url: &str, bearer: Option<&str>, body: &str) -> Option<(u16, String)> {
+    http_request("POST", url, bearer, Some(body))
+}
+
+fn http_request(
+    method: &str,
+    url: &str,
+    bearer: Option<&str>,
+    body: Option<&str>,
+) -> Option<(u16, String)> {
+    use std::io::{Read, Write};
+    use std::net::TcpStream;
+
+    let rest = url.strip_prefix("http://")?;
+    let (authority, path) = rest.split_once('/')?;
+    let path = format!("/{path}");
+
+    let mut stream = TcpStream::connect(authority).ok()?;
+    stream
+        .set_read_timeout(Some(Duration::from_secs(10)))
+        .ok()?;
+    let body = body.unwrap_or("");
+    let mut request = format!(
+        "{method} {path} HTTP/1.1\r\nHost: {authority}\r\nConnection: close\r\n\
+         Content-Type: application/json\r\nContent-Length: {}\r\n",
+        body.len()
+    );
+    if let Some(bearer) = bearer {
+        request.push_str("Authorization: Bearer ");
+        request.push_str(bearer);
+        request.push_str("\r\n");
+    }
+    request.push_str("\r\n");
+    request.push_str(body);
+    stream.write_all(request.as_bytes()).ok()?;
+
+    let mut raw = String::new();
+    stream.read_to_string(&mut raw).ok()?;
+    let status = raw.split_whitespace().nth(1)?.parse().ok()?;
+    let body = raw
+        .split_once("\r\n\r\n")
+        .map_or("", |(_, b)| b)
+        .to_string();
+    Some((status, body))
+}
+
+fn token_from(body: &str) -> String {
+    let value: serde_json::Value = serde_json::from_str(strip_chunking(body).as_str())
+        .unwrap_or_else(|e| panic!("response should be JSON ({e}): {body}"));
+    value["token"]
+        .as_str()
+        .unwrap_or_else(|| panic!("response should carry a token: {body}"))
+        .to_string()
+}
+
+/// Responses come back chunked; for these small single-chunk bodies, dropping
+/// the size lines is enough to recover the JSON.
+fn strip_chunking(body: &str) -> String {
+    if body.trim_start().starts_with('{') {
+        return body.trim().to_string();
+    }
+    body.lines()
+        .filter(|line| line.trim_start().starts_with('{'))
+        .collect::<Vec<_>>()
+        .join("")
+}
+
+/// The reproduction from issue #49: with no admin credential configured, a
+/// `POST /api/tokens` carrying no `Authorization` header used to return `200`
+/// and a usable `la_sk_…` token.
+#[test]
+fn unauthenticated_token_issuance_is_refused_by_default() {
+    let router = Router::start(&[]);
+
+    let (status, body) = ureq_post(
+        &router.url("/api/tokens"),
+        None,
+        r#"{"ttl_hours":1,"label":"anyone"}"#,
+    )
+    .expect("router should answer");
+
+    assert_eq!(status, 401, "unexpected body: {body}");
+    assert!(
+        !body.contains("la_sk_"),
+        "no token may be handed to an unauthenticated caller: {body}"
+    );
+
+    let (status, body) = ureq_get(&router.url("/api/tokens/list"), None).expect("should answer");
+    assert_eq!(status, 401, "unexpected body: {body}");
+}
+
+/// The router must stay usable when nothing is configured: it mints an admin
+/// credential at startup and prints it once.
+#[test]
+fn bootstrap_admin_token_is_printed_and_opens_the_admin_surface() {
+    let router = Router::start(&[]);
+    let token = router
+        .bootstrap_token
+        .clone()
+        .expect("the router should print a bootstrap admin token");
+    assert!(token.starts_with("la_sk_"), "unexpected token: {token}");
+
+    let (status, body) =
+        ureq_get(&router.url("/api/tokens/list"), Some(&token)).expect("should answer");
+    assert_eq!(status, 200, "unexpected body: {body}");
+}
+
+/// Authorisation is by scope, not by "any valid token".
+#[test]
+fn client_tokens_cannot_reach_the_admin_surface() {
+    let router = Router::start(&[]);
+    let admin = router.bootstrap_token.clone().expect("bootstrap token");
+
+    let (status, body) = ureq_post(
+        &router.url("/api/tokens"),
+        Some(&admin),
+        r#"{"ttl_hours":1,"label":"task"}"#,
+    )
+    .expect("should answer");
+    assert_eq!(status, 200, "unexpected body: {body}");
+    let client = token_from(&body);
+
+    let (status, body) =
+        ureq_get(&router.url("/api/tokens/list"), Some(&client)).expect("should answer");
+    assert_eq!(
+        status, 401,
+        "a client token must not read the admin surface: {body}"
+    );
+}
+
+/// An admin-scoped token minted over HTTP works, and can rotate itself.
+#[test]
+fn admin_scoped_tokens_are_issuable_and_rotatable_over_http() {
+    let router = Router::start(&[]);
+    let admin = router.bootstrap_token.clone().expect("bootstrap token");
+
+    let (status, body) = ureq_post(
+        &router.url("/api/tokens"),
+        Some(&admin),
+        r#"{"ttl_hours":1,"label":"ops","scope":"admin"}"#,
+    )
+    .expect("should answer");
+    assert_eq!(status, 200, "unexpected body: {body}");
+    let scoped = token_from(&body);
+
+    let (status, body) =
+        ureq_get(&router.url("/api/tokens/list"), Some(&scoped)).expect("should answer");
+    assert_eq!(status, 200, "unexpected body: {body}");
+
+    let (status, body) =
+        ureq_post(&router.url("/api/tokens/rotate"), Some(&scoped), "{}").expect("should answer");
+    assert_eq!(status, 200, "unexpected body: {body}");
+    let replacement = token_from(&body);
+    assert_ne!(replacement, scoped);
+
+    // The rotated-away credential is revoked; its replacement works.
+    let (status, _) =
+        ureq_get(&router.url("/api/tokens/list"), Some(&scoped)).expect("should answer");
+    assert_eq!(status, 401, "the rotated-away token must stop working");
+    let (status, _) =
+        ureq_get(&router.url("/api/tokens/list"), Some(&replacement)).expect("should answer");
+    assert_eq!(status, 200);
+}
+
+/// An unknown scope is a client error, not a silently-ignored field.
+#[test]
+fn an_unknown_scope_is_rejected() {
+    let router = Router::start(&[]);
+    let admin = router.bootstrap_token.clone().expect("bootstrap token");
+
+    let (status, body) = ureq_post(
+        &router.url("/api/tokens"),
+        Some(&admin),
+        r#"{"ttl_hours":1,"label":"x","scope":"root"}"#,
+    )
+    .expect("should answer");
+    assert_eq!(status, 400, "unexpected body: {body}");
+}
+
+/// The flat `TOKEN_ADMIN_KEY` keeps working unchanged as a bootstrap
+/// credential, and suppresses the generated one.
+#[test]
+fn the_flat_admin_key_still_authorises() {
+    let router = Router::start(&[("TOKEN_ADMIN_KEY", "s3cret-bootstrap-key")]);
+    assert!(
+        router.bootstrap_token.is_none(),
+        "a configured admin key must not trigger token generation"
+    );
+
+    let (status, _) = ureq_get(&router.url("/api/tokens/list"), None).expect("should answer");
+    assert_eq!(status, 401);
+
+    let (status, _) =
+        ureq_get(&router.url("/api/tokens/list"), Some("wrong-key")).expect("should answer");
+    assert_eq!(status, 401);
+
+    let (status, body) = ureq_get(
+        &router.url("/api/tokens/list"),
+        Some("s3cret-bootstrap-key"),
+    )
+    .expect("should answer");
+    assert_eq!(status, 200, "unexpected body: {body}");
+}
+
+/// The historical open behaviour is still reachable, but only on purpose.
+#[test]
+fn allow_anonymous_admin_restores_the_open_surface() {
+    let router = Router::start(&[("ALLOW_ANONYMOUS_ADMIN", "1")]);
+
+    let (status, body) = ureq_post(
+        &router.url("/api/tokens"),
+        None,
+        r#"{"ttl_hours":1,"label":"anyone"}"#,
+    )
+    .expect("should answer");
+    assert_eq!(status, 200, "unexpected body: {body}");
+    assert!(token_from(&body).starts_with("la_sk_"));
+}
+
+/// Guards the assumption that the binary under test is the one built from this
+/// working tree (a stale `PATH` binary would make every assertion above lie).
+#[test]
+fn the_binary_under_test_comes_from_this_workspace() {
+    let bin = PathBuf::from(env!("CARGO_BIN_EXE_link-assistant-router"));
+    assert!(bin.exists(), "{} should exist", bin.display());
+    assert!(bin.starts_with(env!("CARGO_MANIFEST_DIR")));
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -375,6 +375,7 @@ mod config_verbose_tests {
             account_request_limits: vec![],
             experimental_compatibility: false,
             admin_key: None,
+            allow_anonymous_admin: false,
             mpp: link_assistant_router::config::default_mpp_config(),
             login: link_assistant_router::login::LoginConfig::default(),
         }


### PR DESCRIPTION
Closes #49.

## The problem

`is_admin_authorised` in `src/proxy.rs` did two things wrong:

1. It compared `TOKEN_ADMIN_KEY` with `==` — a flat, short-circuiting secret with no identity, expiry, scope, revocation or rotation.
2. When `TOKEN_ADMIN_KEY` was unset it returned `true`, so `/api/tokens*` was **unauthenticated by default**.

Reproduction (before this PR): start the router with no `TOKEN_ADMIN_KEY` and `POST /api/tokens` with no `Authorization` header → `200` plus a usable `la_sk_…` token.

## The fix

Admin access is now a **scoped JWT on the existing `TokenManager` path**, so it inherits expiry, revocation, identity and rotation:

- `TokenClaims`/`TokenRecord` carry a `scope`; `ADMIN_SCOPE = "admin"`. Client tokens carry no scope and are rejected on the admin surface.
- `TokenManager::issue_admin_token`, `validate_admin_token`, `has_active_admin_token`, `rotate_admin_token` (issue replacement + revoke the old `sub` in one step; an unknown id is an error, not a silent no-op).
- `tokens issue --admin`, new `tokens rotate <id>`, a `scope` column in `tokens list`, and `POST /api/tokens {"scope":"admin"}` / `POST /api/tokens/rotate` over HTTP. An unknown scope is a `400`.
- The flat `TOKEN_ADMIN_KEY` keeps working unchanged as a bootstrap credential, now compared in constant time (SHA-256 both sides, XOR fold — the crate forbids `unsafe_code`).

**The default is closed**, implementing both options the issue listed:

- On first start with no credential configured, the router mints an admin token, prints it once, and persists only its record — admin endpoints stay closed.
- Anonymous admin access now requires an explicit opt-out: `--allow-anonymous-admin` / `ALLOW_ANONYMOUS_ADMIN=1`. `doctor` reports `admin_endpoints : OPEN (--allow-anonymous-admin)` when it is set.

The decision itself lives in a new `src/admin_auth.rs` as a pure function over `(manager, provided, admin_key, allow_anonymous)`, so it is testable without an `AppState`; `proxy.rs` is a thin wrapper over it.

## Tests

- `src/admin_auth.rs` — 8 unit tests pinning the rule, including the issue's reproduction (`unauthenticated_request_is_refused_when_no_credential_is_configured`), revoked/expired admin tokens, client-token rejection, and the flat-key path.
- `tests/admin_endpoints_test.rs` (new, unix) — 8 end-to-end tests that boot the real binary on a loopback port and speak HTTP: anonymous `POST /api/tokens` → `401`, the bootstrap token is printed and works, client tokens are refused, admin tokens are issuable and rotatable, unknown scope → `400`, the flat key still authorises, and `ALLOW_ANONYMOUS_ADMIN=1` restores the old open surface.
- `src/token.rs` / `src/storage.rs` — scope round-trips through the text and binary stores; rotation issues a replacement, revokes the old id, and rejects an unknown subject.
- `experiments/issue-45/test-deployment-hardening.sh` — rewritten to assert the closed default against a container: **18 passed, 0 failed** (was 16, and it previously asserted the open behaviour).

`cargo fmt`, `cargo clippy --all-targets --all-features` (clean), and the file-size budget all pass. Full suite: 279 passed.

## Notes

- No `Cargo.toml` version bump — manual bumps are blocked by the `version-check` job; `changelog.d/20260807_190000_issue_49_scoped_admin_tokens.md` carries `bump: minor`.
- `tests/release_workflow_test.rs::dockerfile_offers_a_claude_cli_variant_without_bloating_the_default_image` was failing here **and on a clean `main`**: issue #47's PR duplicated the `nodejs` + `@anthropic-ai/claude-code` install into the `runtime-base` stage that issue #48's test asserts stays minimal — the identical install already exists in the `with-claude-cli` stage layered directly on top, so every default `docker build .` shipped the CLI twice over and `:latest` stopped being the minimal image. Fixed here (`fe23013`) by dropping it from the base stage and pointing `docs/use-cases/remote-login.md` at the `with-claude-cli` variant, since CI stays red otherwise.
