### PR TITLE
fix: refresh expired subscription credentials

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-10T20:22:18.983Z for PR creation at branch issue-83-f06c7bb43bd2 for issue https://github.com/link-assistant/router/issues/83

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-10T20:22:18.983Z for PR creation at branch issue-83-f06c7bb43bd2 for issue https://github.com/link-assistant/router/issues/83

--- a/changelog.d/20260810_220000_refresh_aware_catalogs.md
+++ b/changelog.d/20260810_220000_refresh_aware_catalogs.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+### Fixed
+
+- Refresh expired subscription credentials before routing or catalog discovery, report active-provider catalog failures in `doctor`, and remove unsupported `temperature` values from ChatGPT subscription requests.

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -3,49 +3,69 @@
 use crate::model_catalog::fetch_provider_catalog;
 use crate::subscription::{SubscriptionProvider, all_subscription_readers};
 
-/// Report credential and live-catalog health for every non-active provider.
+/// Report credential and live-catalog health for every provider.
 ///
-/// Returns `true` when a healthy credential could not fetch its catalog.
+/// Expired credentials are refreshed in memory before their catalogs are
+/// fetched. Returns `true` when a present credential cannot become healthy or
+/// cannot fetch its catalog.
 pub async fn subscription_catalog_diagnostics(
-    active_provider: SubscriptionProvider,
+    _active_provider: SubscriptionProvider,
     claude_home: &str,
     user_home: &str,
 ) -> bool {
     let readers = all_subscription_readers(claude_home, user_home);
-    for reader in &readers {
-        let provider = reader.provider();
-        if provider == active_provider {
-            continue;
-        }
-        let label = format!("{provider} subscription");
-        match reader.discover_credential_path() {
-            Some(path) => {
-                let status = reader.read_token().map_or("found, NO TOKEN", |token| {
-                    let now_ms = chrono::Utc::now().timestamp_millis();
-                    if token.is_expired(now_ms) {
-                        "found, token EXPIRED"
-                    } else {
-                        "found, token OK"
-                    }
-                });
-                println!("{label:<23}: {} ({status})", path.display());
-            }
-            None => println!("{label:<23}: {} (MISSING)", reader.home().display()),
-        }
-    }
-
     let client = reqwest::Client::new();
+    let token_cache = crate::refresh::TokenCache::new();
     let now_ms = chrono::Utc::now().timestamp_millis();
     let mut catalog_error = false;
     for reader in readers {
-        let Ok(token) = reader.read_token() else {
+        let provider = reader.provider();
+        let label = format!("{provider} subscription");
+        let Some(path) = reader.discover_credential_path() else {
+            println!("{label:<23}: {} (MISSING)", reader.home().display());
             continue;
         };
+        let disk_token = match reader.read_token() {
+            Ok(token) => token,
+            Err(error) => {
+                println!("{label:<23}: {} (found, NO TOKEN: {error})", path.display());
+                println!(
+                    "{:<23}: ERROR (credential is unreadable)",
+                    format!("{provider} catalog")
+                );
+                catalog_error = true;
+                continue;
+            }
+        };
+        let was_expired = disk_token.is_expired(now_ms);
+        let token = token_cache
+            .get_fresh(&client, provider, disk_token, now_ms)
+            .await;
         if token.is_expired(now_ms) {
+            println!(
+                "{label:<23}: {} (found, token EXPIRED; refresh failed)",
+                path.display()
+            );
+            println!(
+                "{:<23}: ERROR (credential is expired and could not be refreshed)",
+                format!("{provider} catalog")
+            );
+            catalog_error = true;
             continue;
         }
-        let provider = reader.provider();
-        match fetch_provider_catalog(&client, provider, &token, None).await {
+        let catalog = fetch_provider_catalog(&client, provider, &token, None).await;
+        let rejected = catalog
+            .as_ref()
+            .is_err_and(|error| error.starts_with("HTTP 401") || error.starts_with("HTTP 403"));
+        let status = match (was_expired, rejected) {
+            (true, true) => "found, token REJECTED after refresh",
+            (false, true) => "found, token REJECTED",
+            (true, false) => "found, token OK (refreshed in memory)",
+            (false, false) => "found, token OK",
+        };
+        println!("{label:<23}: {} ({status})", path.display());
+
+        match catalog {
             Ok(models) => println!(
                 "{:<23}: OK ({} live model(s))",
                 format!("{provider} catalog"),

--- a/src/gemini.rs
+++ b/src/gemini.rs
@@ -527,9 +527,12 @@ fn native_model_document(model: &str) -> Value {
 /// Native Gemini `ListModels` response.
 pub async fn native_models(State(state): State<AppState>) -> impl IntoResponse {
     let healthy = crate::model_routing::healthy_providers(
+        &state.client,
         &state.subscription_readers,
+        &state.subscription_cache,
         chrono::Utc::now().timestamp_millis(),
-    );
+    )
+    .await;
     let available = matches!(
         state.upstream_provider,
         crate::config::UpstreamProvider::Gemini | crate::config::UpstreamProvider::Auto
@@ -550,9 +553,12 @@ pub async fn native_model(
     Path(model): Path<String>,
 ) -> impl IntoResponse {
     let healthy = crate::model_routing::healthy_providers(
+        &state.client,
         &state.subscription_readers,
+        &state.subscription_cache,
         chrono::Utc::now().timestamp_millis(),
-    );
+    )
+    .await;
     let available = matches!(
         state.upstream_provider,
         crate::config::UpstreamProvider::Gemini | crate::config::UpstreamProvider::Auto
@@ -613,7 +619,9 @@ async fn forward_native(
         match crate::model_routing::route_provider(
             state,
             crate::subscription::SubscriptionProvider::Gemini,
-        ) {
+        )
+        .await
+        {
             Ok(state) => Some(state),
             Err(error) => {
                 return error_response(StatusCode::BAD_REQUEST, "invalid_request_error", &error);

--- a/src/main.rs
+++ b/src/main.rs
@@ -310,6 +310,7 @@ async fn run_server(config: Config, logger: LogLazy) -> Result<(), Box<dyn std::
         link_assistant_router::model_catalog::refresh_catalogs_forever(
             state.client.clone(),
             state.subscription_readers.clone(),
+            Arc::clone(&state.subscription_cache),
             Arc::clone(&state.model_catalogs),
         ),
     );
@@ -903,16 +904,14 @@ async fn run_doctor(config: &Config) -> ExitCode {
     let primary = SubscriptionReader::new(active_provider, &primary_home);
     match primary.discover_credential_path() {
         Some(path) => {
-            let readable = primary.read_token().is_ok();
-            println!(
-                "primary credentials    : {} ({})",
-                path.display(),
-                if readable {
-                    "found, token OK"
+            let status = primary.read_token().map_or("found, NO TOKEN", |token| {
+                if token.is_expired(chrono::Utc::now().timestamp_millis()) {
+                    "found, token EXPIRED on disk"
                 } else {
-                    "found, NO TOKEN"
+                    "found, token OK"
                 }
-            );
+            });
+            println!("primary credentials    : {} ({})", path.display(), status);
         }
         None => println!(
             "primary credentials    : {} (MISSING)",

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -117,20 +117,29 @@ impl ModelCatalogCache {
 pub async fn refresh_catalogs(
     client: &reqwest::Client,
     readers: &[SubscriptionReader],
+    token_cache: &crate::refresh::TokenCache,
     cache: &ModelCatalogCache,
 ) {
     let now_ms = chrono::Utc::now().timestamp_millis();
-    let credentials = readers.iter().filter_map(|reader| {
-        reader
-            .read_token()
-            .ok()
-            .filter(|token| !token.is_expired(now_ms))
-            .map(|token| (reader.provider(), token))
-    });
-    let refreshes = credentials.map(|(provider, token)| async move {
-        let result = fetch_provider_catalog(client, provider, &token, None).await;
-        (provider, result)
-    });
+    let refreshes = readers
+        .iter()
+        .filter_map(|reader| {
+            reader
+                .read_token()
+                .ok()
+                .map(|token| (reader.provider(), token))
+        })
+        .map(|(provider, disk_token)| async move {
+            let token = token_cache
+                .get_fresh(client, provider, disk_token, now_ms)
+                .await;
+            let result = if token.is_expired(now_ms) {
+                Err("credential is expired and could not be refreshed".to_string())
+            } else {
+                fetch_provider_catalog(client, provider, &token, None).await
+            };
+            (provider, result)
+        });
     for (provider, result) in futures_util::future::join_all(refreshes).await {
         match result {
             Ok(models) => {
@@ -152,10 +161,11 @@ pub async fn refresh_catalogs(
 pub async fn refresh_catalogs_forever(
     client: reqwest::Client,
     readers: Vec<SubscriptionReader>,
+    token_cache: std::sync::Arc<crate::refresh::TokenCache>,
     cache: std::sync::Arc<ModelCatalogCache>,
 ) {
     loop {
-        refresh_catalogs(&client, &readers, &cache).await;
+        refresh_catalogs(&client, &readers, &token_cache, &cache).await;
         tokio::time::sleep(CATALOG_TTL).await;
     }
 }
@@ -287,7 +297,9 @@ mod tests {
     use axum::extract::State;
     use axum::http::{HeaderMap, Uri};
     use axum::routing::get;
+    use std::fs;
     use std::sync::Arc;
+    use tempfile::tempdir;
 
     #[test]
     fn parses_each_vendor_response_shape() {
@@ -362,6 +374,53 @@ mod tests {
         .unwrap();
         assert_eq!(models, ["gpt-5.6-sol"]);
         assert!(*seen.read().unwrap());
+    }
+
+    #[tokio::test]
+    async fn catalog_refresh_uses_an_in_memory_refreshed_token() {
+        async fn handler(headers: HeaderMap) -> axum::Json<Value> {
+            assert_eq!(
+                headers
+                    .get("authorization")
+                    .and_then(|value| value.to_str().ok()),
+                Some("Bearer fresh-token")
+            );
+            axum::Json(serde_json::json!({"data":[{"id":"qwen-live"}]}))
+        }
+
+        let app = Router::new().route("/compatible-mode/v1/models", get(handler));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let home = tempdir().unwrap();
+        fs::write(
+            home.path().join("oauth_creds.json"),
+            r#"{"access_token":"expired","refresh_token":"refresh","expiry_date":1000}"#,
+        )
+        .unwrap();
+        let readers = vec![SubscriptionReader::new(
+            SubscriptionProvider::Qwen,
+            home.path(),
+        )];
+        let token_cache = crate::refresh::TokenCache::new();
+        token_cache.store_refreshed(
+            SubscriptionProvider::Qwen,
+            "primary",
+            SubscriptionToken {
+                access_token: "fresh-token".into(),
+                refresh_token: Some("refresh".into()),
+                expires_at_ms: Some(chrono::Utc::now().timestamp_millis() + 60_000),
+                account_id: None,
+                resource_url: Some(format!("http://{address}")),
+            },
+        );
+        let catalogs = ModelCatalogCache::new();
+
+        refresh_catalogs(&reqwest::Client::new(), &readers, &token_cache, &catalogs).await;
+
+        assert_eq!(catalogs.models(SubscriptionProvider::Qwen), ["qwen-live"]);
+        assert!(!catalogs.status(SubscriptionProvider::Qwen).using_fallback);
     }
 
     #[test]

--- a/src/model_routing.rs
+++ b/src/model_routing.rs
@@ -89,18 +89,30 @@ pub fn available_provider_for_model(
         })
 }
 
-/// Readers whose current on-disk access token exists and has not expired.
-#[must_use]
-pub fn healthy_providers(readers: &[SubscriptionReader], now_ms: i64) -> Vec<SubscriptionProvider> {
-    SubscriptionProvider::ALL
+/// Readers whose credential can supply a current access token, refreshing an
+/// expired on-disk token into the shared in-memory cache when possible.
+pub async fn healthy_providers(
+    client: &reqwest::Client,
+    readers: &[SubscriptionReader],
+    token_cache: &crate::refresh::TokenCache,
+    now_ms: i64,
+) -> Vec<SubscriptionProvider> {
+    let checks = SubscriptionProvider::ALL
         .into_iter()
-        .filter(|provider| {
-            readers
+        .map(|provider| async move {
+            let reader = readers
                 .iter()
-                .find(|reader| reader.provider() == *provider)
-                .and_then(|reader| reader.read_token().ok())
-                .is_some_and(|token| !token.is_expired(now_ms))
-        })
+                .find(|reader| reader.provider() == provider)?;
+            let disk_token = reader.read_token().ok()?;
+            let token = token_cache
+                .get_fresh(client, provider, disk_token, now_ms)
+                .await;
+            (!token.is_expired(now_ms)).then_some(provider)
+        });
+    futures_util::future::join_all(checks)
+        .await
+        .into_iter()
+        .flatten()
         .collect()
 }
 
@@ -127,11 +139,14 @@ pub fn model_catalog(providers: &[SubscriptionProvider], catalogs: &ModelCatalog
 
 /// Model catalog for one pinned subscription, empty when its credential is not healthy.
 #[must_use]
-pub fn pinned_model_catalog(state: &AppState, provider: SubscriptionProvider) -> Value {
+pub async fn pinned_model_catalog(state: &AppState, provider: SubscriptionProvider) -> Value {
     let healthy = healthy_providers(
+        &state.client,
         &state.subscription_readers,
+        &state.subscription_cache,
         chrono::Utc::now().timestamp_millis(),
-    );
+    )
+    .await;
     if healthy.contains(&provider) {
         model_catalog(&[provider], &state.model_catalogs)
     } else {
@@ -144,20 +159,27 @@ pub async fn models(State(state): State<AppState>) -> impl IntoResponse {
     let models = match state.upstream_provider {
         UpstreamProvider::Auto => model_catalog(
             &healthy_providers(
+                &state.client,
                 &state.subscription_readers,
+                &state.subscription_cache,
                 chrono::Utc::now().timestamp_millis(),
-            ),
+            )
+            .await,
             &state.model_catalogs,
         ),
-        UpstreamProvider::Anthropic => pinned_model_catalog(&state, SubscriptionProvider::Claude),
+        UpstreamProvider::Anthropic => {
+            pinned_model_catalog(&state, SubscriptionProvider::Claude).await
+        }
         UpstreamProvider::Gonka => state.gonka.as_ref().map_or_else(
             || crate::gonka::list_models(&crate::config::default_gonka_model()),
             |gonka| crate::gonka::list_models(&gonka.model),
         ),
         UpstreamProvider::Crater => crate::crater::list_models(),
-        UpstreamProvider::Codex => pinned_model_catalog(&state, SubscriptionProvider::Codex),
-        UpstreamProvider::Qwen => pinned_model_catalog(&state, SubscriptionProvider::Qwen),
-        UpstreamProvider::Gemini => pinned_model_catalog(&state, SubscriptionProvider::Gemini),
+        UpstreamProvider::Codex => pinned_model_catalog(&state, SubscriptionProvider::Codex).await,
+        UpstreamProvider::Qwen => pinned_model_catalog(&state, SubscriptionProvider::Qwen).await,
+        UpstreamProvider::Gemini => {
+            pinned_model_catalog(&state, SubscriptionProvider::Gemini).await
+        }
         UpstreamProvider::OpenAICompatible => {
             crate::provider_proxy::openai_compatible_models(&state)
         }
@@ -183,29 +205,40 @@ pub async fn route_anthropic_request(
         })?;
     let routing_body = serde_json::from_slice(&body_bytes).unwrap_or(Value::Null);
     let routed = if path.ends_with("/messages") || path.ends_with("/messages/count_tokens") {
-        route_state(state, &routing_body).map_err(|error| model_route_error_response(&error))?
+        route_state(state, &routing_body)
+            .await
+            .map_err(|error| model_route_error_response(&error))?
     } else {
-        route_provider(state, SubscriptionProvider::Claude).map_err(|error| {
-            crate::proxy::error_response(StatusCode::BAD_REQUEST, "invalid_request_error", &error)
-        })?
+        route_provider(state, SubscriptionProvider::Claude)
+            .await
+            .map_err(|error| {
+                crate::proxy::error_response(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_request_error",
+                    &error,
+                )
+            })?
     };
     Ok((routed, Request::from_parts(parts, Body::from(body_bytes))))
 }
 
 /// Resolve one provider only when its credential is currently healthy.
-pub fn route_provider(
+pub async fn route_provider(
     state: &AppState,
     provider: SubscriptionProvider,
 ) -> Result<AppState, String> {
+    let healthy = healthy_providers(
+        &state.client,
+        &state.subscription_readers,
+        &state.subscription_cache,
+        chrono::Utc::now().timestamp_millis(),
+    )
+    .await;
     let reader = state
         .subscription_readers
         .iter()
         .find(|reader| reader.provider() == provider)
-        .filter(|reader| {
-            reader
-                .read_token()
-                .is_ok_and(|token| !token.is_expired(chrono::Utc::now().timestamp_millis()))
-        })
+        .filter(|_| healthy.contains(&provider))
         .cloned()
         .ok_or_else(|| format!("no healthy {provider} credential is available"))?;
 
@@ -224,7 +257,7 @@ pub fn route_provider(
 }
 
 /// Resolve an automatic state to the healthy subscription serving `model`.
-pub fn route_state(state: &AppState, body: &Value) -> Result<AppState, ModelRouteError> {
+pub async fn route_state(state: &AppState, body: &Value) -> Result<AppState, ModelRouteError> {
     if state.upstream_provider != UpstreamProvider::Auto {
         return Ok(state.clone());
     }
@@ -236,12 +269,15 @@ pub fn route_state(state: &AppState, body: &Value) -> Result<AppState, ModelRout
     let provider = available_provider_for_model(
         model,
         &healthy_providers(
+            &state.client,
             &state.subscription_readers,
+            &state.subscription_cache,
             chrono::Utc::now().timestamp_millis(),
-        ),
+        )
+        .await,
         &state.model_catalogs,
     )?;
-    let mut routed = route_provider(state, provider).map_err(|_| {
+    let mut routed = route_provider(state, provider).await.map_err(|_| {
         ModelRouteError::NotFound(format!(
             "model '{model}' has no healthy {provider} credential"
         ))
@@ -398,8 +434,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn missing_and_expired_credentials_are_not_healthy() {
+    #[tokio::test]
+    async fn missing_and_expired_credentials_are_not_healthy() {
         let live = tempdir().unwrap();
         let expired = tempdir().unwrap();
         fs::write(
@@ -417,13 +453,50 @@ mod tests {
             SubscriptionReader::new(SubscriptionProvider::Gemini, expired.path()),
         ];
         assert_eq!(
-            healthy_providers(&readers, 2000),
+            healthy_providers(
+                &reqwest::Client::new(),
+                &readers,
+                &crate::refresh::TokenCache::new(),
+                2000,
+            )
+            .await,
             vec![SubscriptionProvider::Codex]
         );
     }
 
-    #[test]
-    fn automatic_state_selects_the_models_healthy_reader() {
+    #[tokio::test]
+    async fn expired_credentials_with_a_cached_refresh_are_healthy() {
+        let claude = tempdir().unwrap();
+        fs::write(
+            claude.path().join(".credentials.json"),
+            r#"{"claudeAiOauth":{"accessToken":"expired","refreshToken":"refresh","expiresAt":1000}}"#,
+        )
+        .unwrap();
+        let readers = vec![SubscriptionReader::new(
+            SubscriptionProvider::Claude,
+            claude.path(),
+        )];
+        let cache = crate::refresh::TokenCache::new();
+        cache.store_refreshed(
+            SubscriptionProvider::Claude,
+            "primary",
+            crate::subscription::SubscriptionToken {
+                access_token: "fresh".into(),
+                refresh_token: Some("refresh".into()),
+                expires_at_ms: Some(3000),
+                account_id: None,
+                resource_url: None,
+            },
+        );
+
+        assert_eq!(
+            healthy_providers(&reqwest::Client::new(), &readers, &cache, 2000).await,
+            vec![SubscriptionProvider::Claude]
+        );
+    }
+
+    #[tokio::test]
+    async fn automatic_state_selects_the_models_healthy_reader() {
         let data = tempdir().unwrap();
         let codex = tempdir().unwrap();
         fs::write(
@@ -439,13 +512,19 @@ mod tests {
             data.path(),
         );
 
-        let routed = route_state(&state, &json!({"model": "gpt-5"})).unwrap();
+        let routed = route_state(&state, &json!({"model": "gpt-5"}))
+            .await
+            .unwrap();
         assert_eq!(routed.upstream_provider, UpstreamProvider::Codex);
         assert_eq!(routed.bridge_model.as_deref(), Some("gpt-5"));
         assert_eq!(
             routed.subscription_reader.unwrap().provider(),
             SubscriptionProvider::Codex
         );
-        assert!(route_state(&state, &json!({"model": "claude-opus-4-7"})).is_err());
+        assert!(
+            route_state(&state, &json!({"model": "claude-opus-4-7"}))
+                .await
+                .is_err()
+        );
     }
 }

--- a/src/openai.rs
+++ b/src/openai.rs
@@ -134,26 +134,31 @@ pub fn chat_completion_to_anthropic(req: &OpenAIChatCompletionRequest) -> Value 
     if let Some(choice) = &req.tool_choice {
         body["tool_choice"] = translate_tool_choice(choice);
     }
-    remove_unsupported_anthropic_temperature(&mut body);
+    reconcile_subscription_parameters(crate::subscription::SubscriptionProvider::Claude, &mut body);
     body
 }
 
-/// Remove sampling parameters rejected by the selected Anthropic model.
+/// Reconcile request parameters with the selected subscription backend.
 ///
-/// Claude 5 models deprecated `temperature`; older generations continue to
-/// accept it, so retain the caller's value everywhere else.
-pub(crate) fn remove_unsupported_anthropic_temperature(body: &mut Value) {
-    let rejects_temperature = body
-        .get("model")
-        .and_then(Value::as_str)
-        .and_then(|model| model.strip_prefix("claude-"))
-        .and_then(|model| {
-            let mut parts = model.split('-');
-            let family = parts.next()?;
-            let generation = parts.next()?.parse::<u32>().ok()?;
-            matches!(family, "haiku" | "sonnet" | "opus").then_some(generation)
-        })
-        .is_some_and(|generation| generation >= 5);
+/// `ChatGPT` subscription inference rejects `temperature` for every advertised
+/// model. Claude 5 rejects it too, while older Claude generations retain it.
+pub(crate) fn reconcile_subscription_parameters(
+    provider: crate::subscription::SubscriptionProvider,
+    body: &mut Value,
+) {
+    let rejects_temperature = provider == crate::subscription::SubscriptionProvider::Codex
+        || (provider == crate::subscription::SubscriptionProvider::Claude
+            && body
+                .get("model")
+                .and_then(Value::as_str)
+                .and_then(|model| model.strip_prefix("claude-"))
+                .and_then(|model| {
+                    let mut parts = model.split('-');
+                    let family = parts.next()?;
+                    let generation = parts.next()?.parse::<u32>().ok()?;
+                    matches!(family, "haiku" | "sonnet" | "opus").then_some(generation)
+                })
+                .is_some_and(|generation| generation >= 5));
     if rejects_temperature {
         if let Some(object) = body.as_object_mut() {
             object.remove("temperature");

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -28,6 +28,7 @@ pub use crate::model_routing::models as openai_models;
 use crate::openai;
 pub(crate) use crate::request_routing::{request_routing_context, retry_after_duration};
 use crate::responses;
+use crate::subscription::SubscriptionProvider;
 
 /// The legacy API path prefix used to route requests through the proxy.
 pub const API_PREFIX: &str = "/api/latest/anthropic/";
@@ -279,7 +280,7 @@ pub async fn proxy_handler(State(state): State<AppState>, req: Request) -> Respo
     // Same requirement as above: a client that is not Claude Code would be rejected
     // by the upstream with a misleading 429. Idempotent for Claude Code itself.
     let mut upstream_body = routing_body.clone();
-    openai::remove_unsupported_anthropic_temperature(&mut upstream_body);
+    openai::reconcile_subscription_parameters(SubscriptionProvider::Claude, &mut upstream_body);
     if upstream_body != routing_body {
         body_bytes = serde_json::to_vec(&upstream_body)
             .map(bytes::Bytes::from)
@@ -504,7 +505,7 @@ pub async fn openai_chat_completions(
     if stream_from_query {
         body["stream"] = serde_json::json!(true);
     }
-    let state = match crate::model_routing::route_state(&state, &body) {
+    let state = match crate::model_routing::route_state(&state, &body).await {
         Ok(state) => state,
         Err(error) => return crate::model_routing::model_route_error_response(&error),
     };
@@ -599,7 +600,7 @@ pub async fn openai_responses(
     headers: HeaderMap,
     axum::Json(body): axum::Json<serde_json::Value>,
 ) -> Response {
-    let state = match crate::model_routing::route_state(&state, &body) {
+    let state = match crate::model_routing::route_state(&state, &body).await {
         Ok(state) => state,
         Err(error) => return crate::model_routing::model_route_error_response(&error),
     };

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -11,8 +11,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
 use crate::openai::{
-    extract_text, map_model, remove_unsupported_anthropic_temperature, translate_parts,
-    translate_tools,
+    extract_text, map_model, reconcile_subscription_parameters, translate_parts, translate_tools,
 };
 
 /// `OpenAI` `POST /v1/responses` request body. We accept the superset and
@@ -92,7 +91,7 @@ pub fn response_to_anthropic(req: &OpenAIResponseRequest) -> Value {
     if let Some(tools) = &req.tools {
         body["tools"] = translate_tools(tools);
     }
-    remove_unsupported_anthropic_temperature(&mut body);
+    reconcile_subscription_parameters(crate::subscription::SubscriptionProvider::Claude, &mut body);
     body
 }
 

--- a/src/subscription_proxy.rs
+++ b/src/subscription_proxy.rs
@@ -142,9 +142,7 @@ pub async fn forward_subscription_openai(
 
     // The ChatGPT Codex backend is stricter than the generic Responses API, so
     // reshape the body before forwarding (see `normalize_codex_responses_body`).
-    if provider == SubscriptionProvider::Codex {
-        normalize_codex_responses_body(&mut body);
-    }
+    normalize_subscription_request(provider, &mut body);
 
     let serialized = match serde_json::to_vec(&body) {
         Ok(v) => v,
@@ -458,12 +456,11 @@ fn join_subscription_url(provider: SubscriptionProvider, base_url: &str, path: &
 }
 
 /// `OpenAI`-shaped model listing for a subscription provider.
-#[must_use]
-pub fn subscription_models(state: &AppState) -> serde_json::Value {
-    state.upstream_provider.subscription_provider().map_or_else(
-        || serde_json::json!({"object": "list", "data": []}),
-        |provider| crate::model_routing::pinned_model_catalog(state, provider),
-    )
+pub async fn subscription_models(state: &AppState) -> serde_json::Value {
+    match state.upstream_provider.subscription_provider() {
+        Some(provider) => crate::model_routing::pinned_model_catalog(state, provider).await,
+        None => serde_json::json!({"object": "list", "data": []}),
+    }
 }
 
 fn is_event_stream(content_type: &HeaderValue) -> bool {
@@ -488,21 +485,20 @@ fn input_item_text(item: &serde_json::Value) -> Option<String> {
     }
 }
 
+/// Apply provider capability rules, then any provider-specific body shaping.
+fn normalize_subscription_request(provider: SubscriptionProvider, body: &mut serde_json::Value) {
+    crate::openai::reconcile_subscription_parameters(provider, body);
+    if provider == SubscriptionProvider::Codex {
+        normalize_codex_responses_body(body);
+    }
+}
+
 /// Shape a Responses-API request body for the `ChatGPT` Codex backend.
 ///
-/// The Codex backend is stricter than the generic `OpenAI` Responses API:
-/// - it always streams,
-/// - **rejects** `max_output_tokens` (HTTP 400 "Unsupported parameter"),
-/// - **rejects** `system`/`developer` messages inside `input`
-///   (HTTP 400 "System messages are not allowed") — they must be carried in the
-///   top-level `instructions` field,
-/// - **requires** a non-empty `instructions` field (HTTP 400 "Instructions are
-///   required").
-///
-/// Standard Responses clients (e.g. `OpenClaw`'s gateway) send `max_output_tokens`
-/// and put the system prompt as a `system` message in `input`, so without this
-/// shaping the backend rejects every request. System turns are hoisted into
-/// `instructions`; a default is used only if nothing remains.
+/// The Codex backend is stricter than the generic `OpenAI` Responses API: it
+/// always streams, rejects `max_output_tokens` and system/developer input
+/// messages, and requires non-empty top-level `instructions`. System turns are
+/// hoisted into `instructions`; a default is used only if nothing remains.
 fn normalize_codex_responses_body(body: &mut serde_json::Value) {
     let Some(obj) = body.as_object_mut() else {
         return;
@@ -561,10 +557,11 @@ mod tests {
             "model": "gpt-5.5",
             "input": [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}],
             "store": true,
+            "temperature": 0.7,
             "max_output_tokens": 8192,
             "reasoning": {"effort": "none"}
         });
-        normalize_codex_responses_body(&mut body);
+        normalize_subscription_request(SubscriptionProvider::Codex, &mut body);
         assert_eq!(body["stream"], serde_json::Value::Bool(true));
         assert!(
             body.get("max_output_tokens").is_none(),
@@ -573,6 +570,10 @@ mod tests {
         assert_eq!(body["instructions"], "You are a helpful assistant.");
         // ChatGPT subscription inference requires stateless requests.
         assert_eq!(body["store"], serde_json::Value::Bool(false));
+        assert!(
+            body.get("temperature").is_none(),
+            "temperature must be stripped for the ChatGPT subscription backend"
+        );
         // Untouched fields are preserved.
         assert_eq!(body["reasoning"]["effort"], "none");
     }


### PR DESCRIPTION
Fixes #83.

## Summary

- resolve provider health through the shared in-memory token cache, refreshing expired on-disk credentials before model routing
- give background catalog discovery the same refresh-aware token path and record failed refreshes as visible catalog errors
- make `doctor` probe every credential-backed provider, including the active provider, and report expired, refreshed, or upstream-rejected credentials consistently
- reconcile unsupported request parameters by target provider so ChatGPT/Codex requests drop `temperature` as Claude 5 requests already do

## Reproduction

Before this change, `healthy_providers` rejected an expired credential directly from disk. That prevented the existing refresh exchange from running, removed the provider's models from `/v1/models`, and made requests return `404`. `doctor` also skipped the active provider's catalog. Separately, a ChatGPT subscription request containing `temperature` reached the backend unchanged and returned HTTP 400.

The regression tests cover an expired credential backed by a valid in-memory refresh, refresh-aware live catalog fetching, exclusion after refresh cannot produce a current token, automatic routing, and ChatGPT request normalization.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features`
- `cargo test --locked --all-targets --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --no-deps --all-features`
- `rust-script scripts/check-file-size.rs`
- `rust-script --test scripts/version-and-commit.rs`

All checks pass locally. This is not a UI change, so screenshots are not applicable.
