### PR TITLE
fix: preserve authorization codes pasted into Claude TUI

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-09T04:13:55.183Z for PR creation at branch issue-67-bf061f2d3e82 for issue https://github.com/link-assistant/router/issues/67

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-09T04:13:55.183Z for PR creation at branch issue-67-bf061f2d3e82 for issue https://github.com/link-assistant/router/issues/67

--- a/changelog.d/20260809_043000_issue_67_oauth_code_submission.md
+++ b/changelog.d/20260809_043000_issue_67_oauth_code_submission.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+---
+
+### Fixed
+
+- Submit Claude TUI authorization codes as bracketed paste and wait for the input to settle before pressing Enter, preventing long codes from being corrupted.
+- Report the CLI's OAuth rejection immediately and distinguish it from a genuine login timeout.

--- a/examples/fake-login-cli.sh
+++ b/examples/fake-login-cli.sh
@@ -9,7 +9,7 @@
 #   * the TUI waits until `/login` is entered and a login method is selected,
 #   * it repaints, printing the authorization URL more than once,
 #   * it hard-wraps nothing itself and relies on the terminal,
-#   * it waits on stdin for the code the human pastes,
+#   * its TUI accepts the code as bracketed paste, like a terminal emulator,
 #   * the TUI writes `.credentials.json`, while `setup-token` prints a token,
 #   * it prints `Invalid code` and exits 1 when the code is rejected.
 #
@@ -60,6 +60,24 @@ printf 'Paste code here: '
 IFS= read -r code
 code="${code%$'\r'}"
 
+if [ "$mode" = "tui" ]; then
+  paste_start=$'\033[200~'
+  paste_end=$'\033[201~'
+  case "$code" in
+    "$paste_start"*"$paste_end")
+      code="${code#"$paste_start"}"
+      code="${code%"$paste_end"}"
+      ;;
+    *)
+      # Ink positions words with cursor escapes. ANSI stripping therefore
+      # yields OAutherror:Invalidcode... rather than a space-preserving line.
+      printf '\r\nOAuth\033[7Gerror: Invalid\033[22Gcode. Please make sure the full code was copied\r\n'
+      printf 'Press\033[7GEnter\033[13Gto\033[16Gretry.\r\n'
+      exit 1
+      ;;
+  esac
+fi
+
 if [ "$code" = "$expected" ]; then
   printf '\r\nLogin successful.\r\n'
   if [ "$mode" = "setup-token" ]; then
@@ -70,5 +88,6 @@ if [ "$code" = "$expected" ]; then
   exit 0
 fi
 
-printf '\r\nInvalid code\r\n'
+printf '\r\nOAuth\033[7Gerror: Invalid\033[22Gcode. Please make sure the full code was copied\r\n'
+printf 'Press\033[7GEnter\033[13Gto\033[16Gretry.\r\n'
 exit 1

--- a/src/login.rs
+++ b/src/login.rs
@@ -44,17 +44,15 @@ use crate::login_url::{extract_login_url, extract_token};
 use crate::subscription::{SubscriptionProvider, SubscriptionReader};
 
 /// Markers that mean the CLI accepted the code and finished.
-const SUCCESS_MARKERS: &[&str] = &[
-    "Login successful",
-    "successfully authenticated",
-    "sk-ant-oat",
-];
+const SUCCESS_MARKERS: &[&str] = &["Loginsuccessful", "successfullyauthenticated", "sk-ant-oat"];
 /// Markers that mean the CLI rejected the code.
 const FAILURE_MARKERS: &[&str] = &[
-    "Invalid code",
+    "OAutherror",
+    "PressEntertoretry",
+    "Invalidcode",
     "invalid_grant",
-    "Authentication failed",
-    "Login failed",
+    "Authenticationfailed",
+    "Loginfailed",
 ];
 
 /// Stable text on the first-run screens that block the Claude Code prompt.
