### PR TITLE
fix: normalise string Responses input and treat expiresAt as a hint

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-10T22:38:21.240Z for PR creation at branch issue-85-4cee77a6357b for issue https://github.com/link-assistant/router/issues/85

--- a/changelog.d/20260811_090000_issue_85_string_input_and_credential_evidence.md
+++ b/changelog.d/20260811_090000_issue_85_string_input_and_credential_evidence.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+---
+
+### Fixed
+
+- Normalise a string `input` on `/v1/responses` into the typed single-turn list the ChatGPT backend requires, so both documented forms work again instead of drawing `Input must be a list` (HTTP 400).
+- Treat `expiresAt` as a hint rather than a verdict: a stamped-expired credential stays routable until an upstream actually rejects it (HTTP 401/403), catalog refreshes are attempted with it and fall back to the last known models on failure, and `doctor` reports `invalid_grant` refresh failures as "re-authenticate" instead of "expired".

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -41,29 +41,25 @@ pub async fn subscription_catalog_diagnostics(
         let token = token_cache
             .get_fresh(&client, provider, disk_token, now_ms)
             .await;
-        if token.is_expired(now_ms) {
-            println!(
-                "{label:<23}: {} (found, token EXPIRED; refresh failed)",
-                path.display()
-            );
-            println!(
-                "{:<23}: ERROR (credential is expired and could not be refreshed)",
-                format!("{provider} catalog")
-            );
-            catalog_error = true;
-            continue;
-        }
+        // `expiresAt` is a hint, so a still-expired token is probed rather than
+        // declared dead: the catalog endpoint is what actually knows.
+        let still_expired = token.is_expired(now_ms);
         let catalog = fetch_provider_catalog(&client, provider, &token, None).await;
         let rejected = catalog
             .as_ref()
             .is_err_and(|error| error.starts_with("HTTP 401") || error.starts_with("HTTP 403"));
-        let status = match (was_expired, rejected) {
-            (true, true) => "found, token REJECTED after refresh",
-            (false, true) => "found, token REJECTED",
-            (true, false) => "found, token OK (refreshed in memory)",
-            (false, false) => "found, token OK",
+        let status = match (was_expired, still_expired, rejected) {
+            (_, true, true) => "found, token EXPIRED and REJECTED",
+            (_, true, false) => "found, token EXPIRED on disk but ACCEPTED upstream",
+            (true, false, true) => "found, token REJECTED after refresh",
+            (false, _, true) => "found, token REJECTED",
+            (true, false, false) => "found, token OK (refreshed in memory)",
+            (false, false, false) => "found, token OK",
         };
         println!("{label:<23}: {} ({status})", path.display());
+        if let Some(error) = token_cache.last_refresh_error(provider) {
+            println!("{:<23}: {error}", format!("{provider} refresh"));
+        }
 
         match catalog {
             Ok(models) => println!(

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -133,14 +133,14 @@ pub async fn refresh_catalogs(
             let token = token_cache
                 .get_fresh(client, provider, disk_token, now_ms)
                 .await;
-            let result = if token.is_expired(now_ms) {
-                Err("credential is expired and could not be refreshed".to_string())
-            } else {
-                fetch_provider_catalog(client, provider, &token, None).await
-            };
-            (provider, result)
+            // A stamped-expired credential is still tried: `expiresAt` is a
+            // hint, and the catalog endpoint is the authority on whether this
+            // token works for *it*.
+            let stamped_expired = token.is_expired(now_ms);
+            let result = fetch_provider_catalog(client, provider, &token, None).await;
+            (provider, stamped_expired, result)
         });
-    for (provider, result) in futures_util::future::join_all(refreshes).await {
+    for (provider, stamped_expired, result) in futures_util::future::join_all(refreshes).await {
         match result {
             Ok(models) => {
                 tracing::info!(
@@ -150,6 +150,15 @@ pub async fn refresh_catalogs(
                 cache.record_success(provider, models);
             }
             Err(error) => {
+                // A catalog rejection is evidence about the catalog endpoint
+                // only. The provider keeps serving from its last known models
+                // (`using_fallback` says whether those are the bundled ones),
+                // and routing keeps offering it until inference itself fails.
+                let error = if stamped_expired {
+                    format!("{error} (credential is stamped expired; last known catalog retained)")
+                } else {
+                    error
+                };
                 tracing::warn!("failed to refresh {provider} model catalog: {error}");
                 cache.record_failure(provider, &error);
             }
@@ -421,6 +430,53 @@ mod tests {
 
         assert_eq!(catalogs.models(SubscriptionProvider::Qwen), ["qwen-live"]);
         assert!(!catalogs.status(SubscriptionProvider::Qwen).using_fallback);
+    }
+
+    /// A stamped-expired credential is still probed, and when the catalog
+    /// endpoint rejects it the provider keeps serving its last known models
+    /// instead of losing its catalog to a timestamp.
+    #[tokio::test]
+    async fn expired_credential_is_still_probed_and_keeps_its_cached_catalog() {
+        async fn handler() -> (axum::http::StatusCode, &'static str) {
+            (axum::http::StatusCode::UNAUTHORIZED, "expired token")
+        }
+
+        let app = Router::new().route("/compatible-mode/v1/models", get(handler));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let home = tempdir().unwrap();
+        fs::write(
+            home.path().join("oauth_creds.json"),
+            format!(
+                r#"{{"access_token":"expired","expiry_date":1000,"resource_url":"http://{address}"}}"#
+            ),
+        )
+        .unwrap();
+        let readers = vec![SubscriptionReader::new(
+            SubscriptionProvider::Qwen,
+            home.path(),
+        )];
+        let catalogs = ModelCatalogCache::new();
+        catalogs.record_success(SubscriptionProvider::Qwen, vec!["qwen-known".to_string()]);
+
+        refresh_catalogs(
+            &reqwest::Client::new(),
+            &readers,
+            &crate::refresh::TokenCache::new(),
+            &catalogs,
+        )
+        .await;
+
+        let status = catalogs.status(SubscriptionProvider::Qwen);
+        // The fetch was actually attempted (the 401 proves the request went out)
+        // rather than short-circuited on `expiresAt`...
+        let error = status.last_error.expect("catalog fetch was attempted");
+        assert!(error.starts_with("HTTP 401"), "{error}");
+        assert!(error.contains("stamped expired"), "{error}");
+        // ...and the last known catalog survives the failure.
+        assert_eq!(status.models, ["qwen-known"]);
     }
 
     #[test]

--- a/src/model_routing.rs
+++ b/src/model_routing.rs
@@ -89,8 +89,15 @@ pub fn available_provider_for_model(
         })
 }
 
-/// Readers whose credential can supply a current access token, refreshing an
+/// Readers whose credential can plausibly serve a request, refreshing an
 /// expired on-disk token into the shared in-memory cache when possible.
+///
+/// `expiresAt` is treated as a *hint*, not a verdict. Vendors have been
+/// observed to keep honouring a stamped-expired access token on the inference
+/// endpoint while rejecting it on `/v1/models`, so a credential that cannot be
+/// refreshed is still offered for routing — the upstream gets to decide. Only
+/// positive evidence (an upstream 401/403 recorded by a real call, see
+/// [`crate::refresh::CredentialEvidence`]) removes a provider.
 pub async fn healthy_providers(
     client: &reqwest::Client,
     readers: &[SubscriptionReader],
@@ -107,7 +114,21 @@ pub async fn healthy_providers(
             let token = token_cache
                 .get_fresh(client, provider, disk_token, now_ms)
                 .await;
-            (!token.is_expired(now_ms)).then_some(provider)
+            if !token.is_expired(now_ms) {
+                return Some(provider);
+            }
+            if token_cache.evidence(provider) == Some(crate::refresh::CredentialEvidence::Rejected)
+            {
+                tracing::debug!(
+                    "{provider} credential is expired and was rejected upstream; not routable"
+                );
+                return None;
+            }
+            tracing::debug!(
+                "{provider} credential is stamped expired and could not be refreshed; keeping it \
+                 routable until an upstream rejects it"
+            );
+            Some(provider)
         });
     futures_util::future::join_all(checks)
         .await
@@ -435,22 +456,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn missing_and_expired_credentials_are_not_healthy() {
+    async fn missing_credentials_are_not_healthy() {
         let live = tempdir().unwrap();
-        let expired = tempdir().unwrap();
+        let absent = tempdir().unwrap();
         fs::write(
             live.path().join("auth.json"),
             r#"{"tokens":{"access_token":"live"}}"#,
         )
         .unwrap();
-        fs::write(
-            expired.path().join("oauth_creds.json"),
-            r#"{"access_token":"old","expiry_date":1000}"#,
-        )
-        .unwrap();
         let readers = vec![
             SubscriptionReader::new(SubscriptionProvider::Codex, live.path()),
-            SubscriptionReader::new(SubscriptionProvider::Gemini, expired.path()),
+            SubscriptionReader::new(SubscriptionProvider::Gemini, absent.path()),
         ];
         assert_eq!(
             healthy_providers(
@@ -461,6 +477,36 @@ mod tests {
             )
             .await,
             vec![SubscriptionProvider::Codex]
+        );
+    }
+
+    /// A stamped-expired credential that cannot be refreshed may still be
+    /// honoured by the inference endpoint, so `expiresAt` alone must not drop
+    /// the provider from routing.
+    #[tokio::test]
+    async fn expired_credential_stays_routable_without_an_upstream_rejection() {
+        let expired = tempdir().unwrap();
+        fs::write(
+            expired.path().join("oauth_creds.json"),
+            r#"{"access_token":"old","expiry_date":1000}"#,
+        )
+        .unwrap();
+        let readers = vec![SubscriptionReader::new(
+            SubscriptionProvider::Gemini,
+            expired.path(),
+        )];
+        let cache = crate::refresh::TokenCache::new();
+        assert_eq!(
+            healthy_providers(&reqwest::Client::new(), &readers, &cache, 2000).await,
+            vec![SubscriptionProvider::Gemini]
+        );
+
+        // An observed upstream 401/403 is the evidence that does drop it.
+        cache.record_credential_rejected(SubscriptionProvider::Gemini);
+        assert!(
+            healthy_providers(&reqwest::Client::new(), &readers, &cache, 2000)
+                .await
+                .is_empty()
         );
     }
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -324,7 +324,7 @@ pub async fn proxy_handler(State(state): State<AppState>, req: Request) -> Respo
     let status = StatusCode::from_u16(upstream_resp.status().as_u16())
         .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
     let retry_after = retry_after_duration(upstream_resp.headers());
-
+    crate::request_routing::record_claude_evidence(&state, status.as_u16());
     state
         .logger
         .verbose(|| format!("Upstream responded: {status}"));

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -157,16 +157,44 @@ pub enum RefreshError {
     Parse(String),
 }
 
+impl RefreshError {
+    /// Whether the token endpoint rejected the *refresh token itself*.
+    ///
+    /// OAuth reports this as `invalid_grant`. It is worth separating from every
+    /// other refresh failure because it is the one case waiting cannot fix:
+    /// the stored refresh token is gone or revoked, so the only remedy is to
+    /// re-authenticate.
+    #[must_use]
+    pub fn is_invalid_grant(&self) -> bool {
+        matches!(self, Self::Status(_, body) if body.contains("invalid_grant"))
+    }
+}
+
 impl std::fmt::Display for RefreshError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Unsupported => write!(f, "provider does not support router-driven refresh"),
             Self::NoRefreshToken => write!(f, "no refresh token available"),
             Self::Request(m) => write!(f, "refresh request failed: {m}"),
+            Self::Status(_, m) if self.is_invalid_grant() => write!(
+                f,
+                "refresh token is no longer valid (invalid_grant) — re-authenticate this \
+                 subscription; waiting will not help: {m}"
+            ),
             Self::Status(code, m) => write!(f, "refresh endpoint returned {code}: {m}"),
             Self::Parse(m) => write!(f, "refresh response parse error: {m}"),
         }
     }
+}
+
+/// What real upstream calls have said about a credential, as opposed to what
+/// its `expiresAt` timestamp claims.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CredentialEvidence {
+    /// An upstream call succeeded with this credential.
+    Working,
+    /// An upstream call rejected this credential (HTTP 401/403).
+    Rejected,
 }
 
 impl std::error::Error for RefreshError {}
@@ -293,9 +321,15 @@ async fn refresh_at(
 ///
 /// Holds only in-memory copies obtained via OAuth refresh; vendor credential
 /// files on disk are never modified.
+/// Also records what upstreams actually said about each credential, so health
+/// decisions can be based on observed behaviour rather than on `expiresAt`.
 #[derive(Debug, Default)]
 pub struct TokenCache {
     inner: Mutex<HashMap<(SubscriptionProvider, String), SubscriptionToken>>,
+    /// Latest observed verdict per provider from real upstream calls.
+    evidence: Mutex<HashMap<SubscriptionProvider, CredentialEvidence>>,
+    /// Latest refresh failure per provider, cleared by a successful refresh.
+    refresh_errors: Mutex<HashMap<SubscriptionProvider, String>>,
 }
 
 impl TokenCache {
@@ -344,12 +378,72 @@ impl TokenCache {
         match refresh(client, provider, &disk_token, now_ms).await {
             Ok(fresh) => {
                 self.store_for(provider, account, fresh.clone());
+                if let Ok(mut guard) = self.refresh_errors.lock() {
+                    guard.remove(&provider);
+                }
                 fresh
             }
             Err(e) => {
                 tracing::warn!("subscription token refresh for {provider} failed: {e}");
+                self.record_refresh_error(provider, &e.to_string());
+                // The stamped-expired token is returned unchanged on purpose:
+                // it may still be honoured by the inference endpoint.
                 disk_token
             }
+        }
+    }
+
+    /// Record that an upstream call succeeded with `provider`'s credential.
+    pub fn record_credential_working(&self, provider: SubscriptionProvider) {
+        self.record_evidence(provider, CredentialEvidence::Working);
+    }
+
+    /// Record what an upstream status code says about `provider`'s credential.
+    ///
+    /// This is the evidence [`crate::model_routing::healthy_providers`] trusts
+    /// over `expiresAt`: a served request proves the credential works even when
+    /// its timestamp says otherwise, and only a 401/403 proves it does not.
+    /// Every other status describes the request, not the credential.
+    pub fn record_status(&self, provider: SubscriptionProvider, status: u16) {
+        if status == 401 || status == 403 {
+            self.record_credential_rejected(provider);
+        } else if (200..300).contains(&status) {
+            self.record_credential_working(provider);
+        }
+    }
+
+    /// Record that an upstream rejected `provider`'s credential (401/403).
+    pub fn record_credential_rejected(&self, provider: SubscriptionProvider) {
+        self.record_evidence(provider, CredentialEvidence::Rejected);
+    }
+
+    /// The most recent upstream verdict for `provider`, if any call was made.
+    #[must_use]
+    pub fn evidence(&self, provider: SubscriptionProvider) -> Option<CredentialEvidence> {
+        self.evidence
+            .lock()
+            .ok()
+            .and_then(|guard| guard.get(&provider).copied())
+    }
+
+    /// The most recent refresh failure for `provider`, if the last attempt failed.
+    #[must_use]
+    pub fn last_refresh_error(&self, provider: SubscriptionProvider) -> Option<String> {
+        self.refresh_errors
+            .lock()
+            .ok()
+            .and_then(|guard| guard.get(&provider).cloned())
+    }
+
+    fn record_evidence(&self, provider: SubscriptionProvider, evidence: CredentialEvidence) {
+        if let Ok(mut guard) = self.evidence.lock() {
+            guard.insert(provider, evidence);
+        }
+    }
+
+    fn record_refresh_error(&self, provider: SubscriptionProvider, error: &str) {
+        if let Ok(mut guard) = self.refresh_errors.lock() {
+            guard.insert(provider, error.to_string());
         }
     }
 
@@ -627,6 +721,67 @@ mod tests {
             .get_fresh(&client, SubscriptionProvider::Qwen, expired_disk, 1_000)
             .await;
         assert_eq!(out.access_token, "cached-access");
+    }
+
+    /// "expired" invites waiting; a dead refresh token needs re-authentication,
+    /// so the two must not read the same.
+    #[test]
+    fn invalid_grant_is_reported_as_a_re_authentication_prompt() {
+        let dead = RefreshError::Status(
+            400,
+            r#"{"error":"invalid_grant","error_description":"Refresh token not found or invalid"}"#
+                .to_string(),
+        );
+        assert!(dead.is_invalid_grant());
+        let message = dead.to_string();
+        assert!(message.contains("re-authenticate"), "{message}");
+        assert!(message.contains("invalid_grant"), "{message}");
+
+        let transient = RefreshError::Status(503, "upstream busy".to_string());
+        assert!(!transient.is_invalid_grant());
+        assert!(!transient.to_string().contains("re-authenticate"));
+    }
+
+    /// A failed refresh must leave an actionable trace for `doctor`, and a later
+    /// success must clear it.
+    #[test]
+    fn refresh_errors_are_recorded_per_provider_and_cleared() {
+        let cache = TokenCache::new();
+        assert!(
+            cache
+                .last_refresh_error(SubscriptionProvider::Claude)
+                .is_none()
+        );
+        cache.record_refresh_error(SubscriptionProvider::Claude, "invalid_grant");
+        assert_eq!(
+            cache
+                .last_refresh_error(SubscriptionProvider::Claude)
+                .as_deref(),
+            Some("invalid_grant")
+        );
+        assert!(
+            cache
+                .last_refresh_error(SubscriptionProvider::Codex)
+                .is_none()
+        );
+    }
+
+    /// Upstream verdicts, not timestamps, decide whether a credential is dead.
+    #[test]
+    fn credential_evidence_records_the_latest_upstream_verdict() {
+        let cache = TokenCache::new();
+        assert!(cache.evidence(SubscriptionProvider::Claude).is_none());
+        cache.record_credential_rejected(SubscriptionProvider::Claude);
+        assert_eq!(
+            cache.evidence(SubscriptionProvider::Claude),
+            Some(CredentialEvidence::Rejected)
+        );
+        // A credential can come back (re-authentication, vendor-side fix).
+        cache.record_credential_working(SubscriptionProvider::Claude);
+        assert_eq!(
+            cache.evidence(SubscriptionProvider::Claude),
+            Some(CredentialEvidence::Working)
+        );
     }
 
     #[test]

--- a/src/request_routing.rs
+++ b/src/request_routing.rs
@@ -60,3 +60,12 @@ pub fn retry_after_duration(headers: &HeaderMap) -> Option<Duration> {
         .max(0);
     Some(Duration::from_secs(u64::try_from(seconds).ok()?))
 }
+
+/// Record what the Anthropic upstream just said about the Claude credential.
+///
+/// The response status is the only authority on whether a credential still
+/// works; see [`crate::refresh::CredentialEvidence`].
+pub fn record_claude_evidence(state: &crate::app_state::AppState, status: u16) {
+    let cache = &state.subscription_cache;
+    cache.record_status(crate::subscription::SubscriptionProvider::Claude, status);
+}

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -95,6 +95,35 @@ pub fn response_to_anthropic(req: &OpenAIResponseRequest) -> Value {
     body
 }
 
+/// Normalise a Responses-API `input` field to the typed list shape.
+///
+/// The documented Responses API accepts either a bare string or a list of
+/// input items, but the `ChatGPT` backend accepts only the list form and
+/// answers a string with `{"detail":"Input must be a list"}` (HTTP 400). Both
+/// documented forms therefore have to be normalised here before forwarding:
+/// a string becomes a single user turn, and bare strings inside the list get
+/// the same treatment. Anything already typed is passed through untouched.
+#[must_use]
+pub fn normalize_input_items(input: &Value) -> Value {
+    fn user_turn(text: &str) -> Value {
+        json!({
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": text}],
+        })
+    }
+    match input {
+        Value::String(text) => json!([user_turn(text)]),
+        Value::Array(items) => Value::Array(
+            items
+                .iter()
+                .map(|item| item.as_str().map_or_else(|| item.clone(), user_turn))
+                .collect(),
+        ),
+        other => other.clone(),
+    }
+}
+
 /// Translate an `OpenAI` Chat Completions request body to an `OpenAI`
 /// Responses-API request body.
 ///
@@ -313,6 +342,20 @@ mod tests {
         assert_eq!(out["input"][0]["role"], "user");
         assert_eq!(out["input"][0]["content"][0]["type"], "input_text");
         assert_eq!(out["input"][1]["content"][0]["type"], "output_text");
+    }
+
+    #[test]
+    fn normalizes_string_input_and_preserves_typed_input() {
+        let typed = json!([{
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "скажи ок"}],
+        }]);
+        assert_eq!(
+            normalize_input_items(&Value::String("скажи ок".into())),
+            typed
+        );
+        assert_eq!(normalize_input_items(&typed), typed);
     }
 
     #[test]

--- a/src/subscription_proxy.rs
+++ b/src/subscription_proxy.rs
@@ -190,6 +190,9 @@ pub async fn forward_subscription_openai(
     state
         .metrics
         .record_request(surface, status.as_u16(), selected_account.as_deref());
+    state
+        .subscription_cache
+        .record_status(provider, status.as_u16());
     let retry_after = retry_after_duration(upstream_resp.headers());
     if status == StatusCode::TOO_MANY_REQUESTS {
         if let (Some(router), Some(account)) =
@@ -509,6 +512,12 @@ fn normalize_codex_responses_body(body: &mut serde_json::Value) {
     obj.insert("store".to_string(), serde_json::Value::Bool(false));
     // `max_output_tokens` is not accepted by the Codex backend.
     obj.remove("max_output_tokens");
+    // The backend rejects a bare-string `input` ("Input must be a list"), so
+    // normalise both documented forms to the typed list shape.
+    if let Some(input) = obj.get("input") {
+        let normalized = crate::responses::normalize_input_items(input);
+        obj.insert("input".to_string(), normalized);
+    }
 
     // Hoist system/developer turns out of `input` (Codex forbids them there).
     let mut hoisted: Vec<String> = Vec::new();
@@ -576,6 +585,41 @@ mod tests {
         );
         // Untouched fields are preserved.
         assert_eq!(body["reasoning"]["effort"], "none");
+    }
+
+    /// Both documented `input` forms must reach the `ChatGPT` backend as a list;
+    /// the string form previously went through unchanged and drew a 400
+    /// ("Input must be a list").
+    #[test]
+    fn codex_normalizes_both_documented_input_forms_to_a_list() {
+        let typed = serde_json::json!([{
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "скажи ок"}],
+        }]);
+
+        let mut string_form = serde_json::json!({
+            "model": "gpt-5.6-sol",
+            "input": "скажи ок",
+        });
+        normalize_codex_responses_body(&mut string_form);
+        assert_eq!(string_form["input"], typed);
+
+        // The list form is already correct and must survive untouched.
+        let mut list_form = serde_json::json!({
+            "model": "gpt-5.6-sol",
+            "input": typed,
+        });
+        normalize_codex_responses_body(&mut list_form);
+        assert_eq!(list_form["input"], typed);
+
+        // A bare string inside the list is the same defect one level down.
+        let mut mixed = serde_json::json!({
+            "model": "gpt-5.6-sol",
+            "input": ["скажи ок"],
+        });
+        normalize_codex_responses_body(&mut mixed);
+        assert_eq!(mixed["input"], typed);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #85.

## 1. `/v1/responses` rejects a string `input`

**Reproduce**

```bash
curl -s localhost:8787/v1/responses -H 'authorization: Bearer $TOKEN' \
  -d '{"model":"gpt-5.6-sol","input":"скажи ок"}'
# {"detail":"Input must be a list"}   HTTP 400
```

**Root cause** — `normalize_codex_responses_body` (`src/subscription_proxy.rs`) only ever
manipulated `input` when it was already a `Value::Array` (to hoist system/developer turns into
`instructions`). A `Value::String` fell straight through to the ChatGPT backend, which accepts
only the list form. The Responses API documents both.

**Fix** — `responses::normalize_input_items` converts a bare string (and any bare string inside
the list) into the typed single user turn `{"type":"message","role":"user","content":[{"type":"input_text","text":…}]}`,
leaving already-typed items untouched. It runs before the system-turn hoisting.

**Tests** — `responses::tests::normalizes_string_input_and_preserves_typed_input` and
`subscription_proxy::tests::codex_normalizes_both_documented_input_forms_to_a_list`, which asserts
the string form, the already-typed list form and `["скажи ок"]` all leave the router as the same
list. #70 was the mirror image of this gap, so both forms are now pinned.

## 2. `expiresAt` treated as a verdict while the credential still works

**Reproduce** — a Claude credential stamped expired is dropped by `GET /v1/models` (401) although
`/v1/messages` still returns a real completion with real usage.

**Root cause** — `model_routing::healthy_providers` returned `(!token.is_expired(now_ms)).then_some(provider)`,
and `model_catalog::refresh_catalogs` short-circuited with `credential is expired and could not be
refreshed` without ever contacting the vendor. A timestamp alone removed a working provider.

**Fix** — `expiresAt` is now a hint:

- `TokenCache` records `CredentialEvidence` (`Working`/`Rejected`) from real upstream statuses;
  both inference forwarders report it (`proxy.rs` Anthropic path, `subscription_proxy.rs`
  OpenAI-shaped path).
- A stamped-expired provider stays routable until an upstream 401/403 is actually observed.
- Catalog refresh is attempted with the stamped-expired token; on failure the last known models
  are kept (`using_fallback`) and the error says why.
- `doctor` distinguishes `EXPIRED on disk but ACCEPTED upstream` from `EXPIRED and REJECTED`, and
  surfaces `invalid_grant` as "re-authenticate this subscription; waiting will not help".

**Tests** — `model_routing::tests::expired_credential_stays_routable_without_an_upstream_rejection`,
`model_catalog::tests::expired_credential_is_still_probed_and_keeps_its_cached_catalog` (stub
upstream answering 401), and three `refresh::tests` covering evidence recording and the
`invalid_grant` message.

## Checks

`cargo fmt --check`, `cargo clippy --all-targets --all-features` (clean), `cargo test` — 425 tests,
0 failures. `src/proxy.rs` stays at the 1000-line project limit. A `changelog.d` fragment
(`bump: patch`) is included to trigger the release.
