### PR TITLE
feat: use full-scope TUI login by default

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-08T23:19:40.014Z for PR creation at branch issue-65-24a81d950668 for issue https://github.com/link-assistant/router/issues/65

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-08T23:19:40.014Z for PR creation at branch issue-65-24a81d950668 for issue https://github.com/link-assistant/router/issues/65

--- a/README.md
+++ b/README.md
@@ -308,7 +308,10 @@ Claude Code will work exactly as normal, with all requests transparently proxied
 ### Login surface (`--disable-login-api` to opt out)
 
 Authorizes a deployment that has no credential file — see
-[docs/use-cases/remote-login.md](docs/use-cases/remote-login.md).
+[docs/use-cases/remote-login.md](docs/use-cases/remote-login.md). By default it
+drives the TUI `/login` flow, which requests Claude Code's full scope set;
+`LOGIN_CLI_ARGS=setup-token` explicitly selects the narrower `user:inference`
+flow. The use-case guide lists every requested scope.
 
 | Endpoint | Method | Description |
 |---|---|---|
@@ -661,7 +664,7 @@ The HTTP API accepts the same shape at `POST /api/providers`:
 | `--disable-metrics` / `DISABLE_METRICS` | off | Hide `/metrics`, `/v1/usage`, `/v1/accounts` |
 | `--disable-login-api` / `DISABLE_LOGIN_API` | off | Hide `/api/login*` |
 | `--login-cli-command` / `LOGIN_CLI_COMMAND` | `claude` | Program `/api/login` drives on a PTY |
-| `--login-cli-args` / `LOGIN_CLI_ARGS` | `setup-token` | Comma-separated arguments for that program |
+| `--login-cli-args` / `LOGIN_CLI_ARGS` | (none; TUI `/login`) | Comma-separated arguments for that program; set `setup-token` for the narrow-scope alternative |
 | `--login-session-ttl-secs` / `LOGIN_SESSION_TTL_SECS` | `900` | How long a pending login waits for its code before expiring |
 | `--login-max-sessions` / `LOGIN_MAX_SESSIONS` | `4` | Maximum simultaneously pending logins; beyond it, `429` |
 | `--experimental-compatibility` / `EXPERIMENTAL_COMPATIBILITY` | off | XML history, model spoofing and other community-proxy behaviours |
@@ -746,7 +749,7 @@ The default image intentionally contains no Claude CLI. What it can and cannot d
 | Serve requests with a valid access token | No | `:ro` |
 | Renew an **expired** access token | No — the router exchanges the `refreshToken` itself | `:ro` |
 | **First-time login** (no credential file yet) | Yes | writable |
-| `POST /api/login` (remote login over HTTP) | Yes — it drives `claude setup-token` | writable |
+| `POST /api/login` (remote login over HTTP) | Yes — it drives the TUI `/login` flow by default | writable |
 
 Renewal happens in memory: the router exchanges the `refreshToken` stored in the mounted credential file against Anthropic's token endpoint and keeps the result in RAM. The credential file is never written to, which is why `:ro` keeps working across expiry — and why a restarted container refreshes again from the same file. The same mechanism already covers Codex, Gemini, and Qwen.
 

--- a/changelog.d/20260808_233000_issue_65_tui_login.md
+++ b/changelog.d/20260808_233000_issue_65_tui_login.md
@@ -1,0 +1,16 @@
+---
+bump: minor
+---
+
+### Changed
+
+- `POST /api/login` now defaults to Claude Code's TUI `/login` flow and its
+  full OAuth scope set. The PTY driver recognizes first-run theme and workspace
+  trust screens, waits for the prompt before typing `/login`, and selects the
+  Claude subscription method without sending blind input to unknown screens.
+
+### Documentation
+
+- Document all scopes requested by TUI `/login` and by the narrower,
+  long-lived `setup-token` alternative. Operators can retain the latter with
+  `LOGIN_CLI_ARGS=setup-token` or `--login-cli-args setup-token`.