@@ -517,7 +515,7 @@ fn next_tui_action(text: &str, progress: &TuiProgress) -> Option<TuiAction> {
     // Ink-based TUIs position words with cursor escapes instead of printing
     // literal spaces. `strip_ansi` intentionally removes those escapes, so a
     // rendered "Select login method:" may arrive as "Selectloginmethod:".
-    let compact: String = text.chars().filter(|ch| !ch.is_whitespace()).collect();
+    let compact = compact_terminal_text(text);
     if progress.needs(TuiAction::AcceptTheme) && compact.contains(THEME_PICKER_MARKER) {
         Some(TuiAction::AcceptTheme)
     } else if progress.needs(TuiAction::AcceptWorkspaceTrust)
@@ -532,6 +530,16 @@ fn next_tui_action(text: &str, progress: &TuiProgress) -> Option<TuiAction> {
     } else {
         None
     }
+}
+
+/// Match terminal text independently of whether a TUI printed spaces or used
+/// cursor-positioning escapes that disappeared during ANSI stripping.
+fn compact_terminal_text(text: &str) -> String {
+    text.chars().filter(|ch| !ch.is_whitespace()).collect()
+}
+
+fn contains_marker(compact: &str, markers: &[&str]) -> bool {
+    markers.iter().any(|marker| compact.contains(marker))
 }
 
 /// Drive bare `claude` to the full-scope OAuth URL exposed by its `/login`
@@ -624,16 +632,33 @@ fn wait_error_detail(session: &PtySession, err: &WaitError) -> String {
 
 /// Type the code into the live session and decide what happened.
 fn submit_and_finalize(config: &LoginConfig, pty: &PtySession, code: &str) -> Outcome {
-    if let Err(e) = pty.send_text(code).and_then(|()| pty.send_key(Key::Enter)) {
+    // The default flow is an Ink TUI. A real terminal wraps pasted text so the
+    // controlled input receives it as one transaction instead of racing its
+    // repaint one keypress at a time. Preserve raw input for the explicit
+    // `setup-token` alternative, whose line reader does not enable this mode.
+    let send_result = if config.args.is_empty() {
+        pty.send_bracketed_paste(code)
+    } else {
+        pty.send_text(code)
+    };
+    if let Err(e) = send_result {
         return Outcome::Failed(format!("could not send the code to the login process: {e}"));
+    }
+    if let Err(e) = pty.wait_idle(config.idle_settle, config.code_timeout) {
+        return Outcome::Failed(format!(
+            "login timed out while waiting for the pasted authorization code to settle: {e}"
+        ));
+    }
+    if let Err(e) = pty.send_key(Key::Enter) {
+        return Outcome::Failed(format!("could not submit the authorization code: {e}"));
     }
 
     // Either the CLI prints a verdict, or it simply exits. Both are handled;
     // the authoritative check is whether a credential exists afterwards.
-    let _ = pty.wait_for(
+    let verdict = pty.wait_for(
         |text| {
-            SUCCESS_MARKERS.iter().any(|m| text.contains(m))
-                || FAILURE_MARKERS.iter().any(|m| text.contains(m))
+            let compact = compact_terminal_text(text);
+            contains_marker(&compact, SUCCESS_MARKERS) || contains_marker(&compact, FAILURE_MARKERS)
         },
         config.idle_settle,
         config.code_timeout,
@@ -659,24 +684,50 @@ fn submit_and_finalize(config: &LoginConfig, pty: &PtySession, code: &str) -> Ou
             )),
         };
     }
-    let failure = FAILURE_MARKERS
-        .iter()
-        .find(|marker| transcript.contains(**marker))
-        .map_or_else(
-            || {
-                format!(
-                    "no credential was produced; last output: {}",
-                    excerpt(&transcript, code, 400)
-                )
-            },
-            |marker| {
-                format!(
-                    "login rejected ({marker}); last output: {}",
-                    excerpt(&transcript, code, 400)
-                )
-            },
-        );
+    let compact = compact_terminal_text(&transcript);
+    let failure = if contains_marker(&compact, FAILURE_MARKERS) {
+        format!(
+            "authorization code was rejected; CLI reported: {}. Request a fresh login URL and code",
+            rejection_verdict(&compact)
+        )
+    } else if matches!(verdict, Err(WaitError::Timeout)) {
+        format!(
+            "login timed out waiting for the CLI to accept or reject the authorization code; last output: {}",
+            excerpt(&transcript, code, 400)
+        )
+    } else {
+        format!(
+            "login process ended without producing a credential; last output: {}",
+            excerpt(&transcript, code, 400)
+        )
+    };
     Outcome::Failed(failure)
+}
+
+/// Turn the CLI's known compacted verdicts back into readable API text.
+fn rejection_verdict(compact: &str) -> String {
+    const STATUS_PREFIX: &str = "OAutherror:Requestfailedwithstatuscode";
+
+    if compact.contains("OAutherror:Invalidcode") {
+        return "OAuth error: Invalid code. Please make sure the full code was copied".into();
+    }
+    if let Some(start) = compact.rfind(STATUS_PREFIX) {
+        let rest = &compact[start + STATUS_PREFIX.len()..];
+        let status: String = rest.chars().take_while(char::is_ascii_digit).collect();
+        if !status.is_empty() {
+            return format!("OAuth error: Request failed with status code {status}");
+        }
+    }
+    if compact.contains("invalid_grant") {
+        return "OAuth error: invalid_grant".into();
+    }
+    if compact.contains("Authenticationfailed") {
+        return "Authentication failed".into();
+    }
+    if compact.contains("Loginfailed") {
+        return "Login failed".into();
+    }
+    "OAuth error: the CLI rejected the authorization code".into()
 }
 
 /// A credential the router can now read.
