### PR TITLE
feat: configure local Codex and Claude clients

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-10T08:57:27.006Z for PR creation at branch issue-69-c19c2eac4c50 for issue https://github.com/link-assistant/router/issues/69

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-10T08:57:27.006Z for PR creation at branch issue-69-c19c2eac4c50 for issue https://github.com/link-assistant/router/issues/69

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1409,6 +1409,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-test",
+ "toml_edit",
  "tower",
  "tower-http 0.7.0",
  "tracing",
@@ -2637,6 +2638,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.10+spec-1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3297,6 +3335,21 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ reqwest = { version = "0.13", features = ["stream", "json", "form", "query"] }
 tokio = { version = "1.52", features = ["rt-multi-thread", "macros", "time", "signal", "fs", "process", "sync"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+toml_edit = "0.23"
 jsonwebtoken = { version = "10.0", default-features = false, features = ["rust_crypto"] }
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.0", features = ["v4"] }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Link.Assistant.Router is a transparent proxy that sits between API clients (such
 - **Persistent token store** — text (Lino) **and** binary backends, both on by default; tokens survive restarts
 - **Live observability** — Prometheus `/metrics`, JSON `/v1/usage`, per-account health at `/v1/accounts`
 - **`lino-arguments` + `.lenv`** — every flag has an env-var alias and an optional `.lenv` file fallback
-- **First-class CLI** — `serve`, `tokens issue|list|revoke|expire|show`, `providers add|list|show|remove|import`, `accounts list`, `doctor` subcommands
+- **First-class CLI** — `serve`, token/provider/account management, `clients list|setup|show|remove|doctor`, and deployment diagnostics
 - **Replaces custom tokens with real OAuth credentials** internally, so the OAuth token is never exposed to clients
 - **Runs as a single Docker container** for easy deployment
 
@@ -700,6 +700,14 @@ link-assistant-router accounts list
 link-assistant-router providers add --name litellm --base-url http://litellm:4000/v1 --model claude-sonnet
 link-assistant-router providers import providers.lenv
 link-assistant-router providers list
+
+# Safely configure Codex CLI or Claude Code against this router:
+link-assistant-router clients list
+link-assistant-router clients setup codex
+link-assistant-router clients setup claude-code --token la_sk_...
+link-assistant-router clients show codex
+link-assistant-router clients doctor codex
+link-assistant-router clients remove codex
 
 # Print resolved configuration + credential / store probes:
 link-assistant-router doctor

--- a/changelog.d/20260810_093000_clients_subcommand.md
+++ b/changelog.d/20260810_093000_clients_subcommand.md
@@ -1,0 +1,6 @@
+---
+bump: minor
+---
+
+### Added
+- Add `clients list|setup|show|remove|doctor` for safely configuring Codex CLI and Claude Code against the router.

--- a/docs/use-cases/README.md
+++ b/docs/use-cases/README.md
@@ -22,6 +22,11 @@ come first; the per-CLI documents follow.
 
 ## Per-CLI configuration
 
+Use [`configure-clients.md`](configure-clients.md) to configure Codex CLI or
+Claude Code automatically with safe merge, backup, removal, and live diagnosis.
+The individual documents below also describe manual configuration and protocol
+details.
+
 | Document | CLI | Dialect it speaks to the router |
 | --- | --- | --- |
 | [cli-claude-code.md](cli-claude-code.md) | Claude Code | Anthropic Messages |

--- a/docs/use-cases/cli-claude-code.md
+++ b/docs/use-cases/cli-claude-code.md
@@ -4,6 +4,15 @@
 
 ## Configuration
 
+Automatic setup (merges the router URL and backs up an existing settings file):
+
+```bash
+eval "$(link-assistant-router clients setup claude-code | grep '^export ')"
+```
+
+See [configure-clients.md](configure-clients.md) for show, remove, and doctor.
+For manual or per-task setup, export the variables directly.
+
 Claude Code's [settings reference](https://code.claude.com/docs/en/settings)
 documents the two variables that matter:
 

--- a/docs/use-cases/cli-codex.md
+++ b/docs/use-cases/cli-codex.md
@@ -10,6 +10,15 @@ for this CLI.
 
 ## Configuration
 
+Automatic setup (merges this provider and backs up an existing config):
+
+```bash
+eval "$(link-assistant-router clients setup codex | grep '^export ')"
+```
+
+See [configure-clients.md](configure-clients.md) for show, remove, and doctor.
+For manual setup, use the following configuration.
+
 `~/.codex/config.toml`:
 
 ```toml

--- a/docs/use-cases/configure-clients.md
+++ b/docs/use-cases/configure-clients.md
@@ -1,0 +1,44 @@
+# Configure local agentic CLIs
+
+The `clients` command configures the first two supported local clients without
+replacing unrelated user settings:
+
+```bash
+link-assistant-router clients list
+link-assistant-router clients setup codex
+link-assistant-router clients setup claude-code --token la_sk_...
+link-assistant-router clients show codex
+link-assistant-router clients doctor codex
+link-assistant-router clients remove codex
+```
+
+`setup` mints a 24-hour router token unless `--token` supplies one. The token is
+shown once as a shell `export` command and is **not written to either client
+configuration**. Export it in every shell that launches the client. Use
+`--ttl-hours` to change the minted token lifetime and `--base-url` when the
+router is not reachable at the local CLI host and port.
+
+| Client | File changed | Router-owned setting | Token variable | Dialect |
+| --- | --- | --- | --- | --- |
+| Codex CLI | `$CODEX_HOME/config.toml`, or `~/.codex/config.toml` | `model_provider = "link-assistant"` and `[model_providers.link-assistant]` | `LINK_ASSISTANT_TOKEN` via `env_key` | Responses |
+| Claude Code | `$CLAUDE_CONFIG_DIR/settings.json`, or `~/.claude/settings.json` | `env.ANTHROPIC_BASE_URL` | `ANTHROPIC_AUTH_TOKEN` in the launching shell | Anthropic Messages |
+
+Before changing an existing config, the command creates a sibling timestamped
+`*.link-assistant-router.*.bak` file. JSON objects, TOML tables, comments and
+unknown settings are preserved. Running `setup` again updates the same entry;
+it never creates a duplicate.
+
+`remove` deletes only the provider and selection owned by the router for Codex.
+For Claude Code it removes `ANTHROPIC_BASE_URL` only when it still matches the
+value recorded by `setup`; if the user changed that setting later, it is left
+alone. Other environment keys and settings remain untouched.
+
+`show` reports the path, URL, dialect, installed/configured state, and whether
+the expected token variable is set, but never prints its value. `doctor` sends
+one minimal request to the configured endpoint and distinguishes missing
+configuration, missing token environment, an unreachable router, rejected
+tokens, unavailable upstream credentials, and other HTTP failures.
+
+The current milestone supports `codex` and `claude-code`. The other clients in
+this directory remain documented for manual setup and can be added to the same
+command structure later.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,6 +11,7 @@
 //! - `tokens issue|list|revoke|expire|show` — manage persistent tokens
 //!   without going through the HTTP layer (useful for ops scripts).
 //! - `accounts list` — show configured accounts and their health.
+//! - `clients list|setup|show|remove|doctor` — configure local agentic CLIs.
 //! - `doctor` — report on environment, OAuth credential discoverability,
 //!   storage paths, and other config.
 
@@ -25,6 +26,7 @@ use std::time::Duration;
 use clap::Subcommand;
 use lino_arguments::Parser as LinoParser;
 
+use crate::clients::ClientKind;
 use crate::config::{
     ApiFormat, BuildArgs, Config, ConfigError, RoutingMode, StoragePolicy, UpstreamProvider,
     default_activitypub_public_key_pem, default_data_dir,
@@ -435,6 +437,11 @@ pub enum Command {
         #[command(subcommand)]
         op: ProviderOp,
     },
+    /// Configure local agentic CLIs to use this router.
+    Clients {
+        #[command(subcommand)]
+        op: ClientOp,
+    },
     /// Print environment + config diagnostics.
     Doctor,
 }
@@ -512,6 +519,41 @@ pub enum ProviderOp {
     Remove { name: String },
     /// Import providers from JSON, `.lenv`, or indented Links-style config.
     Import { path: PathBuf },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum ClientOp {
+    /// List supported clients and their local installation/configuration state.
+    List,
+    /// Merge this router into a client's user configuration.
+    Setup {
+        #[arg(value_enum)]
+        client: ClientKind,
+        /// Existing router token. Omit to mint one in the configured token store.
+        #[arg(long)]
+        token: Option<String>,
+        /// Router URL reachable from the client (defaults to this CLI's host/port).
+        #[arg(long)]
+        base_url: Option<String>,
+        /// Lifetime of an automatically minted token.
+        #[arg(long, default_value_t = 24)]
+        ttl_hours: i64,
+    },
+    /// Show the effective client integration with secrets redacted.
+    Show {
+        #[arg(value_enum)]
+        client: ClientKind,
+    },
+    /// Remove only settings managed by this router.
+    Remove {
+        #[arg(value_enum)]
+        client: ClientKind,
+    },
+    /// Make a real request using the client's configured URL and token variable.
+    Doctor {
+        #[arg(value_enum)]
+        client: ClientKind,
+    },
 }
 
 impl Cli {

--- a/src/client_command.rs
+++ b/src/client_command.rs
@@ -1,0 +1,181 @@
+//! Output and dispatch layer for the `clients` CLI command.
+
+use std::process::ExitCode;
+
+use crate::cli::ClientOp;
+use crate::clients::{ClientKind, ClientManager};
+use crate::config::Config;
+use crate::storage::build_token_store;
+use crate::token::{IssueRequest, TokenManager};
+
+/// Run one local client-management operation.
+pub async fn run(config: &Config, op: &ClientOp) -> ExitCode {
+    let manager = match ClientManager::from_env() {
+        Ok(manager) => manager,
+        Err(error) => return failed(error),
+    };
+    match op {
+        ClientOp::List => list(&manager),
+        ClientOp::Setup {
+            client,
+            token,
+            base_url,
+            ttl_hours,
+        } => setup(
+            config,
+            &manager,
+            *client,
+            token.as_deref(),
+            base_url.as_deref(),
+            *ttl_hours,
+        ),
+        ClientOp::Show { client } => show(&manager, *client),
+        ClientOp::Remove { client } => remove(&manager, *client),
+        ClientOp::Doctor { client } => match manager.doctor(*client).await {
+            Ok(message) => {
+                println!("ok: {message}");
+                ExitCode::SUCCESS
+            }
+            Err(error) => failed(error),
+        },
+    }
+}
+
+fn list(manager: &ClientManager) -> ExitCode {
+    println!(
+        "{:<12}  {:<9}  {:<11}  {:<19}  config",
+        "client", "installed", "configured", "dialect"
+    );
+    for client in ClientKind::ALL {
+        match manager.status(client) {
+            Ok(status) => println!(
+                "{:<12}  {:<9}  {:<11}  {:<19}  {}",
+                status.client,
+                status.installed,
+                status.configured,
+                status.dialect,
+                status.config_path.display()
+            ),
+            Err(error) => return failed(format!("could not read {client}: {error}")),
+        }
+    }
+    ExitCode::SUCCESS
+}
+
+fn setup(
+    config: &Config,
+    manager: &ClientManager,
+    client: ClientKind,
+    supplied_token: Option<&str>,
+    base_url: Option<&str>,
+    ttl_hours: i64,
+) -> ExitCode {
+    if supplied_token.is_some_and(|token| !token.starts_with("la_sk_")) {
+        eprintln!("error: --token must be a router token beginning with la_sk_");
+        return ExitCode::from(2);
+    }
+    let base_url = base_url.map_or_else(|| local_client_base_url(config), str::to_string);
+    let result = match manager.setup(client, &base_url) {
+        Ok(result) => result,
+        Err(error) => return failed(error),
+    };
+    let token = match supplied_token {
+        Some(token) => token.to_string(),
+        None => match issue_client_token(config, client, ttl_hours) {
+            Ok(token) => token,
+            Err(error) => return failed(error),
+        },
+    };
+    if result.changed {
+        println!(
+            "configured {} in {}",
+            client.display_name(),
+            result.path.display()
+        );
+    } else {
+        println!(
+            "{} is already configured in {}",
+            client.display_name(),
+            result.path.display()
+        );
+    }
+    if let Some(backup) = result.backup {
+        println!("backup: {}", backup.display());
+    }
+    println!("export {}={}", client.token_env(), shell_quote(&token));
+    println!(
+        "The token is not stored in the client config; export it in each shell that launches {}.",
+        client.display_name()
+    );
+    ExitCode::SUCCESS
+}
+
+fn show(manager: &ClientManager, client: ClientKind) -> ExitCode {
+    match manager.status(client) {
+        Ok(status) => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&status).unwrap_or_default()
+            );
+            ExitCode::SUCCESS
+        }
+        Err(error) => failed(error),
+    }
+}
+
+fn remove(manager: &ClientManager, client: ClientKind) -> ExitCode {
+    match manager.remove(client) {
+        Ok(result) => {
+            if result.changed {
+                println!("removed router settings from {}", result.path.display());
+            } else {
+                println!(
+                    "no managed router settings found in {}",
+                    result.path.display()
+                );
+            }
+            if let Some(backup) = result.backup {
+                println!("backup: {}", backup.display());
+            }
+            ExitCode::SUCCESS
+        }
+        Err(error) => failed(error),
+    }
+}
+
+fn issue_client_token(
+    config: &Config,
+    client: ClientKind,
+    ttl_hours: i64,
+) -> Result<String, Box<dyn std::error::Error>> {
+    if !config.data_dir.exists() {
+        std::fs::create_dir_all(&config.data_dir)?;
+    }
+    let store = build_token_store(config.storage_policy, &config.data_dir)?;
+    let manager = TokenManager::with_store(&config.token_secret, store);
+    Ok(manager.issue(&IssueRequest {
+        ttl_hours,
+        label: &format!("client-{client}"),
+        account: None,
+        max_requests: None,
+        scope: "",
+    })?)
+}
+
+fn local_client_base_url(config: &Config) -> String {
+    let host = match config.listen_addr.ip() {
+        std::net::IpAddr::V4(ip) if ip.is_unspecified() => "127.0.0.1".to_string(),
+        std::net::IpAddr::V6(ip) if ip.is_unspecified() => "[::1]".to_string(),
+        ip => ip.to_string(),
+    };
+    format!("http://{host}:{}", config.listen_addr.port())
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn failed(error: impl std::fmt::Display) -> ExitCode {
+    eprintln!("error: {error}");
+    ExitCode::from(1)
+}

--- a/src/clients.rs
+++ b/src/clients.rs
@@ -1,0 +1,610 @@
+//! Safe local configuration for agentic CLI clients.
+//!
+//! The writer deliberately owns only one Codex provider table and one Claude
+//! Code environment key. Unknown settings are parsed and merged, never
+//! replaced wholesale, and every changed existing file is backed up first.
+
+use std::fmt;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use clap::ValueEnum;
+use serde::Serialize;
+use serde_json::{Value, json};
+use toml_edit::{DocumentMut, Item, Table, value};
+
+const CODEX_PROVIDER: &str = "link-assistant";
+const CODEX_TOKEN_ENV: &str = "LINK_ASSISTANT_TOKEN";
+const CLAUDE_TOKEN_ENV: &str = "ANTHROPIC_AUTH_TOKEN";
+const CLAUDE_BASE_ENV: &str = "ANTHROPIC_BASE_URL";
+const OWNERSHIP_MARKER: &str = ".link-assistant-router-client.json";
+
+/// Clients currently supported by the first issue #69 milestone.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum ClientKind {
+    Codex,
+    ClaudeCode,
+}
+
+impl ClientKind {
+    pub const ALL: [Self; 2] = [Self::Codex, Self::ClaudeCode];
+
+    #[must_use]
+    pub const fn command(self) -> &'static str {
+        match self {
+            Self::Codex => "codex",
+            Self::ClaudeCode => "claude",
+        }
+    }
+
+    #[must_use]
+    pub const fn display_name(self) -> &'static str {
+        match self {
+            Self::Codex => "Codex CLI",
+            Self::ClaudeCode => "Claude Code",
+        }
+    }
+
+    #[must_use]
+    pub const fn dialect(self) -> &'static str {
+        match self {
+            Self::Codex => "OpenAI Responses",
+            Self::ClaudeCode => "Anthropic Messages",
+        }
+    }
+
+    #[must_use]
+    pub const fn token_env(self) -> &'static str {
+        match self {
+            Self::Codex => CODEX_TOKEN_ENV,
+            Self::ClaudeCode => CLAUDE_TOKEN_ENV,
+        }
+    }
+}
+
+impl fmt::Display for ClientKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Codex => write!(f, "codex"),
+            Self::ClaudeCode => write!(f, "claude-code"),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ClientError(String);
+
+impl ClientError {
+    fn message(message: impl Into<String>) -> Self {
+        Self(message.into())
+    }
+}
+
+impl fmt::Display for ClientError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for ClientError {}
+
+impl From<std::io::Error> for ClientError {
+    fn from(error: std::io::Error) -> Self {
+        Self(error.to_string())
+    }
+}
+
+impl From<serde_json::Error> for ClientError {
+    fn from(error: serde_json::Error) -> Self {
+        Self(error.to_string())
+    }
+}
+
+/// Secret-free state returned by `clients list` and `clients show`.
+#[derive(Debug, Serialize)]
+pub struct ClientStatus {
+    pub client: String,
+    pub installed: bool,
+    pub configured: bool,
+    pub config_path: PathBuf,
+    pub dialect: &'static str,
+    pub base_url: Option<String>,
+    pub token_env: &'static str,
+    pub token_env_set: bool,
+}
+
+/// Result of a successful setup operation.
+#[derive(Debug)]
+pub struct SetupResult {
+    pub path: PathBuf,
+    pub backup: Option<PathBuf>,
+    pub changed: bool,
+}
+
+/// Reads and updates supported clients below their normal user config roots.
+#[derive(Debug)]
+pub struct ClientManager {
+    codex_home: PathBuf,
+    claude_home: PathBuf,
+}
+
+impl ClientManager {
+    /// Resolve client directories, respecting the clients' own override vars.
+    pub fn from_env() -> Result<Self, ClientError> {
+        let home = std::env::var_os("HOME")
+            .map(PathBuf::from)
+            .ok_or_else(|| ClientError::message("HOME is unset; cannot locate client configs"))?;
+        let codex_home =
+            std::env::var_os("CODEX_HOME").map_or_else(|| home.join(".codex"), PathBuf::from);
+        let claude_home = std::env::var_os("CLAUDE_CONFIG_DIR")
+            .map_or_else(|| home.join(".claude"), PathBuf::from);
+        Ok(Self {
+            codex_home,
+            claude_home,
+        })
+    }
+
+    #[must_use]
+    pub fn config_path(&self, client: ClientKind) -> PathBuf {
+        match client {
+            ClientKind::Codex => self.codex_home.join("config.toml"),
+            ClientKind::ClaudeCode => self.claude_home.join("settings.json"),
+        }
+    }
+
+    pub fn status(&self, client: ClientKind) -> Result<ClientStatus, ClientError> {
+        let path = self.config_path(client);
+        let base_url = match client {
+            ClientKind::Codex => read_codex_base_url(&path)?,
+            ClientKind::ClaudeCode => read_claude_base_url(&path)?,
+        };
+        Ok(ClientStatus {
+            client: client.to_string(),
+            installed: command_exists(client.command()),
+            configured: base_url.is_some(),
+            config_path: path,
+            dialect: client.dialect(),
+            base_url,
+            token_env: client.token_env(),
+            token_env_set: std::env::var_os(client.token_env()).is_some(),
+        })
+    }
+
+    pub fn setup(&self, client: ClientKind, base_url: &str) -> Result<SetupResult, ClientError> {
+        let base_url = normalize_base_url(base_url)?;
+        match client {
+            ClientKind::Codex => self.setup_codex(&base_url),
+            ClientKind::ClaudeCode => self.setup_claude(&base_url),
+        }
+    }
+
+    pub fn remove(&self, client: ClientKind) -> Result<SetupResult, ClientError> {
+        match client {
+            ClientKind::Codex => self.remove_codex(),
+            ClientKind::ClaudeCode => self.remove_claude(),
+        }
+    }
+
+    /// Exercise the same URL and token variable configured for the client.
+    pub async fn doctor(&self, client: ClientKind) -> Result<String, ClientError> {
+        let status = self.status(client)?;
+        let base_url = status.base_url.ok_or_else(|| {
+            ClientError::message(format!(
+                "{} is not configured; run `clients setup {client}`",
+                client.display_name()
+            ))
+        })?;
+        let token = std::env::var(client.token_env()).map_err(|_| {
+            ClientError::message(format!(
+                "{} is unset; export the token printed by `clients setup {client}`",
+                client.token_env()
+            ))
+        })?;
+        let (url, body) = match client {
+            ClientKind::Codex => (
+                format!("{}/responses", base_url.trim_end_matches('/')),
+                json!({"model":"gpt-5", "input":"Reply OK", "max_output_tokens":1}),
+            ),
+            ClientKind::ClaudeCode => (
+                format!("{}/v1/messages", base_url.trim_end_matches('/')),
+                json!({
+                    "model":"claude-sonnet-4-5-20250929",
+                    "max_tokens":1,
+                    "messages":[{"role":"user", "content":"Reply OK"}]
+                }),
+            ),
+        };
+        let response = reqwest::Client::new()
+            .post(&url)
+            .bearer_auth(token)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|error| {
+                ClientError::message(format!("router is not reachable at {url}: {error}"))
+            })?;
+        let code = response.status();
+        let response_body = response.text().await.unwrap_or_default();
+        if code.is_success() {
+            return Ok(format!(
+                "{} reached {url} successfully ({code})",
+                client.display_name()
+            ));
+        }
+        if code.as_u16() == 401 || code.as_u16() == 403 {
+            return Err(ClientError::message(format!(
+                "router rejected {} ({code}); the token is invalid, expired, or revoked",
+                client.token_env()
+            )));
+        }
+        if code.as_u16() == 503 {
+            return Err(ClientError::message(format!(
+                "router reached, but its upstream credential is unavailable ({code}): {}",
+                compact_body(&response_body)
+            )));
+        }
+        Err(ClientError::message(format!(
+            "router request failed at {url} ({code}): {}",
+            compact_body(&response_body)
+        )))
+    }
+
+    fn setup_codex(&self, base_url: &str) -> Result<SetupResult, ClientError> {
+        let path = self.config_path(ClientKind::Codex);
+        let source = read_or_empty(&path)?;
+        let mut document = if source.trim().is_empty() {
+            DocumentMut::new()
+        } else {
+            source.parse::<DocumentMut>().map_err(|error| {
+                ClientError::message(format!("invalid TOML in {}: {error}", path.display()))
+            })?
+        };
+        let previous_provider = document
+            .get("model_provider")
+            .and_then(Item::as_str)
+            .map(str::to_string);
+        document["model_provider"] = value(CODEX_PROVIDER);
+        if document.get("model_providers").is_none() {
+            document["model_providers"] = Item::Table(Table::new());
+        }
+        let providers = document["model_providers"]
+            .as_table_like_mut()
+            .ok_or_else(|| ClientError::message("model_providers must be a TOML table"))?;
+        if providers.get(CODEX_PROVIDER).is_none() {
+            providers.insert(CODEX_PROVIDER, Item::Table(Table::new()));
+        }
+        let provider = providers
+            .get_mut(CODEX_PROVIDER)
+            .and_then(Item::as_table_like_mut)
+            .ok_or_else(|| {
+                ClientError::message("model_providers.link-assistant must be a TOML table")
+            })?;
+        provider.insert("name", value("Link.Assistant.Router"));
+        provider.insert("base_url", value(format!("{base_url}/v1")));
+        provider.insert("env_key", value(CODEX_TOKEN_ENV));
+        provider.insert("wire_api", value("responses"));
+        let result = write_if_changed(&path, &source, &document.to_string())?;
+        let marker = self.codex_home.join(OWNERSHIP_MARKER);
+        if !marker.exists() {
+            let previous_provider = previous_provider.filter(|value| value != CODEX_PROVIDER);
+            write_codex_marker(&marker, previous_provider.as_deref())?;
+        }
+        Ok(result)
+    }
+
+    fn setup_claude(&self, base_url: &str) -> Result<SetupResult, ClientError> {
+        let path = self.config_path(ClientKind::ClaudeCode);
+        let source = read_or_empty(&path)?;
+        let mut document: Value = if source.trim().is_empty() {
+            json!({})
+        } else {
+            serde_json::from_str(&source).map_err(|error| {
+                ClientError::message(format!("invalid JSON in {}: {error}", path.display()))
+            })?
+        };
+        let root = document.as_object_mut().ok_or_else(|| {
+            ClientError::message(format!("{} must contain a JSON object", path.display()))
+        })?;
+        let env = root.entry("env").or_insert_with(|| json!({}));
+        let env = env.as_object_mut().ok_or_else(|| {
+            ClientError::message(format!("{}.env must be a JSON object", path.display()))
+        })?;
+        env.insert(CLAUDE_BASE_ENV.into(), Value::String(base_url.into()));
+        let rendered = format!("{}\n", serde_json::to_string_pretty(&document)?);
+        let result = write_if_changed(&path, &source, &rendered)?;
+        write_claude_marker(&self.claude_home.join(OWNERSHIP_MARKER), base_url)?;
+        Ok(result)
+    }
+
+    fn remove_codex(&self) -> Result<SetupResult, ClientError> {
+        let path = self.config_path(ClientKind::Codex);
+        let source = read_or_empty(&path)?;
+        if source.trim().is_empty() {
+            return Ok(unchanged(path));
+        }
+        let marker_path = self.codex_home.join(OWNERSHIP_MARKER);
+        if !marker_path.exists() {
+            return Ok(unchanged(path));
+        }
+        let mut document = source.parse::<DocumentMut>().map_err(|error| {
+            ClientError::message(format!("invalid TOML in {}: {error}", path.display()))
+        })?;
+        let previous_provider = read_codex_marker(&marker_path)?;
+        if document.get("model_provider").and_then(Item::as_str) == Some(CODEX_PROVIDER) {
+            if let Some(previous_provider) = previous_provider {
+                document["model_provider"] = value(previous_provider);
+            } else {
+                document.as_table_mut().remove("model_provider");
+            }
+        }
+        if let Some(providers) = document
+            .get_mut("model_providers")
+            .and_then(Item::as_table_like_mut)
+        {
+            providers.remove(CODEX_PROVIDER);
+        }
+        let result = write_if_changed(&path, &source, &document.to_string())?;
+        if marker_path.exists() {
+            fs::remove_file(marker_path)?;
+        }
+        Ok(result)
+    }
+
+    fn remove_claude(&self) -> Result<SetupResult, ClientError> {
+        let path = self.config_path(ClientKind::ClaudeCode);
+        let source = read_or_empty(&path)?;
+        if source.trim().is_empty() {
+            return Ok(unchanged(path));
+        }
+        let marker_path = self.claude_home.join(OWNERSHIP_MARKER);
+        let managed_url = read_claude_marker(&marker_path)?;
+        let Some(managed_url) = managed_url else {
+            return Ok(unchanged(path));
+        };
+        let mut document: Value = serde_json::from_str(&source).map_err(|error| {
+            ClientError::message(format!("invalid JSON in {}: {error}", path.display()))
+        })?;
+        let current_url = document
+            .get("env")
+            .and_then(|env| env.get(CLAUDE_BASE_ENV))
+            .and_then(Value::as_str);
+        if current_url != Some(managed_url.as_str()) {
+            fs::remove_file(marker_path)?;
+            return Ok(unchanged(path));
+        }
+        if let Some(env) = document.get_mut("env").and_then(Value::as_object_mut) {
+            env.remove(CLAUDE_BASE_ENV);
+        }
+        let rendered = format!("{}\n", serde_json::to_string_pretty(&document)?);
+        let result = write_if_changed(&path, &source, &rendered)?;
+        if marker_path.exists() {
+            fs::remove_file(marker_path)?;
+        }
+        Ok(result)
+    }
+}
+
+fn normalize_base_url(base_url: &str) -> Result<String, ClientError> {
+    let trimmed = base_url.trim().trim_end_matches('/');
+    if !(trimmed.starts_with("http://") || trimmed.starts_with("https://")) {
+        return Err(ClientError::message(
+            "base URL must start with http:// or https://",
+        ));
+    }
+    Ok(trimmed.to_string())
+}
+
+fn read_codex_base_url(path: &Path) -> Result<Option<String>, ClientError> {
+    let source = read_or_empty(path)?;
+    if source.trim().is_empty() {
+        return Ok(None);
+    }
+    let document = source.parse::<DocumentMut>().map_err(|error| {
+        ClientError::message(format!("invalid TOML in {}: {error}", path.display()))
+    })?;
+    if document.get("model_provider").and_then(Item::as_str) != Some(CODEX_PROVIDER) {
+        return Ok(None);
+    }
+    let Some(provider) = document
+        .get("model_providers")
+        .and_then(Item::as_table_like)
+        .and_then(|providers| providers.get(CODEX_PROVIDER))
+    else {
+        return Ok(None);
+    };
+    let Some(provider) = provider.as_table_like() else {
+        return Ok(None);
+    };
+    let configured = provider.get("wire_api").and_then(Item::as_str) == Some("responses")
+        && provider.get("env_key").and_then(Item::as_str) == Some(CODEX_TOKEN_ENV);
+    Ok(configured
+        .then(|| {
+            provider
+                .get("base_url")
+                .and_then(Item::as_str)
+                .map(str::to_string)
+        })
+        .flatten())
+}
+
+fn read_claude_base_url(path: &Path) -> Result<Option<String>, ClientError> {
+    let source = read_or_empty(path)?;
+    if source.trim().is_empty() {
+        return Ok(None);
+    }
+    let document: Value = serde_json::from_str(&source).map_err(|error| {
+        ClientError::message(format!("invalid JSON in {}: {error}", path.display()))
+    })?;
+    Ok(document
+        .get("env")
+        .and_then(|env| env.get(CLAUDE_BASE_ENV))
+        .and_then(Value::as_str)
+        .map(str::to_string))
+}
+
+fn read_or_empty(path: &Path) -> Result<String, ClientError> {
+    match fs::read_to_string(path) {
+        Ok(source) => Ok(source),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(String::new()),
+        Err(error) => Err(ClientError::message(format!(
+            "could not read {}: {error}",
+            path.display()
+        ))),
+    }
+}
+
+fn write_if_changed(path: &Path, before: &str, after: &str) -> Result<SetupResult, ClientError> {
+    if before == after {
+        return Ok(unchanged(path.to_path_buf()));
+    }
+    let parent = path.parent().ok_or_else(|| {
+        ClientError::message(format!("{} has no parent directory", path.display()))
+    })?;
+    fs::create_dir_all(parent)?;
+    let backup = path.exists().then(|| backup_file(path)).transpose()?;
+    atomic_write(path, after.as_bytes())?;
+    Ok(SetupResult {
+        path: path.to_path_buf(),
+        backup,
+        changed: true,
+    })
+}
+
+const fn unchanged(path: PathBuf) -> SetupResult {
+    SetupResult {
+        path,
+        backup: None,
+        changed: false,
+    }
+}
+
+fn backup_file(path: &Path) -> Result<PathBuf, ClientError> {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| ClientError::message("config file name is not valid UTF-8"))?;
+    let backup = path.with_file_name(format!("{file_name}.link-assistant-router.{stamp}.bak"));
+    fs::copy(path, &backup)?;
+    Ok(backup)
+}
+
+fn atomic_write(path: &Path, contents: &[u8]) -> Result<(), ClientError> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| ClientError::message("missing parent directory"))?;
+    let temp = parent.join(format!(
+        ".link-assistant-router.{}.{}.tmp",
+        std::process::id(),
+        uuid::Uuid::new_v4()
+    ));
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(&temp)?;
+    file.write_all(contents)?;
+    file.sync_all()?;
+    if let Ok(metadata) = fs::metadata(path) {
+        fs::set_permissions(&temp, metadata.permissions())?;
+    }
+    fs::rename(&temp, path)?;
+    Ok(())
+}
+
+fn write_claude_marker(path: &Path, base_url: &str) -> Result<(), ClientError> {
+    let rendered = format!(
+        "{}\n",
+        serde_json::to_string_pretty(&json!({
+            "anthropic_base_url": base_url
+        }))?
+    );
+    if read_or_empty(path)? != rendered {
+        let parent = path
+            .parent()
+            .ok_or_else(|| ClientError::message("missing marker parent"))?;
+        fs::create_dir_all(parent)?;
+        atomic_write(path, rendered.as_bytes())?;
+    }
+    Ok(())
+}
+
+fn read_claude_marker(path: &Path) -> Result<Option<String>, ClientError> {
+    let source = read_or_empty(path)?;
+    if source.trim().is_empty() {
+        return Ok(None);
+    }
+    let marker: Value = serde_json::from_str(&source)?;
+    Ok(marker
+        .get("anthropic_base_url")
+        .and_then(Value::as_str)
+        .map(str::to_string))
+}
+
+fn write_codex_marker(path: &Path, previous_provider: Option<&str>) -> Result<(), ClientError> {
+    let rendered = format!(
+        "{}\n",
+        serde_json::to_string_pretty(&json!({
+            "previous_model_provider": previous_provider
+        }))?
+    );
+    let parent = path
+        .parent()
+        .ok_or_else(|| ClientError::message("missing marker parent"))?;
+    fs::create_dir_all(parent)?;
+    atomic_write(path, rendered.as_bytes())
+}
+
+fn read_codex_marker(path: &Path) -> Result<Option<String>, ClientError> {
+    let source = read_or_empty(path)?;
+    if source.trim().is_empty() {
+        return Ok(None);
+    }
+    let marker: Value = serde_json::from_str(&source)?;
+    Ok(marker
+        .get("previous_model_provider")
+        .and_then(Value::as_str)
+        .map(str::to_string))
+}
+
+fn command_exists(command: &str) -> bool {
+    std::env::var_os("PATH").is_some_and(|path| {
+        std::env::split_paths(&path).any(|directory| directory.join(command).is_file())
+    })
+}
+
+fn compact_body(body: &str) -> String {
+    const MAX: usize = 240;
+    let compact = body.split_whitespace().collect::<Vec<_>>().join(" ");
+    if compact.chars().count() <= MAX {
+        compact
+    } else {
+        format!("{}…", compact.chars().take(MAX).collect::<String>())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_non_http_router_urls() {
+        assert!(normalize_base_url("router.internal:8080").is_err());
+    }
+
+    #[test]
+    fn compact_diagnostics_do_not_echo_unbounded_upstream_bodies() {
+        let body = "x".repeat(500);
+        let compact = compact_body(&body);
+        assert!(compact.ends_with('…'));
+        assert!(compact.chars().count() <= 241);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,8 @@ pub mod chat_commands;
 pub mod chat_config;
 pub mod claude_identity;
 pub mod cli;
+pub mod client_command;
+pub mod clients;
 pub mod config;
 pub mod config_defaults;
 pub mod crater;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@
 //! Parses the [`Cli`] (lino-arguments + clap), then either:
 //!
 //! 1. Runs the HTTP server (default — `Command::Serve` or no subcommand), or
-//! 2. Dispatches a CLI subcommand (`tokens`, `accounts`, `doctor`) that runs
+//! 2. Dispatches a CLI subcommand (`tokens`, `accounts`, `clients`, `doctor`) that runs
 //!    locally and exits without binding a port.
 //!
 //! All shared services (config, token store, multi-account router, metrics)
@@ -73,6 +73,9 @@ async fn main() -> ExitCode {
         Some(Command::Tokens { op }) => run_tokens(&config, op),
         Some(Command::Accounts { op }) => run_accounts(&config, op),
         Some(Command::Providers { op }) => run_providers(&config, op),
+        Some(Command::Clients { op }) => {
+            link_assistant_router::client_command::run(&config, op).await
+        }
         Some(Command::Doctor) => run_doctor(&config),
     }
 }

--- a/tests/clients_cli_test.rs
+++ b/tests/clients_cli_test.rs
@@ -1,0 +1,292 @@
+//! Black-box coverage for the local client configurator from issue #69.
+
+use std::fs;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::process::{Command, Output};
+use std::time::Duration;
+
+fn router(home: &std::path::Path, args: &[&str]) -> Output {
+    router_with_env(home, args, &[])
+}
+
+fn router_with_env(home: &std::path::Path, args: &[&str], env: &[(&str, &str)]) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_link-assistant-router"));
+    command
+        .args(args)
+        .env("HOME", home)
+        .env("TOKEN_SECRET", "clients-cli-test-secret")
+        .env("DATA_DIR", home.join("router-data"))
+        .env("STORAGE_POLICY", "text");
+    for (key, value) in env {
+        command.env(key, value);
+    }
+    command.output().expect("router CLI should run")
+}
+
+#[test]
+fn codex_setup_merges_idempotently_and_remove_is_surgical() {
+    let home = tempfile::tempdir().expect("temp home");
+    let codex_dir = home.path().join(".codex");
+    fs::create_dir_all(&codex_dir).expect("create codex dir");
+    fs::write(
+        codex_dir.join("config.toml"),
+        "model = \"user-model\"\nmodel_provider = \"user-provider\"\napproval_policy = \"never\"\n\n[model_providers.user-provider]\nname = \"Mine\"\nbase_url = \"http://mine.test/v1\"\n\n[custom]\nkeep = true\n",
+    )
+    .expect("seed config");
+
+    let args = [
+        "clients",
+        "setup",
+        "codex",
+        "--token",
+        "la_sk_existing",
+        "--base-url",
+        "http://router.test:8080",
+    ];
+    let first = router(home.path(), &args);
+    assert!(
+        first.status.success(),
+        "{}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+    let configured = fs::read_to_string(codex_dir.join("config.toml")).expect("read config");
+    assert!(configured.contains("approval_policy = \"never\""));
+    assert!(configured.contains("[custom]"));
+    assert!(configured.contains("[model_providers.link-assistant]"));
+    assert!(configured.contains("wire_api = \"responses\""));
+    assert!(configured.contains("env_key = \"LINK_ASSISTANT_TOKEN\""));
+    assert!(
+        !configured.contains("la_sk_existing"),
+        "secret leaked into config"
+    );
+    assert!(String::from_utf8_lossy(&first.stdout).contains("LINK_ASSISTANT_TOKEN"));
+    assert!(
+        fs::read_dir(&codex_dir)
+            .expect("list codex dir")
+            .filter_map(Result::ok)
+            .any(|entry| entry.file_name().to_string_lossy().ends_with(".bak")),
+        "a changed existing config must be backed up"
+    );
+
+    let second = router(home.path(), &args);
+    assert!(second.status.success());
+    let configured_again = fs::read_to_string(codex_dir.join("config.toml")).expect("read config");
+    assert_eq!(configured, configured_again, "setup must be idempotent");
+
+    let removed = router(home.path(), &["clients", "remove", "codex"]);
+    assert!(removed.status.success());
+    let after_remove = fs::read_to_string(codex_dir.join("config.toml")).expect("read config");
+    assert!(after_remove.contains("model = \"user-model\""));
+    assert!(after_remove.contains("model_provider = \"user-provider\""));
+    assert!(after_remove.contains("[model_providers.user-provider]"));
+    assert!(after_remove.contains("approval_policy = \"never\""));
+    assert!(after_remove.contains("[custom]"));
+    assert!(!after_remove.contains("model_providers.link-assistant"));
+}
+
+#[test]
+fn claude_code_setup_preserves_settings_without_storing_the_token() {
+    let home = tempfile::tempdir().expect("temp home");
+    let claude_dir = home.path().join(".claude");
+    fs::create_dir_all(&claude_dir).expect("create claude dir");
+    fs::write(
+        claude_dir.join("settings.json"),
+        r#"{"permissions":{"allow":["Read"]},"env":{"KEEP_ME":"yes"}}"#,
+    )
+    .expect("seed settings");
+
+    let setup = router(
+        home.path(),
+        &[
+            "clients",
+            "setup",
+            "claude-code",
+            "--token",
+            "la_sk_existing",
+            "--base-url",
+            "http://router.test:8080/",
+        ],
+    );
+    assert!(
+        setup.status.success(),
+        "{}",
+        String::from_utf8_lossy(&setup.stderr)
+    );
+
+    let settings: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(claude_dir.join("settings.json")).expect("read settings"),
+    )
+    .expect("valid JSON");
+    assert_eq!(settings["permissions"]["allow"][0], "Read");
+    assert_eq!(settings["env"]["KEEP_ME"], "yes");
+    assert_eq!(
+        settings["env"]["ANTHROPIC_BASE_URL"],
+        "http://router.test:8080"
+    );
+    assert!(settings["env"].get("ANTHROPIC_AUTH_TOKEN").is_none());
+    assert!(!settings.to_string().contains("la_sk_existing"));
+    assert!(String::from_utf8_lossy(&setup.stdout).contains("ANTHROPIC_AUTH_TOKEN"));
+
+    let removed = router(home.path(), &["clients", "remove", "claude-code"]);
+    assert!(removed.status.success());
+    let settings: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(claude_dir.join("settings.json")).expect("read settings"),
+    )
+    .expect("valid JSON");
+    assert_eq!(settings["env"]["KEEP_ME"], "yes");
+    assert!(settings["env"].get("ANTHROPIC_BASE_URL").is_none());
+}
+
+#[test]
+fn claude_remove_without_an_ownership_marker_is_a_noop() {
+    let home = tempfile::tempdir().expect("temp home");
+    let claude_dir = home.path().join(".claude");
+    fs::create_dir_all(&claude_dir).expect("create claude dir");
+    let original = r#"{"env":{"ANTHROPIC_BASE_URL":"http://someone-elses-router"}}"#;
+    fs::write(claude_dir.join("settings.json"), original).expect("seed settings");
+
+    let removed = router(home.path(), &["clients", "remove", "claude-code"]);
+    assert!(removed.status.success());
+    assert_eq!(
+        fs::read_to_string(claude_dir.join("settings.json")).expect("read settings"),
+        original
+    );
+}
+
+#[test]
+fn codex_remove_without_an_ownership_marker_is_a_noop() {
+    let home = tempfile::tempdir().expect("temp home");
+    let codex_dir = home.path().join(".codex");
+    fs::create_dir_all(&codex_dir).expect("create codex dir");
+    let original = "model_provider = \"link-assistant\"\n\n[model_providers.link-assistant]\nbase_url = \"http://someone-elses-router/v1\"\n";
+    fs::write(codex_dir.join("config.toml"), original).expect("seed config");
+
+    let removed = router(home.path(), &["clients", "remove", "codex"]);
+    assert!(removed.status.success());
+    assert_eq!(
+        fs::read_to_string(codex_dir.join("config.toml")).expect("read config"),
+        original
+    );
+}
+
+#[test]
+fn setup_can_mint_a_persisted_token_and_status_never_discloses_it() {
+    let home = tempfile::tempdir().expect("temp home");
+    let setup = router(
+        home.path(),
+        &[
+            "clients",
+            "setup",
+            "codex",
+            "--base-url",
+            "http://router.test:8080",
+        ],
+    );
+    assert!(
+        setup.status.success(),
+        "{}",
+        String::from_utf8_lossy(&setup.stderr)
+    );
+    let output = String::from_utf8_lossy(&setup.stdout);
+    assert!(output.contains("export LINK_ASSISTANT_TOKEN='la_sk_"));
+
+    let tokens = router(home.path(), &["tokens", "list"]);
+    assert!(tokens.status.success());
+    assert!(String::from_utf8_lossy(&tokens.stdout).contains("client-codex"));
+
+    let show = router(home.path(), &["clients", "show", "codex"]);
+    assert!(show.status.success());
+    let shown = String::from_utf8_lossy(&show.stdout);
+    assert!(shown.contains("\"configured\": true"));
+    assert!(shown.contains("\"token_env\": \"LINK_ASSISTANT_TOKEN\""));
+    assert!(!shown.contains("la_sk_"));
+
+    let doctor = router(home.path(), &["clients", "doctor", "codex"]);
+    assert!(!doctor.status.success());
+    let diagnostic = String::from_utf8_lossy(&doctor.stderr);
+    assert!(diagnostic.contains("LINK_ASSISTANT_TOKEN is unset"));
+    assert!(diagnostic.contains("clients setup codex"));
+
+    let config_path = home.path().join(".codex/config.toml");
+    let config = fs::read_to_string(&config_path).expect("read configured Codex file");
+    fs::write(
+        &config_path,
+        config.replacen(
+            "model_provider = \"link-assistant\"",
+            "model_provider = \"user-provider\"",
+            1,
+        ),
+    )
+    .expect("switch selected provider");
+    let show = router(home.path(), &["clients", "show", "codex"]);
+    assert!(show.status.success());
+    assert!(String::from_utf8_lossy(&show.stdout).contains("\"configured\": false"));
+
+    let doctor = router(home.path(), &["clients", "doctor", "codex"]);
+    assert!(!doctor.status.success());
+    let diagnostic = String::from_utf8_lossy(&doctor.stderr);
+    assert!(diagnostic.contains("Codex CLI is not configured"));
+}
+
+#[test]
+fn doctor_uses_the_configured_codex_path_and_token_variable() {
+    let home = tempfile::tempdir().expect("temp home");
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock router");
+    let port = listener.local_addr().expect("listener address").port();
+    let base_url = format!("http://127.0.0.1:{port}");
+    let setup = router(
+        home.path(),
+        &[
+            "clients",
+            "setup",
+            "codex",
+            "--token",
+            "la_sk_doctor",
+            "--base-url",
+            &base_url,
+        ],
+    );
+    assert!(setup.status.success());
+
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept doctor request");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .expect("set timeout");
+        let mut bytes = Vec::new();
+        let mut buffer = [0_u8; 4096];
+        loop {
+            let count = stream.read(&mut buffer).expect("read request");
+            if count == 0 {
+                break;
+            }
+            bytes.extend_from_slice(&buffer[..count]);
+            if bytes.windows(4).any(|window| window == b"\r\n\r\n") {
+                break;
+            }
+        }
+        stream
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}")
+            .expect("write response");
+        String::from_utf8_lossy(&bytes).into_owned()
+    });
+    let doctor = router_with_env(
+        home.path(),
+        &["clients", "doctor", "codex"],
+        &[("LINK_ASSISTANT_TOKEN", "la_sk_doctor")],
+    );
+    assert!(
+        doctor.status.success(),
+        "{}",
+        String::from_utf8_lossy(&doctor.stderr)
+    );
+    assert!(String::from_utf8_lossy(&doctor.stdout).contains("successfully (200 OK)"));
+    let request = server.join().expect("mock server thread");
+    assert!(request.starts_with("POST /v1/responses HTTP/1.1"));
+    assert!(
+        request
+            .to_ascii_lowercase()
+            .contains("authorization: bearer la_sk_doctor")
+    );
+}


### PR DESCRIPTION
Closes #69.

## Summary

- add `clients list|setup|show|remove|doctor` for Codex CLI and Claude Code
- merge router settings into TOML/JSON configs with timestamped backups, ownership markers, idempotent updates, and surgical removal
- mint client tokens through the existing `TokenManager` (or accept `--token`) while keeping secrets out of client config and status output
- probe each client's configured protocol path with actionable diagnostics for config, connectivity, authentication, and upstream failures
- document file locations, environment variables, dialects, and the automated workflow

## Reproduction and verification

Before this change, the router had no `clients` command, so users had to hand-edit each client config and manually diagnose routing failures.

`tests/clients_cli_test.rs` now reproduces the risky cases as black-box CLI tests: preserving unrelated settings, backups, idempotence, no secret persistence/disclosure, ownership-safe removal, token minting, provider selection, and a real local HTTP doctor request to `/v1/responses`.

Checks run:

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features`
- `cargo test --all-features`
- `rust-script scripts/check-file-size.rs`
- `rust-script scripts/check-changelog-fragment.rs`
- `rust-script scripts/check-version-modification.rs`
- `rust-script --test scripts/version-and-commit.rs`

This is a CLI/configuration change, so there is no visual UI screenshot.