--- a/docs/use-cases/remote-login.md
+++ b/docs/use-cases/remote-login.md
@@ -44,7 +44,7 @@ $ curl -s -X POST http://localhost:8080/api/login \
 {
   "login_id": "3f2b…",
   "status": "awaiting_code",
-  "url": "https://claude.ai/oauth/authorize?code=true&state=…",
+  "url": "https://claude.com/cai/oauth/authorize?code=true&state=…",
   "session_expires_at": "2026-08-07T12:15:00Z"
 }
 ```
@@ -67,7 +67,7 @@ Polling is available for clients that would rather not block:
 
 ```console
 $ curl -s http://localhost:8080/api/login/3f2b… -H "Authorization: Bearer $ADMIN"
-{"login_id":"3f2b…","status":"awaiting_code","url":"https://claude.ai/…", …}
+{"login_id":"3f2b…","status":"awaiting_code","url":"https://claude.com/…", …}
 ```
 
 ## Statuses
@@ -111,13 +111,35 @@ link-assistant-router --disable-login-api    # or DISABLE_LOGIN_API=1
 With it disabled the routes are not registered at all, and requests to them are
 `404`.
 
+## Choosing the login mode
+
+The default is Claude Code's own TUI `/login` flow. The router starts bare
+`claude`, recognizes and accepts the first-run theme and workspace-trust
+screens, waits for the real prompt before typing `/login`, and selects the
+Claude subscription login method. It does not type into unknown wizard screens:
+if Claude Code changes onboarding, the request fails with the last recognized
+output instead of guessing.
+
+`setup-token` remains available by setting `LOGIN_CLI_ARGS=setup-token` or
+passing `--login-cli-args setup-token`.
+
+| Mode | How to select it | OAuth scopes requested |
+| --- | --- | --- |
+| TUI `/login` (default) | Leave `LOGIN_CLI_ARGS` unset or empty | `org:create_api_key`, `user:profile`, `user:inference`, `user:sessions:claude_code`, `user:mcp_servers`, `user:file_upload` |
+| `setup-token` | `LOGIN_CLI_ARGS=setup-token` | `user:inference` |
+
+Use the default when the deployment should receive the same credential Claude
+Code produces interactively. Choose `setup-token` explicitly when the narrower,
+long-lived credential intended for non-interactive consumers is preferable.
+
 ## Requirements
 
-* **The CLI must exist in the image.** The flow drives `claude setup-token` by
-  default, so in Docker use the `with-claude-cli` image variant — it ships the
-  Claude Code CLI and Node for exactly this reason, while the default image
-  stays minimal for mounted-credential deployments. Point it elsewhere with
-  `--login-cli-command` / `--login-cli-args` if you drive something else.
+* **The CLI must exist in the image.** The default flow drives the Claude Code
+  TUI and its `/login` command, so in Docker use the `with-claude-cli` image
+  variant — it ships the Claude Code CLI and Node for exactly this reason,
+  while the default image stays minimal for mounted-credential deployments.
+  Point it elsewhere with `--login-cli-command` / `--login-cli-args` if you
+  drive something else.
 * **`CLAUDE_CODE_HOME` must be writable.** This is checked *before* the URL is
   returned, so a read-only mount fails immediately rather than after the human
   has already finished the browser step.
@@ -125,10 +147,12 @@ With it disabled the routes are not registered at all, and requests to them are
 ## What is tested
 
 `tests/login_flow_test.rs` drives the whole flow against
-`examples/fake-login-cli.sh`, a stand-in for `claude setup-token` that repaints
-like the real TUI, waits on stdin, and prints an `sk-ant-oat…` token. It
-asserts that the URL is recovered, that a *separate* later call reaches the same
-live process, that the resulting credential is readable by
-`OAuthProvider` (the component that actually serves upstream requests), and that
-rejection, double submission, cancellation, expiry and the concurrency cap each
-behave as described above.
+`examples/fake-login-cli.sh`, a stand-in for both the TUI `/login` flow and
+`claude setup-token`. It reproduces the first-run screens, prompt readiness,
+login-method selection and repainting URL, then waits on stdin. The tests assert
+that the full-scope default URL is recovered, that a *separate* later call
+reaches the same live process, that the resulting credential is readable by
+`OAuthProvider` (the component that actually serves upstream requests), that
+`setup-token` remains selectable with its narrower scope, and that rejection,
+double submission, cancellation, expiry and the concurrency cap each behave as
+described above.

--- a/examples/fake-login-cli.sh
+++ b/examples/fake-login-cli.sh
@@ -1,19 +1,51 @@
 #!/usr/bin/env bash
-# A stand-in for `claude setup-token` used by the login-flow tests and by
-# anyone who wants to exercise `POST /api/login` without a real Anthropic
-# account.
+# A stand-in for the Claude Code login flows used by the login-flow tests and
+# by anyone who wants to exercise `POST /api/login` without a real Anthropic
+# account. With no arguments it behaves like the TUI `/login` flow; with
+# `setup-token` it behaves like that explicit alternative.
 #
 # It behaves like the real TUI in the ways the router depends on:
+#   * a fresh TUI presents the theme and workspace-trust screens,
+#   * the TUI waits until `/login` is entered and a login method is selected,
 #   * it repaints, printing the authorization URL more than once,
 #   * it hard-wraps nothing itself and relies on the terminal,
 #   * it waits on stdin for the code the human pastes,
-#   * it prints a `sk-ant-oat…` token on success and exits 0,
+#   * the TUI writes `.credentials.json`, while `setup-token` prints a token,
 #   * it prints `Invalid code` and exits 1 when the code is rejected.
 #
 # The accepted code is `$FAKE_LOGIN_EXPECTED_CODE` (default: `good-code`).
 set -u
 expected="${FAKE_LOGIN_EXPECTED_CODE:-good-code}"
-url="https://claude.ai/oauth/authorize?code=true&state=fake-$$&scope=user%3Ainference"
+mode="${1:-tui}"
+
+if [ "$mode" = "setup-token" ]; then
+  url="https://claude.ai/oauth/authorize?code=true&state=fake-$$&scope=user%3Ainference"
+elif [ "$mode" = "tui" ]; then
+  url="https://claude.com/cai/oauth/authorize?code=true&state=fake-$$&scope=org%3Acreate_api_key+user%3Aprofile+user%3Ainference+user%3Asessions%3Aclaude_code+user%3Amcp_servers+user%3Afile_upload"
+
+  printf "Choose the text style that looks best with your terminal\r\n"
+  printf "To change this later, run /theme\r\n"
+  IFS= read -r theme
+  [ "${theme%$'\r'}" = "" ] || exit 2
+
+  printf "Quick safety check: Is this a project you created or one you trust?\r\n"
+  printf "1. Yes, I trust this folder\r\n"
+  IFS= read -r trust
+  [ "${trust%$'\r'}" = "" ] || exit 2
+
+  printf "Tips for getting started\r\n"
+  printf "Not logged in · Run /login\r\n"
+  IFS= read -r command
+  [ "${command%$'\r'}" = "/login" ] || exit 2
+
+  printf "Select login method:\r\n"
+  printf "1. Claude account with subscription\r\n"
+  IFS= read -r login_method
+  [ "${login_method%$'\r'}" = "" ] || exit 2
+else
+  printf "unsupported fake login mode: %s\r\n" "$mode"
+  exit 2
+fi
 
 printf '\033[2J\033[H'
 printf '\033[1mClaude Code login\033[0m\r\n'
@@ -30,7 +62,11 @@ code="${code%$'\r'}"
 
 if [ "$code" = "$expected" ]; then
   printf '\r\nLogin successful.\r\n'
-  printf 'sk-ant-oat01-FAKE%s\r\n' "0123456789abcdef"
+  if [ "$mode" = "setup-token" ]; then
+    printf 'sk-ant-oat01-FAKE%s\r\n' "0123456789abcdef"
+  else
+    printf '{"claudeAiOauth":{"accessToken":"sk-ant-oat01-FAKE0123456789abcdef","refreshToken":"sk-ant-ort01-FAKE","expiresAt":4102444800000}}\n' > "$CLAUDE_CONFIG_DIR/.credentials.json"
+  fi
   exit 0
 fi
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -398,13 +398,7 @@ pub struct Cli {
     pub login_cli_command: String,
 
     /// Arguments passed to the login program.
-    #[arg(
-        long,
-        env = "LOGIN_CLI_ARGS",
-        value_delimiter = ',',
-        default_value = "setup-token",
-        global = true
-    )]
+    #[arg(long, env = "LOGIN_CLI_ARGS", value_delimiter = ',', global = true)]
     pub login_cli_args: Vec<String>,
 
     /// How long a pending login stays valid while waiting for the human.
@@ -661,6 +655,12 @@ mod tests {
     };
 
     #[test]
+    fn login_cli_defaults_to_bare_tui() {
+        let cli = Cli::try_parse_from(["link-assistant-router"]).unwrap();
+        assert!(cli.login_cli_args.is_empty());
+    }
+
+    #[test]
     fn cli_defaults_round_trip_to_config() {
         let cli = Cli {
             command: None,
@@ -720,7 +720,7 @@ mod tests {
             mpp_method: None,
             disable_login_api: false,
             login_cli_command: "claude".into(),
-            login_cli_args: vec!["setup-token".into()],
+            login_cli_args: vec![],
             login_session_ttl_secs: 900,
             login_max_sessions: 4,
         };
@@ -793,7 +793,7 @@ mod tests {
             mpp_method: None,
             disable_login_api: false,
             login_cli_command: "claude".into(),
-            login_cli_args: vec!["setup-token".into()],
+            login_cli_args: vec![],
             login_session_ttl_secs: 900,
             login_max_sessions: 4,
         };

--- a/src/config.rs
+++ b/src/config.rs
@@ -381,7 +381,7 @@ impl Config {
             args: env::var("LOGIN_CLI_ARGS")
                 .ok()
                 .filter(|raw| !raw.trim().is_empty())
-                .map_or_else(|| vec!["setup-token".to_string()], |raw| parse_csv(&raw)),
+                .map_or_else(Vec::new, |raw| parse_csv(&raw)),
             session_ttl: Duration::from_secs(parse_u64_env("LOGIN_SESSION_TTL_SECS", 900)),
             max_sessions: usize::try_from(parse_u64_env("LOGIN_MAX_SESSIONS", 4)).unwrap_or(4),
             ..crate::login::LoginConfig::default()

--- a/src/login.rs
+++ b/src/login.rs
@@ -33,7 +33,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc};
 use portable_pty::CommandBuilder;
@@ -57,6 +57,16 @@ const FAILURE_MARKERS: &[&str] = &[
     "Login failed",
 ];
 
+/// Stable text on the first-run screens that block the Claude Code prompt.
+///
+/// Each marker names the screen whose currently selected safe/default action
+/// is accepted with Enter. Unknown screens are deliberately left untouched so
+/// a changed onboarding flow times out loudly instead of receiving blind input.
+const THEME_PICKER_MARKER: &str = "Choosethetextstylethatlooksbestwithyourterminal";
+const WORKSPACE_TRUST_MARKER: &str = "Quicksafetycheck:Isthisaprojectyoucreated";
+const LOGIN_METHOD_MARKER: &str = "Selectloginmethod:";
+const READY_PROMPT_MARKER: &str = "Tipsforgettingstarted";
+
 /// Settings for the login flow.
 #[derive(Clone, Debug)]
 pub struct LoginConfig {
@@ -64,7 +74,8 @@ pub struct LoginConfig {
     pub enabled: bool,
     /// Program to drive, e.g. `claude`.
     pub command: String,
-    /// Arguments passed to that program, e.g. `["setup-token"]`.
+    /// Arguments passed to that program. Empty selects the default TUI
+    /// `/login` flow; `["setup-token"]` selects the narrow-scope alternative.
     pub args: Vec<String>,
     /// Directory the resulting credential must land in. This is the same
     /// directory [`crate::oauth::OAuthProvider`] reads.
@@ -87,7 +98,7 @@ impl Default for LoginConfig {
         Self {
             enabled: true,
             command: "claude".to_string(),
-            args: vec!["setup-token".to_string()],
+            args: vec![],
             claude_code_home: PathBuf::from("/data/claude"),
             session_ttl: Duration::from_secs(900),
             max_sessions: 4,
@@ -463,27 +474,140 @@ fn spawn_and_wait_for_url(config: &LoginConfig) -> Result<(Arc<PtySession>, Stri
 
     let session =
         Arc::new(PtySession::spawn(command).map_err(|e| LoginError::Spawn(e.to_string()))?);
-    match session.wait_for(
-        |text| extract_login_url(text).is_some(),
-        config.idle_settle,
-        config.url_timeout,
-    ) {
-        Ok(text) => {
-            let url = extract_login_url(&text)
-                .ok_or_else(|| LoginError::NoUrl(session.transcript_tail(400)))?;
-            Ok((session, url))
-        }
-        Err(err) => {
-            let detail = match err {
-                WaitError::Timeout => {
-                    format!("timed out; last output: {}", session.transcript_tail(400))
-                }
-                WaitError::ChildExited(_) => {
-                    format!("{err}; last output: {}", session.transcript_tail(400))
-                }
-            };
+    let result = if config.args.is_empty() {
+        drive_tui_to_login_url(&session, config)
+    } else {
+        wait_for_login_url(&session, config)
+    };
+    match result {
+        Ok(url) => Ok((session, url)),
+        Err(detail) => {
             session.kill();
             Err(LoginError::NoUrl(detail))
+        }
+    }
+}
+
+/// Progress through the known TUI screens without re-reacting to old text in
+/// the append-only PTY transcript.
+#[derive(Default)]
+struct TuiProgress {
+    theme_accepted: bool,
+    trust_accepted: bool,
+    login_sent: bool,
+    method_selected: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TuiAction {
+    AcceptTheme,
+    AcceptWorkspaceTrust,
+    SendLogin,
+    SelectLoginMethod,
+}
+
+fn next_tui_action(text: &str, progress: &TuiProgress) -> Option<TuiAction> {
+    // Ink-based TUIs position words with cursor escapes instead of printing
+    // literal spaces. `strip_ansi` intentionally removes those escapes, so a
+    // rendered "Select login method:" may arrive as "Selectloginmethod:".
+    let compact: String = text.chars().filter(|ch| !ch.is_whitespace()).collect();
+    if !progress.theme_accepted && compact.contains(THEME_PICKER_MARKER) {
+        Some(TuiAction::AcceptTheme)
+    } else if !progress.trust_accepted && compact.contains(WORKSPACE_TRUST_MARKER) {
+        Some(TuiAction::AcceptWorkspaceTrust)
+    } else if !progress.login_sent && compact.contains(READY_PROMPT_MARKER) {
+        Some(TuiAction::SendLogin)
+    } else if !progress.method_selected && compact.contains(LOGIN_METHOD_MARKER) {
+        Some(TuiAction::SelectLoginMethod)
+    } else {
+        None
+    }
+}
+
+/// Drive bare `claude` to the full-scope OAuth URL exposed by its `/login`
+/// command. The one timeout covers the whole startup sequence, not each screen.
+fn drive_tui_to_login_url(session: &PtySession, config: &LoginConfig) -> Result<String, String> {
+    let deadline = Instant::now() + config.url_timeout;
+    let mut progress = TuiProgress::default();
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Err(format!(
+                "timed out; last output: {}",
+                session.transcript_tail(400)
+            ));
+        }
+        let text = session
+            .wait_for(
+                |text| {
+                    extract_login_url(text).is_some() || next_tui_action(text, &progress).is_some()
+                },
+                config.idle_settle,
+                remaining,
+            )
+            .map_err(|err| wait_error_detail(session, &err))?;
+        if let Some(url) = extract_login_url(&text) {
+            return Ok(url);
+        }
+        match next_tui_action(&text, &progress) {
+            Some(TuiAction::AcceptTheme) => {
+                session
+                    .send_key(Key::Enter)
+                    .map_err(|e| format!("could not accept the Claude Code theme screen: {e}"))?;
+                progress.theme_accepted = true;
+            }
+            Some(TuiAction::AcceptWorkspaceTrust) => {
+                session.send_key(Key::Enter).map_err(|e| {
+                    format!("could not accept the Claude Code workspace trust screen: {e}")
+                })?;
+                progress.trust_accepted = true;
+            }
+            Some(TuiAction::SendLogin) => {
+                session
+                    .send_text("/login")
+                    .and_then(|()| session.send_key(Key::Enter))
+                    .map_err(|e| format!("could not type /login at the Claude Code prompt: {e}"))?;
+                progress.login_sent = true;
+            }
+            Some(TuiAction::SelectLoginMethod) => {
+                session.send_key(Key::Enter).map_err(|e| {
+                    format!("could not select the Claude subscription login method: {e}")
+                })?;
+                progress.method_selected = true;
+            }
+            None => {
+                return Err(format!(
+                    "Claude Code reached an unrecognized screen; last output: {}",
+                    session.transcript_tail(400)
+                ));
+            }
+        }
+    }
+}
+
+/// Preserve the existing custom-argument behaviour: wait for whichever login
+/// URL the configured command prints without sending TUI input first.
+fn wait_for_login_url(session: &PtySession, config: &LoginConfig) -> Result<String, String> {
+    let text = session
+        .wait_for(
+            |text| extract_login_url(text).is_some(),
+            config.idle_settle,
+            config.url_timeout,
+        )
+        .map_err(|err| wait_error_detail(session, &err))?;
+    extract_login_url(&text).ok_or_else(|| {
+        format!(
+            "authorization URL disappeared; last output: {}",
+            session.transcript_tail(400)
+        )
+    })
+}
+
+fn wait_error_detail(session: &PtySession, err: &WaitError) -> String {
+    match err {
+        WaitError::Timeout => format!("timed out; last output: {}", session.transcript_tail(400)),
+        WaitError::ChildExited(_) => {
+            format!("{err}; last output: {}", session.transcript_tail(400))
         }
     }
 }
@@ -628,6 +752,27 @@ fn tail(text: &str, limit: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn tui_only_types_into_recognized_screens() {
+        let progress = TuiProgress::default();
+        let rendered_theme = crate::login_pty::strip_ansi(
+            "Choose\x1b[9Gthe\x1b[13Gtext\x1b[18Gstyle\x1b[24Gthat\x1b[29Glooks\x1b[35Gbest\x1b[40Gwith\x1b[45Gyour\x1b[50Gterminal",
+        );
+        assert_eq!(
+            next_tui_action(&rendered_theme, &progress),
+            Some(TuiAction::AcceptTheme)
+        );
+        assert_eq!(
+            next_tui_action("A future, unknown onboarding screen", &progress),
+            None
+        );
+    }
+
+    #[test]
+    fn login_config_defaults_to_bare_tui() {
+        assert!(LoginConfig::default().args.is_empty());
+    }
 
     /// Build a session that already reached `status`, settled `age` ago.
     fn settled_session(id: &str, status: LoginStatus, age: chrono::Duration) -> Arc<Session> {

--- a/src/login.rs
+++ b/src/login.rs
@@ -492,10 +492,17 @@ fn spawn_and_wait_for_url(config: &LoginConfig) -> Result<(Arc<PtySession>, Stri
 /// the append-only PTY transcript.
 #[derive(Default)]
 struct TuiProgress {
-    theme_accepted: bool,
-    trust_accepted: bool,
-    login_sent: bool,
-    method_selected: bool,
+    completed: Vec<TuiAction>,
+}
+
+impl TuiProgress {
+    fn needs(&self, action: TuiAction) -> bool {
+        !self.completed.contains(&action)
+    }
+
+    fn complete(&mut self, action: TuiAction) {
+        self.completed.push(action);
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -511,13 +518,16 @@ fn next_tui_action(text: &str, progress: &TuiProgress) -> Option<TuiAction> {
     // literal spaces. `strip_ansi` intentionally removes those escapes, so a
     // rendered "Select login method:" may arrive as "Selectloginmethod:".
     let compact: String = text.chars().filter(|ch| !ch.is_whitespace()).collect();
-    if !progress.theme_accepted && compact.contains(THEME_PICKER_MARKER) {
+    if progress.needs(TuiAction::AcceptTheme) && compact.contains(THEME_PICKER_MARKER) {
         Some(TuiAction::AcceptTheme)
-    } else if !progress.trust_accepted && compact.contains(WORKSPACE_TRUST_MARKER) {
+    } else if progress.needs(TuiAction::AcceptWorkspaceTrust)
+        && compact.contains(WORKSPACE_TRUST_MARKER)
+    {
         Some(TuiAction::AcceptWorkspaceTrust)
-    } else if !progress.login_sent && compact.contains(READY_PROMPT_MARKER) {
+    } else if progress.needs(TuiAction::SendLogin) && compact.contains(READY_PROMPT_MARKER) {
         Some(TuiAction::SendLogin)
-    } else if !progress.method_selected && compact.contains(LOGIN_METHOD_MARKER) {
+    } else if progress.needs(TuiAction::SelectLoginMethod) && compact.contains(LOGIN_METHOD_MARKER)
+    {
         Some(TuiAction::SelectLoginMethod)
     } else {
         None
@@ -549,31 +559,28 @@ fn drive_tui_to_login_url(session: &PtySession, config: &LoginConfig) -> Result<
         if let Some(url) = extract_login_url(&text) {
             return Ok(url);
         }
-        match next_tui_action(&text, &progress) {
+        let action = next_tui_action(&text, &progress);
+        match action {
             Some(TuiAction::AcceptTheme) => {
                 session
                     .send_key(Key::Enter)
                     .map_err(|e| format!("could not accept the Claude Code theme screen: {e}"))?;
-                progress.theme_accepted = true;
             }
             Some(TuiAction::AcceptWorkspaceTrust) => {
                 session.send_key(Key::Enter).map_err(|e| {
                     format!("could not accept the Claude Code workspace trust screen: {e}")
                 })?;
-                progress.trust_accepted = true;
             }
             Some(TuiAction::SendLogin) => {
                 session
                     .send_text("/login")
                     .and_then(|()| session.send_key(Key::Enter))
                     .map_err(|e| format!("could not type /login at the Claude Code prompt: {e}"))?;
-                progress.login_sent = true;
             }
             Some(TuiAction::SelectLoginMethod) => {
                 session.send_key(Key::Enter).map_err(|e| {
                     format!("could not select the Claude subscription login method: {e}")
                 })?;
-                progress.method_selected = true;
             }
             None => {
                 return Err(format!(
@@ -581,6 +588,9 @@ fn drive_tui_to_login_url(session: &PtySession, config: &LoginConfig) -> Result<
                     session.transcript_tail(400)
                 ));
             }
+        }
+        if let Some(action) = action {
+            progress.complete(action);
         }
     }
 }

--- a/tests/login_flow_test.rs
+++ b/tests/login_flow_test.rs
@@ -1,9 +1,10 @@
 //! End-to-end tests of the interactive login flow (issue #47).
 //!
 //! These drive [`LoginManager`] against `examples/fake-login-cli.sh`, a stand-in
-//! for `claude setup-token` that behaves like the real TUI in the ways the flow
-//! depends on: it repaints, it prints the authorization URL, it waits on stdin
-//! for a code, and it prints a `sk-ant-oat…` token on success.
+//! for both the default TUI `/login` flow and the explicit `setup-token`
+//! alternative. The default path includes the first-run theme and trust
+//! screens, waits for `/login`, repaints its authorization URL, waits on stdin
+//! for a code, and writes the same credential shape as the real TUI.
 //!
 //! The point of the test is the part that is easy to get wrong: the process
 //! spawned by the first request must still be alive when a *separate* later
@@ -46,6 +47,17 @@ fn manager_with(home: &Path) -> LoginManager {
     })
 }
 
+fn setup_token_manager_with(home: &Path) -> LoginManager {
+    LoginManager::new(LoginConfig {
+        command: fake_cli(),
+        args: vec!["setup-token".to_string()],
+        claude_code_home: home.to_path_buf(),
+        url_timeout: Duration::from_secs(20),
+        code_timeout: Duration::from_secs(20),
+        ..LoginConfig::default()
+    })
+}
+
 #[tokio::test]
 async fn login_produces_a_url_then_a_usable_credential() {
     let home = temp_home();
@@ -55,9 +67,19 @@ async fn login_produces_a_url_then_a_usable_credential() {
     assert_eq!(begun.status, LoginStatus::AwaitingCode);
     let url = begun.url.as_deref().expect("a URL must be reported");
     assert!(
-        url.starts_with("https://claude.ai/oauth/authorize?"),
+        url.starts_with("https://claude.com/cai/oauth/authorize?"),
         "unexpected URL: {url}"
     );
+    for scope in [
+        "org%3Acreate_api_key",
+        "user%3Aprofile",
+        "user%3Ainference",
+        "user%3Asessions%3Aclaude_code",
+        "user%3Amcp_servers",
+        "user%3Afile_upload",
+    ] {
+        assert!(url.contains(scope), "default login URL lacks {scope}: {url}");
+    }
 
     // The session survives between requests: status is served from the registry
     // while the process is still parked on its stdin read.
@@ -83,6 +105,29 @@ async fn login_produces_a_url_then_a_usable_credential() {
 
     // A finished session is cleaned up: it no longer counts against the cap.
     assert_eq!(manager.pending_count(), 0);
+}
+
+#[tokio::test]
+async fn setup_token_remains_an_explicit_alternative() {
+    let home = temp_home();
+    let manager = setup_token_manager_with(&home);
+
+    let begun = manager.begin().await.expect("setup-token should start");
+    let url = begun.url.as_deref().expect("a URL must be reported");
+    assert!(url.contains("scope=user%3Ainference"), "unexpected URL: {url}");
+    assert!(!url.contains("user%3Aprofile"), "unexpected URL: {url}");
+
+    let done = manager
+        .submit_code(&begun.login_id, "good-code")
+        .await
+        .expect("code should be accepted");
+    assert_eq!(done.status, LoginStatus::Authorized);
+    assert!(
+        OAuthProvider::new(home.to_str().unwrap())
+            .get_token()
+            .expect("the synthesized credential must be readable")
+            .starts_with("sk-ant-oat")
+    );
 }
 
 #[tokio::test]

--- a/tests/login_flow_test.rs
+++ b/tests/login_flow_test.rs
@@ -78,7 +78,10 @@ async fn login_produces_a_url_then_a_usable_credential() {
         "user%3Amcp_servers",
         "user%3Afile_upload",
     ] {
-        assert!(url.contains(scope), "default login URL lacks {scope}: {url}");
+        assert!(
+            url.contains(scope),
+            "default login URL lacks {scope}: {url}"
+        );
     }
 
     // The session survives between requests: status is served from the registry
@@ -114,7 +117,10 @@ async fn setup_token_remains_an_explicit_alternative() {
 
     let begun = manager.begin().await.expect("setup-token should start");
     let url = begun.url.as_deref().expect("a URL must be reported");
-    assert!(url.contains("scope=user%3Ainference"), "unexpected URL: {url}");
+    assert!(
+        url.contains("scope=user%3Ainference"),
+        "unexpected URL: {url}"
+    );
     assert!(!url.contains("user%3Aprofile"), "unexpected URL: {url}");
 
     let done = manager


### PR DESCRIPTION
Fixes #65.

## Summary

- make bare `claude` plus TUI `/login` the default remote-login flow
- recognize and safely advance the known theme, workspace-trust, ready-prompt, and login-method screens
- preserve `claude setup-token` as an explicit narrow-scope alternative via `LOGIN_CLI_ARGS=setup-token`
- document the exact OAuth scopes and add a minor-release changelog fragment

## Scope behavior

| Mode | Scopes |
| --- | --- |
| TUI `/login` (default) | `org:create_api_key`, `user:profile`, `user:inference`, `user:sessions:claude_code`, `user:mcp_servers`, `user:file_upload` |
| `setup-token` (explicit) | `user:inference` |

The TUI driver waits for output to settle at each recognized screen and never types into an unknown onboarding screen. One timeout covers the complete startup sequence.

## Reproduction and verification

Before the implementation, the new integration fixture stopped at the first-run theme picker and `POST /api/login` failed with `NoUrl("timed out; last output: Choose the text style ...")`.

`tests/login_flow_test.rs` now reproduces the full first-run TUI sequence and verifies all six default scopes, credential creation, and the explicit `setup-token` path with only `user:inference`.

I also exercised the built router against an isolated real Claude Code 2.1.222 configuration. `POST /api/login` advanced the theme and workspace-trust screens, waited for the prompt, entered `/login`, selected the subscription method, and returned the real `claude.com` authorization URL containing all six expected scopes. The session was then cancelled without completing OAuth or touching existing credentials.

## Checks

- `cargo fmt --all -- --check`
- `cargo check --locked --all-targets --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features --verbose`
- `cargo test --locked --doc --verbose`
- `cargo build --locked --release --verbose`
- changelog, version-modification, file-size, and version-script checks
