### PR TITLE
feat: route across mounted subscriptions

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-10T08:51:48.952Z for PR creation at branch issue-71-fee363b3db8a for issue https://github.com/link-assistant/router/issues/71

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Link.Assistant.Router is a transparent proxy that sits between API clients (such
 
 - **Proxies all Anthropic API requests** transparently, including SSE/streaming responses
 - **Supports Claude MAX (OAuth)** by reading Claude Code session credentials
-- **Vendor subscriptions** — `UPSTREAM_PROVIDER=codex|gemini|qwen` reads each vendor CLI's OAuth credentials read-only (`~/.codex`, `~/.gemini`, `~/.qwen`), refreshes expired tokens in memory, and routes to the ChatGPT/Code Assist/DashScope backend with full dialect translation
+- **Vendor subscriptions** — the default `UPSTREAM_PROVIDER=auto` discovers healthy Claude, Codex, Gemini, and Qwen CLI credentials, exposes their model union, and routes each model to its owning subscription; an explicit provider value pins all traffic
 - **OpenAI-compatible endpoints** — `/v1/chat/completions`, `/v1/responses`, `/v1/models` translate to Anthropic or forward to a configured OpenAI-compatible provider
 - **Optional Gonka upstream** — `UPSTREAM_PROVIDER=gonka` forwards OpenAI-compatible routes to Gonka instead of translating them to Anthropic
 - **Optional Crater ForgeFed upstream** — `UPSTREAM_PROVIDER=crater` turns OpenAI chat requests into ForgeFed `Offer{Ticket}` tasks and waits for resolved task results
@@ -63,9 +63,11 @@ chat requests, delivers a ForgeFed `Offer` containing a `Ticket` to
 
 ### Vendor subscriptions (Codex, Gemini, Qwen)
 
-Set `UPSTREAM_PROVIDER` to `codex`, `gemini`, or `qwen` to serve a vendor
-subscription instead of an API key. Clients still authenticate to the router
-with their `la_sk_...` token; the router supplies the vendor OAuth token.
+By default, leave `UPSTREAM_PROVIDER=auto`: the router discovers every healthy
+vendor credential, returns their union from `/v1/models`, and sends each model
+to its owning subscription. Set a concrete value to pin a deployment to one
+provider. Clients still authenticate with their `la_sk_...` token; the router
+supplies the selected vendor OAuth token.
 
 | Provider | `UPSTREAM_PROVIDER` (aliases) | Credentials (read-only) | Upstream |
 | --- | --- | --- | --- |
@@ -370,7 +372,7 @@ in a browser *or* in a chat. See
 |---|---|---|
 | `/v1/chat/completions` | POST | Chat Completions, translated to Anthropic Messages, forwarded to the selected OpenAI-compatible provider, or delivered as a Crater ForgeFed task |
 | `/v1/responses` | POST | Responses API, translated to Anthropic Messages or forwarded to the selected OpenAI-compatible provider |
-| `/v1/models` | GET | OpenAI-shaped model list |
+| `/v1/models` | GET | OpenAI-shaped union of models from healthy subscriptions in automatic mode |
 | `/api/openai/v1/*` | GET/POST | Namespaced aliases for models, Chat Completions, and Responses |
 | `/api/codex/v1/*` | GET/POST | Codex namespace; Responses is the subscription's native protocol |
 | `/api/qwen/v1/*` | GET/POST | Qwen namespace; forwards its native OpenAI-compatible protocol |
@@ -380,10 +382,8 @@ in a browser *or* in a chat. See
 | `/api/gemini/v1beta/models/{model}:streamGenerateContent` | POST | Native Gemini SSE response |
 | `/api/vertex/v1/projects/.../models/{model}:generateContent` | POST | Native Vertex-style generation through Gemini Code Assist |
 
-Provider-specific namespaces use the matching active subscription configured
-by `UPSTREAM_PROVIDER`; for example, native Gemini and Vertex generation
-requires `UPSTREAM_PROVIDER=gemini`. They are additive client-facing protocol
-aliases, not cross-provider fallback rules.
+Provider-specific namespaces use the matching healthy subscription in
+automatic mode, or the provider pinned by `UPSTREAM_PROVIDER`.
 
 `gpt-4o`, `gpt-4o-mini`, `gpt-4`, and the `o*` reasoning families auto-map to the Claude Sonnet / Haiku / Opus tiers respectively. Native `claude-*` IDs pass through unchanged.
 
@@ -519,7 +519,7 @@ Every flag listed in `--help` has an env-var alias and can be configured from
 | `--port` / `ROUTER_PORT` | `8080` | No | Port to listen on |
 | `--host` / `ROUTER_HOST` | `0.0.0.0` | No | Host/IP to bind to |
 | `--claude-code-home` / `CLAUDE_CODE_HOME` | `~/.claude` | No | Primary Claude Code credentials directory |
-| `--upstream-provider` / `UPSTREAM_PROVIDER` | `anthropic` | No | Upstream provider: `anthropic`, `codex`, `gemini`, `qwen`, `gonka`, `crater`, or `openai-compatible` |
+| `--upstream-provider` / `UPSTREAM_PROVIDER` | `auto` | No | Automatically route by model across healthy subscriptions, or pin `anthropic`, `codex`, `gemini`, `qwen`, `gonka`, `crater`, or `openai-compatible` |
 | `--upstream-base-url` / `UPSTREAM_BASE_URL` | `https://api.anthropic.com` | No | Upstream Anthropic API URL |
 | `--api-format` / `UPSTREAM_API_FORMAT` | (auto) | No | Restrict the proxy to `anthropic` / `bedrock` / `vertex` |
 | `--bridge-model` / `ANTHROPIC_BRIDGE_MODEL` | (per provider) | No | Upstream model used when `/v1/messages` is served from a non-Anthropic upstream ([details](docs/use-cases/chatgpt-in-claude-code.md)) |
@@ -528,8 +528,8 @@ Every flag listed in `--help` has an env-var alias and can be configured from
 
 ### Gonka provider
 
-Gonka support is optional. Anthropic remains the default provider, and existing
-Claude MAX OAuth behavior is unchanged unless `UPSTREAM_PROVIDER=gonka` is set.
+Gonka support is optional. Set `UPSTREAM_PROVIDER=gonka` to pin the deployment
+to it instead of using automatic subscription routing.
 
 ```env
 TOKEN_SECRET=your-router-token-secret

--- a/changelog.d/20260810_100000_multi_subscription_routing.md
+++ b/changelog.d/20260810_100000_multi_subscription_routing.md
@@ -1,0 +1,3 @@
+### Added
+
+- Discover all healthy vendor subscriptions by default, union their advertised models, and route requests to the subscription that owns the requested model. `UPSTREAM_PROVIDER` still pins a deployment when set explicitly.

--- a/docs/use-cases/cli-claude-code.md
+++ b/docs/use-cases/cli-claude-code.md
@@ -32,7 +32,8 @@ The client sends only its `la_sk_…` token. The router adds, per request:
 
 | `UPSTREAM_PROVIDER` | Behaviour |
 | --- | --- |
-| `anthropic` (default) | native pass-through to `api.anthropic.com` with the Claude MAX OAuth token |
+| `auto` (default) | routes the requested advertised model to its healthy owning subscription |
+| `anthropic` | native pass-through to `api.anthropic.com` with the Claude MAX OAuth token |
 | `codex`, `qwen`, `gemini`, `openai-compatible` | bridged — see [chatgpt-in-claude-code.md](chatgpt-in-claude-code.md) |
 | `gonka`, `crater` | unchanged prior behaviour on this surface |
 

--- a/docs/use-cases/cli-codex.md
+++ b/docs/use-cases/cli-codex.md
@@ -39,6 +39,7 @@ codex "explain this repository"
 
 | `UPSTREAM_PROVIDER` | Behaviour |
 | --- | --- |
+| `auto` (default) | `gpt-5` and other advertised Codex models route to the healthy ChatGPT subscription |
 | `anthropic` | Responses request is translated to Anthropic Messages and served by Claude MAX — see [claude-max-in-codex.md](claude-max-in-codex.md) |
 | `codex` | native: forwarded to the ChatGPT backend Responses API with the `~/.codex/auth.json` OAuth token |
 | `qwen`, `gemini`, `openai-compatible`, `gonka`, `crater` | translated to that provider's dialect |

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -27,6 +27,8 @@ pub struct AppState {
     /// Subscription credential reader for vendor OAuth providers
     /// (Codex/Gemini/Qwen). `None` for non-subscription upstreams.
     pub subscription_reader: Option<crate::subscription::SubscriptionReader>,
+    /// Credential readers for every discoverable vendor subscription.
+    pub subscription_readers: Vec<crate::subscription::SubscriptionReader>,
     /// In-memory cache of refreshed subscription tokens (Codex/Gemini/Qwen).
     pub subscription_cache: Arc<crate::refresh::TokenCache>,
     /// Base URL for the upstream Anthropic API.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -105,13 +105,9 @@ pub struct Cli {
     #[arg(long, env = "CLAUDE_CLI_BIN", global = true)]
     pub claude_cli_bin: Option<PathBuf>,
 
-    /// Upstream provider: anthropic, gonka, crater, or openai-compatible.
-    #[arg(
-        long,
-        env = "UPSTREAM_PROVIDER",
-        default_value = "anthropic",
-        global = true
-    )]
+    /// Upstream provider: auto, anthropic, codex, gemini, qwen, gonka, crater,
+    /// or openai-compatible.
+    #[arg(long, env = "UPSTREAM_PROVIDER", default_value = "auto", global = true)]
     pub upstream_provider: String,
 
     /// Gonka private key used for request signing.
@@ -526,8 +522,8 @@ impl Cli {
         let api_format = self.api_format.as_deref().and_then(ApiFormat::from_str_opt);
         let routing_mode =
             RoutingMode::from_str_opt(&self.routing_mode).ok_or(ConfigError::InvalidRoutingMode)?;
-        let upstream_provider = UpstreamProvider::from_str_opt(&self.upstream_provider)
-            .unwrap_or(UpstreamProvider::Anthropic);
+        let upstream_provider =
+            UpstreamProvider::from_str_opt(&self.upstream_provider).unwrap_or_default();
         let storage_policy = StoragePolicy::from_str_opt(&self.storage_policy).unwrap_or_default();
         let account_routing_strategy =
             crate::accounts::SelectionStrategy::from_str_opt(&self.account_routing_strategy)
@@ -658,6 +654,7 @@ mod tests {
     fn login_cli_defaults_to_bare_tui() {
         let cli = Cli::try_parse_from(["link-assistant-router"]).unwrap();
         assert!(cli.login_cli_args.is_empty());
+        assert_eq!(cli.upstream_provider, "auto");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,8 +20,10 @@ use crate::accounts::SelectionStrategy;
 /// Supported upstream inference providers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum UpstreamProvider {
-    /// Anthropic via Claude MAX OAuth credentials.
+    /// Automatically route requests across every healthy vendor subscription.
     #[default]
+    Auto,
+    /// Anthropic via Claude MAX OAuth credentials.
     Anthropic,
     /// Gonka OpenAI-compatible inference provider.
     Gonka,
@@ -42,6 +44,7 @@ impl UpstreamProvider {
     #[must_use]
     pub fn from_str_opt(s: &str) -> Option<Self> {
         match s.to_lowercase().as_str() {
+            "auto" | "all" => Some(Self::Auto),
             "anthropic" | "claude" => Some(Self::Anthropic),
             "gonka" => Some(Self::Gonka),
             "crater" | "forgefed" => Some(Self::Crater),
@@ -65,7 +68,7 @@ impl UpstreamProvider {
             Self::Codex => Some(S::Codex),
             Self::Gemini => Some(S::Gemini),
             Self::Qwen => Some(S::Qwen),
-            Self::Gonka | Self::Crater | Self::OpenAICompatible => None,
+            Self::Auto | Self::Gonka | Self::Crater | Self::OpenAICompatible => None,
         }
     }
 
@@ -73,6 +76,7 @@ impl UpstreamProvider {
     #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {
+            Self::Auto => "auto",
             Self::Anthropic => "anthropic",
             Self::Gonka => "gonka",
             Self::Crater => "crater",
@@ -700,7 +704,7 @@ mod tests {
             storage_policy: StoragePolicy::Memory,
             data_dir: PathBuf::from("/tmp/test-data"),
             claude_cli_bin: None,
-            upstream_provider: UpstreamProvider::Anthropic,
+            upstream_provider: UpstreamProvider::Auto,
             gonka_private_key: None,
             gonka_source_url: default_gonka_source_url(),
             gonka_model: default_gonka_model(),
@@ -747,15 +751,15 @@ mod tests {
         assert_eq!(config.token_secret, "test-secret-key");
         assert_eq!(config.claude_code_home, "/tmp/claude");
         assert_eq!(config.upstream_base_url, "https://api.anthropic.com");
-        assert_eq!(config.upstream_provider, UpstreamProvider::Anthropic);
+        assert_eq!(config.upstream_provider, UpstreamProvider::Auto);
         assert!(!config.verbose);
         assert_eq!(config.routing_mode, RoutingMode::Direct);
     }
 
     #[test]
-    fn default_provider_is_anthropic() {
+    fn default_provider_routes_across_subscriptions() {
         let config = build_default(Some("secret")).expect("should build");
-        assert_eq!(config.upstream_provider, UpstreamProvider::Anthropic);
+        assert_eq!(config.upstream_provider, UpstreamProvider::Auto);
     }
 
     #[test]

--- a/src/gemini.rs
+++ b/src/gemini.rs
@@ -549,7 +549,14 @@ fn native_model_document(model: &str) -> Value {
 }
 
 /// Native Gemini `ListModels` response.
-pub async fn native_models() -> impl IntoResponse {
+pub async fn native_models(State(state): State<AppState>) -> impl IntoResponse {
+    let available = state.upstream_provider == crate::config::UpstreamProvider::Gemini
+        || (state.upstream_provider == crate::config::UpstreamProvider::Auto
+            && crate::model_routing::healthy_providers(
+                &state.subscription_readers,
+                chrono::Utc::now().timestamp_millis(),
+            )
+            .contains(&crate::subscription::SubscriptionProvider::Gemini));
     let models = [
         "gemini-2.5-pro",
         "gemini-2.5-flash",
@@ -557,14 +564,32 @@ pub async fn native_models() -> impl IntoResponse {
         "gemini-2.0-flash-lite",
     ]
     .iter()
+    .filter(|_| available)
     .map(|model| native_model_document(model))
     .collect::<Vec<_>>();
     (StatusCode::OK, axum::Json(json!({"models": models})))
 }
 
 /// Native Gemini `GetModel` response.
-pub async fn native_model(Path(model): Path<String>) -> impl IntoResponse {
-    (StatusCode::OK, axum::Json(native_model_document(&model)))
+pub async fn native_model(
+    State(state): State<AppState>,
+    Path(model): Path<String>,
+) -> impl IntoResponse {
+    let available = state.upstream_provider == crate::config::UpstreamProvider::Gemini
+        || (state.upstream_provider == crate::config::UpstreamProvider::Auto
+            && crate::model_routing::provider_for_model(&model)
+                == Some(crate::subscription::SubscriptionProvider::Gemini)
+            && crate::model_routing::healthy_providers(
+                &state.subscription_readers,
+                chrono::Utc::now().timestamp_millis(),
+            )
+            .contains(&crate::subscription::SubscriptionProvider::Gemini));
+    let status = if available {
+        StatusCode::OK
+    } else {
+        StatusCode::NOT_FOUND
+    };
+    (status, axum::Json(native_model_document(&model)))
 }
 
 fn parse_native_target(path: &str) -> Option<(String, bool)> {
@@ -609,6 +634,20 @@ async fn forward_native(
     path: &str,
     body: Value,
 ) -> Response {
+    let routed_state = if state.upstream_provider == crate::config::UpstreamProvider::Auto {
+        match crate::model_routing::route_provider(
+            state,
+            crate::subscription::SubscriptionProvider::Gemini,
+        ) {
+            Ok(state) => Some(state),
+            Err(error) => {
+                return error_response(StatusCode::BAD_REQUEST, "invalid_request_error", &error);
+            }
+        }
+    } else {
+        None
+    };
+    let state = routed_state.as_ref().unwrap_or(state);
     if state.upstream_provider != crate::config::UpstreamProvider::Gemini {
         return error_response(
             StatusCode::BAD_REQUEST,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub mod login_api;
 pub mod login_pty;
 pub mod login_url;
 pub mod metrics;
+pub mod model_routing;
 pub mod mpp;
 pub mod oauth;
 pub mod openai;

--- a/src/main.rs
+++ b/src/main.rs
@@ -241,24 +241,24 @@ async fn run_server(config: Config, logger: LogLazy) -> Result<(), Box<dyn std::
             None
         };
 
-    // Vendor-subscription upstreams (Codex/Gemini/Qwen) read their OAuth token
-    // from the vendor CLI's credential file. Claude keeps using `oauth_provider`.
-    let subscription_reader = match config.upstream_provider.subscription_provider() {
-        Some(provider)
-            if provider != link_assistant_router::subscription::SubscriptionProvider::Claude =>
-        {
-            let user_home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-            let reader = link_assistant_router::subscription::SubscriptionReader::from_user_home(
-                provider, &user_home,
-            );
-            tracing::info!(
-                "Subscription provider {provider}: reading credentials from {}",
-                reader.home().display()
-            );
-            Some(reader)
-        }
-        _ => None,
-    };
+    // Keep readers for every vendor so automatic routing can discover all
+    // mounted subscriptions. Claude's configured home may differ from HOME.
+    let user_home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+    let subscription_readers = link_assistant_router::subscription::all_subscription_readers(
+        &config.claude_code_home,
+        &user_home,
+    );
+    for reader in &subscription_readers {
+        tracing::info!(
+            "Subscription provider {}: reading credentials from {}",
+            reader.provider(),
+            reader.home().display()
+        );
+    }
+    let subscription_reader = link_assistant_router::subscription::active_subscription_reader(
+        config.upstream_provider,
+        &subscription_readers,
+    );
 
     // The admin credential: a deploy-time key when provided, otherwise the
     // persisted first-visitor claim (unclaimed until someone confirms one).
@@ -274,6 +274,7 @@ async fn run_server(config: Config, logger: LogLazy) -> Result<(), Box<dyn std::
         oauth_provider,
         account_router,
         subscription_reader,
+        subscription_readers,
         subscription_cache: Arc::new(link_assistant_router::refresh::TokenCache::new()),
         upstream_base_url: config.upstream_base_url.clone(),
         upstream_provider: config.upstream_provider,
@@ -359,6 +360,7 @@ async fn run_server(config: Config, logger: LogLazy) -> Result<(), Box<dyn std::
             )
             .route("/api/openai/v1/responses", post(proxy::openai_responses))
             .route("/api/openai/v1/models", get(proxy::openai_models))
+            .route("/api/anthropic/v1/models", get(proxy::openai_models))
             .route(
                 "/api/codex/v1/chat/completions",
                 post(proxy::openai_chat_completions),

--- a/src/model_routing.rs
+++ b/src/model_routing.rs
@@ -1,0 +1,358 @@
+//! Model catalog and automatic subscription-provider routing.
+
+use axum::body::Body;
+use axum::extract::{Request, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde_json::{Value, json};
+
+use crate::app_state::AppState;
+use crate::config::UpstreamProvider;
+use crate::subscription::{SubscriptionProvider, SubscriptionReader};
+
+const CLAUDE_MODELS: &[&str] = &[
+    "claude-opus-4-7",
+    "claude-sonnet-4-5-20250929",
+    "claude-haiku-4-5-20251001",
+    "claude-sonnet-3-5-20241022",
+    "claude-haiku-3-5-20241022",
+];
+const CODEX_MODELS: &[&str] = &["gpt-5-codex", "gpt-5", "codex-mini-latest"];
+const GEMINI_MODELS: &[&str] = &[
+    "gemini-2.5-pro",
+    "gemini-2.5-flash",
+    "gemini-2.0-flash",
+    "gemini-2.0-flash-lite",
+];
+const QWEN_MODELS: &[&str] = &[
+    "qwen3-coder-plus",
+    "qwen3-coder-flash",
+    "qwen-max",
+    "qwen-plus",
+];
+
+const fn provider_models(
+    provider: SubscriptionProvider,
+) -> (&'static str, &'static [&'static str]) {
+    match provider {
+        SubscriptionProvider::Claude => ("anthropic", CLAUDE_MODELS),
+        SubscriptionProvider::Codex => ("openai", CODEX_MODELS),
+        SubscriptionProvider::Gemini => ("google", GEMINI_MODELS),
+        SubscriptionProvider::Qwen => ("qwen", QWEN_MODELS),
+    }
+}
+
+/// Return the provider that owns an advertised model id.
+#[must_use]
+pub fn provider_for_model(model: &str) -> Option<SubscriptionProvider> {
+    SubscriptionProvider::ALL.into_iter().find(|provider| {
+        let (_, models) = provider_models(*provider);
+        models.contains(&model)
+    })
+}
+
+/// Resolve a model only when the owning subscription is available.
+pub fn available_provider_for_model(
+    model: &str,
+    available: &[SubscriptionProvider],
+) -> Result<SubscriptionProvider, String> {
+    let provider = provider_for_model(model)
+        .ok_or_else(|| format!("model '{model}' is not advertised by any subscription"))?;
+    available
+        .contains(&provider)
+        .then_some(provider)
+        .ok_or_else(|| format!("model '{model}' has no healthy {provider} credential"))
+}
+
+/// Readers whose current on-disk access token exists and has not expired.
+#[must_use]
+pub fn healthy_providers(readers: &[SubscriptionReader], now_ms: i64) -> Vec<SubscriptionProvider> {
+    SubscriptionProvider::ALL
+        .into_iter()
+        .filter(|provider| {
+            readers
+                .iter()
+                .find(|reader| reader.provider() == *provider)
+                .and_then(|reader| reader.read_token().ok())
+                .is_some_and(|token| !token.is_expired(now_ms))
+        })
+        .collect()
+}
+
+/// `OpenAI` list-shape union for all supplied subscription providers.
+#[must_use]
+pub fn model_catalog(providers: &[SubscriptionProvider]) -> Value {
+    let now = chrono::Utc::now().timestamp();
+    let data = providers
+        .iter()
+        .flat_map(|provider| {
+            let (owner, models) = provider_models(*provider);
+            models.iter().map(move |id| {
+                json!({
+                    "id": id,
+                    "object": "model",
+                    "created": now,
+                    "owned_by": owner,
+                })
+            })
+        })
+        .collect::<Vec<_>>();
+    json!({"object": "list", "data": data})
+}
+
+/// Model catalog for one pinned subscription, empty when its credential is not healthy.
+#[must_use]
+pub fn pinned_model_catalog(state: &AppState, provider: SubscriptionProvider) -> Value {
+    let healthy = healthy_providers(
+        &state.subscription_readers,
+        chrono::Utc::now().timestamp_millis(),
+    );
+    if healthy.contains(&provider) {
+        model_catalog(&[provider])
+    } else {
+        model_catalog(&[])
+    }
+}
+
+/// `GET /v1/models` across automatic or explicitly pinned providers.
+pub async fn models(State(state): State<AppState>) -> impl IntoResponse {
+    let models = match state.upstream_provider {
+        UpstreamProvider::Auto => model_catalog(&healthy_providers(
+            &state.subscription_readers,
+            chrono::Utc::now().timestamp_millis(),
+        )),
+        UpstreamProvider::Anthropic => pinned_model_catalog(&state, SubscriptionProvider::Claude),
+        UpstreamProvider::Gonka => state.gonka.as_ref().map_or_else(
+            || crate::gonka::list_models(&crate::config::default_gonka_model()),
+            |gonka| crate::gonka::list_models(&gonka.model),
+        ),
+        UpstreamProvider::Crater => crate::crater::list_models(),
+        UpstreamProvider::Codex => pinned_model_catalog(&state, SubscriptionProvider::Codex),
+        UpstreamProvider::Qwen => pinned_model_catalog(&state, SubscriptionProvider::Qwen),
+        UpstreamProvider::Gemini => pinned_model_catalog(&state, SubscriptionProvider::Gemini),
+        UpstreamProvider::OpenAICompatible => {
+            crate::provider_proxy::openai_compatible_models(&state)
+        }
+    };
+    (StatusCode::OK, axum::Json(models)).into_response()
+}
+
+/// Consume an automatic Anthropic-surface request and return its concrete state.
+pub async fn route_anthropic_request(
+    state: &AppState,
+    request: Request,
+) -> Result<(AppState, Request), Response> {
+    let path = request.uri().path().to_string();
+    let (parts, body) = request.into_parts();
+    let body_bytes = axum::body::to_bytes(body, 10 * 1024 * 1024)
+        .await
+        .map_err(|error| {
+            crate::proxy::error_response(
+                StatusCode::BAD_REQUEST,
+                "invalid_request_error",
+                &format!("Failed to read request body: {error}"),
+            )
+        })?;
+    let routing_body = serde_json::from_slice(&body_bytes).unwrap_or(Value::Null);
+    let routed = if path.ends_with("/messages") || path.ends_with("/messages/count_tokens") {
+        route_state(state, &routing_body)
+    } else {
+        route_provider(state, SubscriptionProvider::Claude)
+    }
+    .map_err(|error| {
+        crate::proxy::error_response(StatusCode::BAD_REQUEST, "invalid_request_error", &error)
+    })?;
+    Ok((routed, Request::from_parts(parts, Body::from(body_bytes))))
+}
+
+/// Resolve one provider only when its credential is currently healthy.
+pub fn route_provider(
+    state: &AppState,
+    provider: SubscriptionProvider,
+) -> Result<AppState, String> {
+    let reader = state
+        .subscription_readers
+        .iter()
+        .find(|reader| reader.provider() == provider)
+        .filter(|reader| {
+            reader
+                .read_token()
+                .is_ok_and(|token| !token.is_expired(chrono::Utc::now().timestamp_millis()))
+        })
+        .cloned()
+        .ok_or_else(|| format!("no healthy {provider} credential is available"))?;
+
+    let mut routed = state.clone();
+    routed.upstream_provider = match provider {
+        SubscriptionProvider::Claude => UpstreamProvider::Anthropic,
+        SubscriptionProvider::Codex => UpstreamProvider::Codex,
+        SubscriptionProvider::Gemini => UpstreamProvider::Gemini,
+        SubscriptionProvider::Qwen => UpstreamProvider::Qwen,
+    };
+    if provider != SubscriptionProvider::Claude {
+        routed.account_router = None;
+        routed.subscription_reader = Some(reader);
+    }
+    Ok(routed)
+}
+
+/// Resolve an automatic state to the healthy subscription serving `model`.
+pub fn route_state(state: &AppState, body: &Value) -> Result<AppState, String> {
+    if state.upstream_provider != UpstreamProvider::Auto {
+        return Ok(state.clone());
+    }
+    let model = body
+        .get("model")
+        .and_then(Value::as_str)
+        .filter(|model| !model.is_empty())
+        .ok_or_else(|| "model is required when UPSTREAM_PROVIDER=auto".to_string())?;
+    let provider = available_provider_for_model(
+        model,
+        &healthy_providers(
+            &state.subscription_readers,
+            chrono::Utc::now().timestamp_millis(),
+        ),
+    )?;
+    let mut routed = route_provider(state, provider)
+        .map_err(|_| format!("model '{model}' has no healthy {provider} credential"))?;
+    if provider != SubscriptionProvider::Claude {
+        // The Anthropic bridge normally substitutes its provider default
+        // because pinned clients name Claude models. Auto mode selected this
+        // provider from the requested model itself, so preserve that exact id.
+        routed.bridge_model = Some(model.to_string());
+    }
+    Ok(routed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::sync::Arc;
+    use tempfile::tempdir;
+
+    fn auto_state(readers: Vec<SubscriptionReader>, data_dir: &std::path::Path) -> AppState {
+        AppState {
+            client: reqwest::Client::new(),
+            token_manager: crate::token::TokenManager::new("test-secret"),
+            oauth_provider: crate::oauth::OAuthProvider::new(&data_dir.to_string_lossy()),
+            account_router: None,
+            subscription_reader: None,
+            subscription_readers: readers,
+            subscription_cache: Arc::new(crate::refresh::TokenCache::new()),
+            upstream_base_url: "https://api.anthropic.com".to_string(),
+            upstream_provider: UpstreamProvider::Auto,
+            gonka: None,
+            bridge_model: None,
+            crater: None,
+            openai_compatible: crate::config::default_openai_compatible_config(),
+            provider_store: crate::providers::ProviderStore::open(data_dir, "test-secret").unwrap(),
+            logger: log_lazy::LogLazy::new(),
+            admin: Arc::new(crate::admin::AdminClaim::load(
+                None,
+                data_dir,
+                std::time::Duration::from_secs(60),
+            )),
+            admin_key: None,
+            allow_anonymous_admin: false,
+            metrics: Arc::new(crate::metrics::Metrics::default()),
+            audit: Arc::new(crate::audit::AuditLog::to_path(None)),
+            activitypub_actor_base_url: "https://router.example".to_string(),
+            activitypub_public_key_pem: crate::config::default_activitypub_public_key_pem(),
+            mpp: crate::config::default_mpp_config(),
+            login_manager: crate::login::LoginManager::new(crate::login::LoginConfig::default()),
+        }
+    }
+
+    #[test]
+    fn catalog_unions_models_with_their_real_owners() {
+        let catalog = model_catalog(&[SubscriptionProvider::Claude, SubscriptionProvider::Codex]);
+        let data = catalog["data"].as_array().unwrap();
+        assert!(
+            data.iter()
+                .any(|m| m["id"] == "claude-opus-4-7" && m["owned_by"] == "anthropic")
+        );
+        assert!(
+            data.iter()
+                .any(|m| m["id"] == "gpt-5" && m["owned_by"] == "openai")
+        );
+    }
+
+    #[test]
+    fn model_ids_route_to_the_subscription_that_serves_them() {
+        assert_eq!(
+            provider_for_model("gpt-5"),
+            Some(SubscriptionProvider::Codex)
+        );
+        assert_eq!(
+            provider_for_model("claude-opus-4-7"),
+            Some(SubscriptionProvider::Claude)
+        );
+        assert_eq!(
+            provider_for_model("gemini-2.5-pro"),
+            Some(SubscriptionProvider::Gemini)
+        );
+        assert_eq!(provider_for_model("made-up-model"), None);
+        assert_eq!(
+            available_provider_for_model("gpt-5", &[SubscriptionProvider::Codex]),
+            Ok(SubscriptionProvider::Codex)
+        );
+        assert!(
+            available_provider_for_model("gpt-5", &[SubscriptionProvider::Claude])
+                .unwrap_err()
+                .contains("no healthy codex credential")
+        );
+        assert!(available_provider_for_model("made-up-model", &[]).is_err());
+    }
+
+    #[test]
+    fn missing_and_expired_credentials_are_not_healthy() {
+        let live = tempdir().unwrap();
+        let expired = tempdir().unwrap();
+        fs::write(
+            live.path().join("auth.json"),
+            r#"{"tokens":{"access_token":"live"}}"#,
+        )
+        .unwrap();
+        fs::write(
+            expired.path().join("oauth_creds.json"),
+            r#"{"access_token":"old","expiry_date":1000}"#,
+        )
+        .unwrap();
+        let readers = vec![
+            SubscriptionReader::new(SubscriptionProvider::Codex, live.path()),
+            SubscriptionReader::new(SubscriptionProvider::Gemini, expired.path()),
+        ];
+        assert_eq!(
+            healthy_providers(&readers, 2000),
+            vec![SubscriptionProvider::Codex]
+        );
+    }
+
+    #[test]
+    fn automatic_state_selects_the_models_healthy_reader() {
+        let data = tempdir().unwrap();
+        let codex = tempdir().unwrap();
+        fs::write(
+            codex.path().join("auth.json"),
+            r#"{"tokens":{"access_token":"live"}}"#,
+        )
+        .unwrap();
+        let state = auto_state(
+            vec![SubscriptionReader::new(
+                SubscriptionProvider::Codex,
+                codex.path(),
+            )],
+            data.path(),
+        );
+
+        let routed = route_state(&state, &json!({"model": "gpt-5"})).unwrap();
+        assert_eq!(routed.upstream_provider, UpstreamProvider::Codex);
+        assert_eq!(routed.bridge_model.as_deref(), Some("gpt-5"));
+        assert_eq!(
+            routed.subscription_reader.unwrap().provider(),
+            SubscriptionProvider::Codex
+        );
+        assert!(route_state(&state, &json!({"model": "claude-opus-4-7"})).is_err());
+    }
+}

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -24,6 +24,7 @@ use std::collections::BTreeMap;
 use crate::accounts::RoutingContext;
 pub use crate::app_state::AppState;
 use crate::config::UpstreamProvider;
+pub use crate::model_routing::models as openai_models;
 use crate::openai;
 pub(crate) use crate::request_routing::{request_routing_context, retry_after_duration};
 use crate::responses;
@@ -120,10 +121,19 @@ pub(crate) fn extract_client_token(headers: &HeaderMap) -> Option<&str> {
 /// - Bedrock `InvokeModel`: `/invoke`, `/invoke-with-response-stream`
 /// - Vertex rawPredict: paths ending in `:rawPredict`, `:streamRawPredict`
 /// - Legacy: `/api/latest/anthropic/*`
-pub async fn proxy_handler(State(state): State<AppState>, req: Request) -> impl IntoResponse {
+pub async fn proxy_handler(State(state): State<AppState>, req: Request) -> Response {
     let path = req.uri().path().to_string();
     let method = req.method().clone();
     let incoming_headers = req.headers().clone();
+
+    if state.upstream_provider == UpstreamProvider::Auto {
+        let (routed, request) =
+            match crate::model_routing::route_anthropic_request(&state, req).await {
+                Ok(routed) => routed,
+                Err(response) => return response,
+            };
+        return Box::pin(proxy_handler(State(routed), request)).await;
+    }
 
     state.logger.verbose(|| format!("Incoming {method} {path}"));
 
@@ -474,27 +484,6 @@ async fn resolve_upstream_credentials(
     Ok((token, None))
 }
 
-/// `GET /v1/models` — OpenAI-compatible model listing.
-#[allow(clippy::unused_async)]
-pub async fn openai_models(State(state): State<AppState>) -> impl IntoResponse {
-    let models = match state.upstream_provider {
-        UpstreamProvider::Anthropic => openai::list_models(),
-        UpstreamProvider::Gonka => state.gonka.as_ref().map_or_else(
-            || crate::gonka::list_models(&crate::config::default_gonka_model()),
-            |gonka| crate::gonka::list_models(&gonka.model),
-        ),
-        UpstreamProvider::Crater => crate::crater::list_models(),
-        UpstreamProvider::Codex | UpstreamProvider::Qwen => {
-            crate::subscription_proxy::subscription_models(&state)
-        }
-        UpstreamProvider::Gemini => crate::gemini::list_models(),
-        UpstreamProvider::OpenAICompatible => {
-            crate::provider_proxy::openai_compatible_models(&state)
-        }
-    };
-    (StatusCode::OK, axum::Json(models)).into_response()
-}
-
 /// `POST /v1/chat/completions` — `OpenAI` Chat Completions.
 ///
 /// Translates to Anthropic Messages, forwards via the same OAuth-substituting
@@ -509,6 +498,12 @@ pub async fn openai_chat_completions(
     if stream_from_query {
         body["stream"] = serde_json::json!(true);
     }
+    let state = match crate::model_routing::route_state(&state, &body) {
+        Ok(state) => state,
+        Err(error) => {
+            return error_response(StatusCode::BAD_REQUEST, "invalid_request_error", &error);
+        }
+    };
     if state.upstream_provider == UpstreamProvider::Gonka {
         return crate::gonka::forward_openai(
             &state,
@@ -603,6 +598,12 @@ pub async fn openai_responses(
     headers: HeaderMap,
     axum::Json(body): axum::Json<serde_json::Value>,
 ) -> Response {
+    let state = match crate::model_routing::route_state(&state, &body) {
+        Ok(state) => state,
+        Err(error) => {
+            return error_response(StatusCode::BAD_REQUEST, "invalid_request_error", &error);
+        }
+    };
     if state.upstream_provider == UpstreamProvider::Gonka {
         return crate::gonka::forward_openai(
             &state,

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -283,6 +283,38 @@ impl SubscriptionReader {
     }
 }
 
+/// Construct readers for every vendor, honoring the configured Claude home.
+#[must_use]
+pub fn all_subscription_readers(claude_home: &str, user_home: &str) -> Vec<SubscriptionReader> {
+    SubscriptionProvider::ALL
+        .into_iter()
+        .map(|provider| {
+            if provider == SubscriptionProvider::Claude {
+                SubscriptionReader::new(provider, claude_home)
+            } else {
+                SubscriptionReader::from_user_home(provider, user_home)
+            }
+        })
+        .collect()
+}
+
+/// Reader used by an explicitly pinned non-Claude subscription provider.
+#[must_use]
+pub fn active_subscription_reader(
+    upstream: crate::config::UpstreamProvider,
+    readers: &[SubscriptionReader],
+) -> Option<SubscriptionReader> {
+    upstream
+        .subscription_provider()
+        .filter(|provider| *provider != SubscriptionProvider::Claude)
+        .and_then(|provider| {
+            readers
+                .iter()
+                .find(|reader| reader.provider() == provider)
+                .cloned()
+        })
+}
+
 /// Superset of every vendor credential layout. Each provider reads only the
 /// fields it uses; serde `alias` covers `camelCase`/`snake_case` variants.
 #[derive(Debug, Default, Deserialize)]

--- a/tests/admin_ui_test.rs
+++ b/tests/admin_ui_test.rs
@@ -27,6 +27,7 @@ fn state_with(admin: Arc<AdminClaim>, data_dir: &std::path::Path) -> AppState {
         ),
         account_router: None,
         subscription_reader: None,
+        subscription_readers: vec![],
         subscription_cache: Arc::new(link_assistant_router::refresh::TokenCache::new()),
         upstream_base_url: "https://api.anthropic.com".to_string(),
         upstream_provider: link_assistant_router::config::UpstreamProvider::Anthropic,

--- a/tests/chat_admin_test.rs
+++ b/tests/chat_admin_test.rs
@@ -122,6 +122,7 @@ fn state_with(
         ),
         account_router: None,
         subscription_reader: None,
+        subscription_readers: vec![],
         subscription_cache: Arc::new(link_assistant_router::refresh::TokenCache::new()),
         upstream_base_url: "https://api.anthropic.com".to_string(),
         upstream_provider: link_assistant_router::config::UpstreamProvider::Anthropic,

--- a/tests/security_review_test.rs
+++ b/tests/security_review_test.rs
@@ -40,6 +40,7 @@ fn state_with(admin: Arc<AdminClaim>, data_dir: &std::path::Path) -> AppState {
         ),
         account_router: None,
         subscription_reader: None,
+        subscription_readers: vec![],
         subscription_cache: Arc::new(link_assistant_router::refresh::TokenCache::new()),
         upstream_base_url: "https://api.anthropic.com".to_string(),
         upstream_provider: link_assistant_router::config::UpstreamProvider::Anthropic,


### PR DESCRIPTION
## Summary

- make `UPSTREAM_PROVIDER=auto` the default and discover mounted Claude, Codex, Gemini, and Qwen credentials
- return the union of models belonging to healthy subscriptions from `/v1/models`
- route OpenAI Chat Completions, Responses, Anthropic Messages, and native Gemini requests by exact model ownership
- keep explicit `UPSTREAM_PROVIDER` values as the existing pinned-provider behavior
- omit missing or explicitly expired credentials and reject unavailable or unadvertised models before an upstream call

## Reproduction

Before this change, startup selected one `subscription_reader` from `UPSTREAM_PROVIDER`, `/v1/models` listed only that provider, and every request followed that same provider regardless of its model. Mounting both Claude and Codex credentials could therefore neither advertise both catalogs nor send `gpt-5` to Codex while sending `claude-*` to Anthropic.

The new model-routing tests construct multiple mounted credential readers, verify that only live credentials join the catalog, and assert that `gpt-5` selects the Codex reader while an unavailable Claude model is rejected.

## Tests

- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features`
- `cargo test --doc`
- `rust-script scripts/check-file-size.rs`

Closes #71