@@ -782,6 +833,18 @@ mod tests {
     #[test]
     fn login_config_defaults_to_bare_tui() {
         assert!(LoginConfig::default().args.is_empty());
+    }
+
+    #[test]
+    fn compacted_oauth_verdicts_are_restored_for_api_errors() {
+        assert_eq!(
+            rejection_verdict("promptOAutherror:Invalidcode.Pleasemakesurethefullcodewascopied"),
+            "OAuth error: Invalid code. Please make sure the full code was copied"
+        );
+        assert_eq!(
+            rejection_verdict("promptOAutherror:Requestfailedwithstatuscode400"),
+            "OAuth error: Request failed with status code 400"
+        );
     }
 
     /// Build a session that already reached `status`, settled `age` ago.

--- a/src/login_pty.rs
+++ b/src/login_pty.rs
@@ -232,6 +232,26 @@ impl PtySession {
         }
     }
 
+    /// Block until output has stayed quiet for `idle` after this call began.
+    ///
+    /// Requiring a full idle interval after entry prevents old quiet time from
+    /// making a post-input settle return before the child has processed the
+    /// newly written bytes.
+    pub fn wait_idle(&self, idle: Duration, timeout: Duration) -> Result<(), WaitError> {
+        let started = Instant::now();
+        let deadline = started + timeout;
+        loop {
+            let (_, quiet_for) = self.snapshot();
+            if started.elapsed() >= idle && quiet_for >= idle {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                return Err(WaitError::Timeout);
+            }
+            std::thread::sleep(POLL_INTERVAL);
+        }
+    }
+
     /// Current transcript and how long the child has been quiet.
     fn snapshot(&self) -> (String, Duration) {
         let (bytes, quiet_for) = self.output.lock().map_or_else(
@@ -264,6 +284,22 @@ impl PtySession {
             .lock()
             .map_err(|_| std::io::Error::other("PTY writer poisoned"))?;
         writer.write_all(text.as_bytes())?;
+        writer.flush()
+    }
+
+    /// Paste `text` as one bracketed-paste transaction.
+    ///
+    /// Ink and other terminal UIs use these delimiters to distinguish a paste
+    /// from a burst of independent keypresses. Keeping the complete sequence
+    /// under one writer lock also prevents another input from interleaving.
+    pub fn send_bracketed_paste(&self, text: &str) -> std::io::Result<()> {
+        let mut writer = self
+            .writer
+            .lock()
+            .map_err(|_| std::io::Error::other("PTY writer poisoned"))?;
+        writer.write_all(b"\x1b[200~")?;
+        writer.write_all(text.as_bytes())?;
+        writer.write_all(b"\x1b[201~")?;
         writer.flush()
     }
 

--- a/tests/login_flow_test.rs
+++ b/tests/login_flow_test.rs
@@ -139,15 +139,40 @@ async fn setup_token_remains_an_explicit_alternative() {
 #[tokio::test]
 async fn a_rejected_code_fails_the_session_without_writing_a_credential() {
     let home = temp_home();
-    let manager = manager_with(&home);
+    let timeout = Duration::from_secs(3);
+    let manager = LoginManager::new(LoginConfig {
+        command: fake_cli(),
+        args: vec![],
+        claude_code_home: home.clone(),
+        idle_settle: Duration::from_millis(50),
+        url_timeout: Duration::from_secs(20),
+        code_timeout: timeout,
+        ..LoginConfig::default()
+    });
 
     let begun = manager.begin().await.expect("login should start");
+    let started = std::time::Instant::now();
     let done = manager
         .submit_code(&begun.login_id, "wrong-code")
         .await
         .expect("submitting is not itself an error");
     assert_eq!(done.status, LoginStatus::Failed);
-    assert!(done.error.is_some(), "a failure must explain itself");
+    assert!(
+        started.elapsed() < timeout,
+        "a recognized rejection must not consume code_timeout"
+    );
+    let error = done
+        .error
+        .as_deref()
+        .expect("a failure must explain itself");
+    assert!(
+        error.contains("authorization code was rejected"),
+        "the caller must be told to obtain a fresh code: {error}"
+    );
+    assert!(
+        error.contains("OAuth error") && error.contains("Invalid code"),
+        "the CLI's verdict must be surfaced in readable form: {error}"
+    );
 
     assert!(
         OAuthProvider::new(home.to_str().unwrap())


### PR DESCRIPTION
Fixes #67.

## Summary

- submit codes to the default Ink TUI as one bracketed-paste transaction
- wait for a fresh quiet interval before pressing Enter, so repainting cannot race submission
- normalize cursor-positioned terminal output before matching success and failure markers
- return a readable CLI OAuth verdict immediately and distinguish rejection from timeout
- preserve raw line input for the explicit `setup-token` alternative

## Reproduction

The integration fixture now models the real TUI: it rejects unframed code input and renders `OAuth error: Invalid code` with cursor-positioning escapes. Before the fix, the valid-code test failed because the raw code was not bracketed, while the rejected-code test consumed `code_timeout` and returned the generic `no credential was produced` fallback.

## Automated regression coverage

- `login_produces_a_url_then_a_usable_credential` proves the default TUI accepts the bracketed code and writes a usable credential.
- `a_rejected_code_fails_the_session_without_writing_a_credential` proves a cursor-compacted OAuth rejection returns before `code_timeout`, reports an actionable readable verdict, and writes no credential.
- `compacted_oauth_verdicts_are_restored_for_api_errors` covers both invalid-code and HTTP-status OAuth verdicts.
- The existing `setup_token_remains_an_explicit_alternative` test confirms compatibility with raw line input.

## Local verification

- `cargo fmt --all -- --check`
- `cargo check --locked --all-targets --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo doc --locked --no-deps --all-features`
- `rust-script scripts/check-file-size.rs`
- `rust-script --test scripts/version-and-commit.rs`
- changelog and version-modification policy checks
- `cargo test --locked --all-features --verbose`
- `cargo test --locked --doc --verbose`
- `cargo build --locked --release --verbose`
- `cargo package --locked --list`
