### PR TITLE
fix: reconcile subscription API semantics

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-10T14:55:02.614Z for PR creation at branch issue-81-347231a9479c for issue https://github.com/link-assistant/router/issues/81

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-10T14:55:02.614Z for PR creation at branch issue-81-347231a9479c for issue https://github.com/link-assistant/router/issues/81

--- a/changelog.d/20260810_160000_subscription_parameter_compatibility.md
+++ b/changelog.d/20260810_160000_subscription_parameter_compatibility.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+### Fixed
+
+- Assemble non-streaming ChatGPT subscription responses from their streamed output events, always send `store: false` to that backend, and omit deprecated `temperature` values from Claude 5 requests.

--- a/src/openai.rs
+++ b/src/openai.rs
@@ -134,7 +134,31 @@ pub fn chat_completion_to_anthropic(req: &OpenAIChatCompletionRequest) -> Value 
     if let Some(choice) = &req.tool_choice {
         body["tool_choice"] = translate_tool_choice(choice);
     }
+    remove_unsupported_anthropic_temperature(&mut body);
     body
+}
+
+/// Remove sampling parameters rejected by the selected Anthropic model.
+///
+/// Claude 5 models deprecated `temperature`; older generations continue to
+/// accept it, so retain the caller's value everywhere else.
+pub(crate) fn remove_unsupported_anthropic_temperature(body: &mut Value) {
+    let rejects_temperature = body
+        .get("model")
+        .and_then(Value::as_str)
+        .and_then(|model| model.strip_prefix("claude-"))
+        .and_then(|model| {
+            let mut parts = model.split('-');
+            let family = parts.next()?;
+            let generation = parts.next()?.parse::<u32>().ok()?;
+            matches!(family, "haiku" | "sonnet" | "opus").then_some(generation)
+        })
+        .is_some_and(|generation| generation >= 5);
+    if rejects_temperature {
+        if let Some(object) = body.as_object_mut() {
+            object.remove("temperature");
+        }
+    }
 }
 
 /// Translate the upstream Anthropic JSON response to an `OpenAI` Chat
@@ -731,6 +755,28 @@ mod tests {
         let body = chat_completion_to_anthropic(&req);
         assert_eq!(body["model"], "claude-opus-4-7");
         assert_eq!(body["max_tokens"], 4096);
+    }
+
+    #[test]
+    fn drops_temperature_for_claude_5_models() {
+        let req = OpenAIChatCompletionRequest {
+            model: "claude-sonnet-5".into(),
+            messages: vec![ChatMessage {
+                role: "user".into(),
+                content: Value::String("hi".into()),
+                name: None,
+            }],
+            max_tokens: None,
+            max_completion_tokens: None,
+            temperature: Some(0.7),
+            top_p: None,
+            stream: None,
+            stop: None,
+            tools: None,
+            tool_choice: None,
+        };
+        let body = chat_completion_to_anthropic(&req);
+        assert!(body.get("temperature").is_none());
     }
 
     #[test]

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -232,7 +232,7 @@ pub async fn proxy_handler(State(state): State<AppState>, req: Request) -> Respo
 
     // Read the body before account selection so the router gets a copy of
     // stable request metadata and can preserve conversation affinity.
-    let body_bytes = match axum::body::to_bytes(req.into_body(), 10 * 1024 * 1024).await {
+    let mut body_bytes = match axum::body::to_bytes(req.into_body(), 10 * 1024 * 1024).await {
         Ok(bytes) => bytes,
         Err(e) => {
             return error_response(
@@ -276,11 +276,17 @@ pub async fn proxy_handler(State(state): State<AppState>, req: Request) -> Respo
             }
         };
 
-    // Same requirement as above for the pass-through surface: a client that is
-    // not Claude Code (an SDK, a curl smoke test) would otherwise be rejected
+    // Same requirement as above: a client that is not Claude Code would be rejected
     // by the upstream with a misleading 429. Idempotent for Claude Code itself.
+    let mut upstream_body = routing_body.clone();
+    openai::remove_unsupported_anthropic_temperature(&mut upstream_body);
+    if upstream_body != routing_body {
+        body_bytes = serde_json::to_vec(&upstream_body)
+            .map(bytes::Bytes::from)
+            .unwrap_or(body_bytes);
+    }
     let body_bytes = if crate::claude_identity::is_oauth_credential(&oauth_token) {
-        crate::claude_identity::ensure_claude_code_system_bytes(&routing_body, body_bytes)
+        crate::claude_identity::ensure_claude_code_system_bytes(&upstream_body, body_bytes)
     } else {
         body_bytes
     };

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -10,7 +10,10 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
-use crate::openai::{extract_text, map_model, translate_parts, translate_tools};
+use crate::openai::{
+    extract_text, map_model, remove_unsupported_anthropic_temperature, translate_parts,
+    translate_tools,
+};
 
 /// `OpenAI` `POST /v1/responses` request body. We accept the superset and
 /// project to Anthropic Messages, so unknown keys are ignored.
@@ -89,6 +92,7 @@ pub fn response_to_anthropic(req: &OpenAIResponseRequest) -> Value {
     if let Some(tools) = &req.tools {
         body["tools"] = translate_tools(tools);
     }
+    remove_unsupported_anthropic_temperature(&mut body);
     body
 }
 
@@ -310,5 +314,20 @@ mod tests {
         assert_eq!(out["input"][0]["role"], "user");
         assert_eq!(out["input"][0]["content"][0]["type"], "input_text");
         assert_eq!(out["input"][1]["content"][0]["type"], "output_text");
+    }
+
+    #[test]
+    fn drops_temperature_for_claude_5_models() {
+        let req = OpenAIResponseRequest {
+            model: "claude-opus-5".into(),
+            input: Value::String("hello".into()),
+            instructions: None,
+            max_output_tokens: None,
+            temperature: Some(0.7),
+            stream: None,
+            tools: None,
+        };
+        let body = response_to_anthropic(&req);
+        assert!(body.get("temperature").is_none());
     }
 }

--- a/src/subscription_proxy.rs
+++ b/src/subscription_proxy.rs
@@ -17,6 +17,7 @@ use axum::body::Body;
 use axum::http::{HeaderMap, HeaderValue, StatusCode};
 use axum::response::Response;
 use futures_util::StreamExt;
+use std::collections::BTreeMap;
 
 use crate::metrics::Surface;
 use crate::proxy::{
@@ -286,6 +287,7 @@ pub async fn forward_subscription_openai(
 fn codex_sse_to_response_json(body: &[u8]) -> Option<Vec<u8>> {
     let text = std::str::from_utf8(body).ok()?;
     let mut completed: Option<serde_json::Value> = None;
+    let mut output = BTreeMap::<u64, serde_json::Value>::new();
     for line in text.lines() {
         let Some(payload) = line.strip_prefix("data:") else {
             continue;
@@ -297,13 +299,93 @@ fn codex_sse_to_response_json(body: &[u8]) -> Option<Vec<u8>> {
         let Ok(event) = serde_json::from_str::<serde_json::Value>(payload) else {
             continue;
         };
-        if event.get("type").and_then(serde_json::Value::as_str) == Some("response.completed") {
-            if let Some(response) = event.get("response") {
-                completed = Some(response.clone());
+        match event.get("type").and_then(serde_json::Value::as_str) {
+            Some("response.output_item.added" | "response.output_item.done") => {
+                if let Some(item) = event.get("item") {
+                    let index = event
+                        .get("output_index")
+                        .and_then(serde_json::Value::as_u64)
+                        .unwrap_or(output.len() as u64);
+                    output.insert(index, item.clone());
+                }
             }
+            Some("response.output_text.delta") => {
+                update_codex_output_text(&mut output, &event, false);
+            }
+            Some("response.output_text.done") => {
+                update_codex_output_text(&mut output, &event, true);
+            }
+            Some("response.completed") => {
+                if let Some(response) = event.get("response") {
+                    completed = Some(response.clone());
+                }
+            }
+            _ => {}
+        }
+    }
+    if let Some(response) = completed.as_mut() {
+        let missing_output = response
+            .get("output")
+            .and_then(serde_json::Value::as_array)
+            .is_none_or(Vec::is_empty);
+        if missing_output && !output.is_empty() {
+            response["output"] = serde_json::Value::Array(output.into_values().collect());
         }
     }
     completed.and_then(|value| serde_json::to_vec(&value).ok())
+}
+
+fn update_codex_output_text(
+    output: &mut BTreeMap<u64, serde_json::Value>,
+    event: &serde_json::Value,
+    done: bool,
+) {
+    let output_index = event
+        .get("output_index")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    let content_index = event
+        .get("content_index")
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|index| usize::try_from(index).ok())
+        .unwrap_or(0);
+    let item_id = event
+        .get("item_id")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("");
+    let item = output.entry(output_index).or_insert_with(|| {
+        serde_json::json!({
+            "id": item_id,
+            "type": "message",
+            "status": "in_progress",
+            "role": "assistant",
+            "content": []
+        })
+    });
+    let Some(content) = item
+        .get_mut("content")
+        .and_then(serde_json::Value::as_array_mut)
+    else {
+        return;
+    };
+    content.resize(content_index + 1, serde_json::Value::Null);
+    if content[content_index].is_null() {
+        content[content_index] =
+            serde_json::json!({"type": "output_text", "text": "", "annotations": []});
+    }
+    let text = if done {
+        event.get("text")
+    } else {
+        event.get("delta")
+    }
+    .and_then(serde_json::Value::as_str)
+    .unwrap_or("");
+    if done {
+        content[content_index]["text"] = serde_json::Value::String(text.to_string());
+        item["status"] = serde_json::Value::String("completed".to_string());
+    } else if let Some(current) = content[content_index]["text"].as_str() {
+        content[content_index]["text"] = serde_json::Value::String(format!("{current}{text}"));
+    }
 }
 
 /// Collect rate-limit-related headers (`retry-after`, `x-ratelimit-*`) from an
@@ -427,6 +509,8 @@ fn normalize_codex_responses_body(body: &mut serde_json::Value) {
     };
     // Codex always streams from the ChatGPT backend.
     obj.insert("stream".to_string(), serde_json::Value::Bool(true));
+    // ChatGPT subscription inference does not permit stored responses.
+    obj.insert("store".to_string(), serde_json::Value::Bool(false));
     // `max_output_tokens` is not accepted by the Codex backend.
     obj.remove("max_output_tokens");
 
@@ -476,7 +560,7 @@ mod tests {
         let mut body = serde_json::json!({
             "model": "gpt-5.5",
             "input": [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}],
-            "store": false,
+            "store": true,
             "max_output_tokens": 8192,
             "reasoning": {"effort": "none"}
         });
@@ -487,8 +571,9 @@ mod tests {
             "max_output_tokens must be stripped for Codex"
         );
         assert_eq!(body["instructions"], "You are a helpful assistant.");
-        // Untouched fields are preserved.
+        // ChatGPT subscription inference requires stateless requests.
         assert_eq!(body["store"], serde_json::Value::Bool(false));
+        // Untouched fields are preserved.
         assert_eq!(body["reasoning"]["effort"], "none");
     }
 
@@ -534,15 +619,19 @@ mod tests {
             "event: response.created\n",
             "data: {\"type\":\"response.created\",\"response\":{\"status\":\"in_progress\"}}\n\n",
             "event: response.output_text.delta\n",
-            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n",
+            "data: {\"type\":\"response.output_text.delta\",\"item_id\":\"msg_1\",\"output_index\":0,\"content_index\":0,\"delta\":\"hi\"}\n\n",
+            "event: response.output_text.done\n",
+            "data: {\"type\":\"response.output_text.done\",\"item_id\":\"msg_1\",\"output_index\":0,\"content_index\":0,\"text\":\"hi\"}\n\n",
             "event: response.completed\n",
-            "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"status\":\"completed\",\"output\":[{\"type\":\"message\"}]}}\n\n"
+            "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.6-sol\",\"status\":\"completed\",\"output\":[]}}\n\n"
         );
         let out = codex_sse_to_response_json(sse.as_bytes()).expect("completed payload");
         let value: serde_json::Value = serde_json::from_slice(&out).unwrap();
         assert_eq!(value["id"], "resp_1");
         assert_eq!(value["status"], "completed");
         assert_eq!(value["output"][0]["type"], "message");
+        assert_eq!(value["output"][0]["role"], "assistant");
+        assert_eq!(value["output"][0]["content"][0]["text"], "hi");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- reconstruct non-streaming ChatGPT subscription responses when the final `response.completed` event has an empty `output`, using the preceding streamed output events
- always send `store: false` to the ChatGPT subscription backend
- omit the deprecated `temperature` parameter for Claude 5 models across native Anthropic, Chat Completions, and Responses requests while preserving it for older Claude generations
- add the required patch changelog fragment

## Reproduction and root cause

A non-streaming `/v1/responses` request was internally converted to a stream. The backend emitted the generated text in `response.output_text.*` events, but its terminal `response.completed.response` contained `output: []`. The router returned only that terminal object and discarded the earlier text. The request normalizer also preserved a caller-provided `store: true`, which the ChatGPT subscription backend does not accept.

Separately, Anthropic subscription requests forwarded `temperature` unchanged even though Claude 5 rejects that parameter.

## Regression coverage

- reproduces an empty terminal Codex response and verifies the assembled non-streaming response contains `hi`
- verifies caller-provided `store: true` is normalized to `false`
- verifies Chat Completions and Responses translations remove `temperature` for Claude 5 models
- existing translation coverage verifies supported models retain `temperature`

## Verification

- `cargo fmt --all -- --check`
- `cargo check --locked --all-targets --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features --verbose` (416 tests passed)
- `cargo test --locked --doc --verbose`
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps --all-features`
- repository file-size, changelog, and version-policy scripts
- `cargo build --locked --release --verbose`
- `cargo package --locked --list`
- `git diff --check`

Fixes #81
