### PR TITLE
feat(auth): add provider-aware authorization

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-08-10T22:38:21.240Z for PR creation at branch issue-85-4cee77a6357b for issue https://github.com/link-assistant/router/issues/85
+# Updated: 2026-08-11T08:03:51.665Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-10T22:38:21.240Z for PR creation at branch issue-85-4cee77a6357b for issue https://github.com/link-assistant/router/issues/85
-# Updated: 2026-08-11T08:03:51.665Z

--- a/README.md
+++ b/README.md
@@ -311,17 +311,24 @@ Claude Code will work exactly as normal, with all requests transparently proxied
 ### Login surface (`--disable-login-api` to opt out)
 
 Authorizes a deployment that has no credential file — see
-[docs/use-cases/remote-login.md](docs/use-cases/remote-login.md). By default it
-drives the TUI `/login` flow, which requests Claude Code's full scope set;
+[docs/use-cases/remote-login.md](docs/use-cases/remote-login.md). The optional
+`provider` request field selects `claude` (the backwards-compatible default)
+or `codex`. Claude drives the TUI `/login` flow and requests its full scope set;
 `LOGIN_CLI_ARGS=setup-token` explicitly selects the narrower `user:inference`
-flow. The use-case guide lists every requested scope.
+flow. Codex binds a temporary PKCE loopback listener and needs no vendor CLI.
+The use-case guide lists the networking requirement and every requested scope.
 
 | Endpoint | Method | Description |
 |---|---|---|
-| `/api/login` | POST | (admin) Start a login; returns `login_id` and the URL the human must open |
-| `/api/login/{id}` | GET | (admin) Status: `awaiting_code`, `authorized`, `failed` or `expired` |
+| `/api/login` | POST | (admin) Start a login; optional body: `{"provider":"claude"|"codex"}` |
+| `/api/login/{id}` | GET | (admin) Status includes `awaiting_code` (Claude) or `awaiting_callback` (Codex) |
 | `/api/login/{id}` | DELETE | (admin) Cancel a pending login and kill its process |
 | `/api/login/{id}/code` | POST | (admin) Submit the code the human copied from the browser |
+
+For a foreground local login, use `link-assistant-router auth claude`,
+`auth claude --code <code>`, or `auth codex`. `auth status` reports each
+provider credential as `usable`, `expired`, or `absent`. `--flow` can enforce
+`code` or `loopback`; unsupported forced flows fail instead of falling back.
 
 ### Admin UI surface (`--admin-port` to opt in)
 

--- a/changelog.d/20260811_100000_provider_authorization.md
+++ b/changelog.d/20260811_100000_provider_authorization.md
@@ -1,0 +1,7 @@
+---
+bump: minor
+---
+
+### Added
+
+- Add provider-aware authorization for Claude and Codex: `auth` CLI commands, Codex PKCE loopback login with strict state and listener lifecycle handling, provider status, and `POST /api/login` support for `{"provider":"codex"}`.

--- a/docs/use-cases/remote-login.md
+++ b/docs/use-cases/remote-login.md
@@ -7,18 +7,17 @@ problem this solves:
 > that was produced somewhere else. There is no way to log in *to the
 > deployment*.
 
-This document covers that scenario: a container that starts with an empty
-`CLAUDE_CODE_HOME` and is authorized entirely through three HTTP calls, with a
-human doing only the part a human must do — opening a URL in a browser.
+This document covers Claude's copied-code flow and Codex's PKCE loopback flow.
+In both cases the human only opens the returned URL and approves access.
 
 ## The flow
 
 | Request | Does |
 | --- | --- |
-| `POST /api/login` | Starts the Claude Code CLI on a PTY **inside the container** and returns the authorization URL it printed |
-| *(human)* | Opens that URL, approves, copies the code the browser shows |
-| `POST /api/login/{id}/code` | Types that code into the **same, still-running** process |
-| `GET /api/login/{id}` | Reports `awaiting_code`, `authorized`, `failed` or `expired` |
+| `POST /api/login` | Starts Claude by default; `{"provider":"codex"}` binds Codex's callback listener before returning its URL |
+| *(human)* | Opens that URL and approves; Claude displays a code, while Codex redirects to its listener |
+| `POST /api/login/{id}/code` | Claude only: types the copied code into the **same, still-running** process |
+| `GET /api/login/{id}` | Reports `awaiting_code`, `awaiting_callback`, `authorized`, `failed` or `expired` |
 | `DELETE /api/login/{id}` | Cancels a pending login and kills its process |
 
 The middle step can take minutes, so the process started by the first request
@@ -63,6 +62,35 @@ The deployment is now authorized: the credential is written into
 `CLAUDE_CODE_HOME` in the layout the proxy reads, and the proxy's cached token
 is refreshed, so the very next `/v1/messages` request works without a restart.
 
+### Codex / ChatGPT
+
+Codex displays no code to paste. Start its provider-aware session instead:
+
+```console
+$ curl -s -X POST http://localhost:8080/api/login \
+    -H "Authorization: Bearer $ADMIN" \
+    -H 'content-type: application/json' \
+    -d '{"provider":"codex"}'
+{
+  "login_id": "7ab1…",
+  "provider": "codex",
+  "status": "awaiting_callback",
+  "url": "https://auth.openai.com/oauth/authorize?…redirect_uri=http%3A%2F%2Flocalhost%3A1455%2Fauth%2Fcallback…"
+}
+```
+
+The router has already bound port 1455 when this response arrives. The browser
+callback exchanges the code with its PKCE verifier and atomically writes
+`$CODEX_HOME/auth.json`; a mismatched `state` is rejected without ending the
+wait. The listener closes on success, failure, cancellation, or timeout.
+
+Because OpenAI registers a loopback redirect, the browser's `localhost:1455`
+must reach the router process. For Docker, publish both ports with
+`-p 8080:8080 -p 1455:1455`. For a remote host, forward it first, for example
+`ssh -L 1455:localhost:1455 router-host`. The foreground
+`link-assistant-router auth codex` command is simpler when run on the browser's
+machine and does not require the Codex CLI to be installed.
+
 Polling is available for clients that would rather not block:
 
 ```console
@@ -75,6 +103,7 @@ $ curl -s http://localhost:8080/api/login/3f2b… -H "Authorization: Bearer $ADM
 | `status` | Meaning |
 | --- | --- |
 | `awaiting_code` | The URL is live and the process is parked, waiting for a code |
+| `awaiting_callback` | The Codex loopback listener is bound and waiting for the browser |
 | `authorized` | A credential exists and is readable by the proxy |
 | `failed` | The CLI rejected the code, or no credential was produced; `error` says which |
 | `expired` | The session's TTL elapsed before a code arrived; its process was killed |
@@ -132,6 +161,19 @@ Use the default when the deployment should receive the same credential Claude
 Code produces interactively. Choose `setup-token` explicitly when the narrower,
 long-lived credential intended for non-interactive consumers is preferable.
 
+For local or scripted authorization, use the foreground commands:
+
+```bash
+link-assistant-router auth claude
+link-assistant-router auth claude --code "$CODE"
+link-assistant-router auth codex
+link-assistant-router auth status
+```
+
+Claude supports `--flow code`; Codex supports `--flow loopback`. A forced
+`device` flow fails clearly because neither vendor currently advertises one
+for these clients.
+
 ## Requirements
 
 * **The CLI must exist in the image.** The default flow drives the Claude Code
@@ -143,6 +185,8 @@ long-lived credential intended for non-interactive consumers is preferable.
 * **`CLAUDE_CODE_HOME` must be writable.** This is checked *before* the URL is
   returned, so a read-only mount fails immediately rather than after the human
   has already finished the browser step.
+* **`CODEX_HOME` must be writable for Codex.** The router performs Codex OAuth
+  directly, so no Codex CLI image variant is required.
 
 ## What is tested
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,0 +1,512 @@
+//! Provider-aware interactive subscription authorization.
+//!
+//! Claude uses its vendor CLI's copy/paste flow. Codex uses an OAuth 2.0
+//! authorization-code flow with PKCE and a temporary loopback callback server.
+
+use std::collections::HashMap;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use axum::Router;
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::routing::get;
+use base64::Engine as _;
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use tokio::sync::{mpsc, oneshot};
+
+/// Public OAuth client id embedded by the Codex CLI.
+pub const CODEX_CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
+/// Default `OpenAI` OAuth issuer.
+pub const CODEX_ISSUER: &str = "https://auth.openai.com";
+/// Callback path registered for the Codex public client.
+pub const CODEX_CALLBACK_PATH: &str = "/auth/callback";
+
+/// Settings for one Codex loopback authorization.
+#[derive(Clone, Debug)]
+pub struct CodexAuthConfig {
+    /// OAuth issuer; overridable so tests can use a local token endpoint.
+    pub issuer: String,
+    /// Public OAuth client id.
+    pub client_id: String,
+    /// Preferred callback port. Zero asks the OS for a free port.
+    pub port: u16,
+    /// Directory in which `auth.json` is written.
+    pub codex_home: PathBuf,
+    /// Maximum time to wait for the browser callback.
+    pub timeout: Duration,
+    /// Interface on which the callback listener is reachable.
+    pub bind_host: String,
+}
+
+impl CodexAuthConfig {
+    /// Production configuration for a resolved Codex home.
+    #[must_use]
+    pub fn production(codex_home: PathBuf, port: u16, timeout: Duration) -> Self {
+        Self {
+            issuer: CODEX_ISSUER.to_string(),
+            client_id: CODEX_CLIENT_ID.to_string(),
+            port,
+            codex_home,
+            timeout,
+            bind_host: "127.0.0.1".to_string(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct CallbackState {
+    expected_state: String,
+    outcome_tx: mpsc::Sender<Result<String, String>>,
+    handled: AtomicBool,
+}
+
+/// A bound Codex callback listener waiting for the browser round trip.
+pub struct CodexLogin {
+    config: CodexAuthConfig,
+    redirect_uri: String,
+    authorization_url: String,
+    code_verifier: String,
+    outcome_rx: mpsc::Receiver<Result<String, String>>,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+    server: tokio::task::JoinHandle<()>,
+}
+
+impl CodexLogin {
+    /// Bind the callback port before constructing and exposing the URL.
+    pub async fn bind(config: CodexAuthConfig) -> Result<Self, String> {
+        let listener = tokio::net::TcpListener::bind((config.bind_host.as_str(), config.port))
+            .await
+            .map_err(|error| format!("could not bind Codex callback listener: {error}"))?;
+        let port = listener
+            .local_addr()
+            .map_err(|error| format!("could not inspect callback listener: {error}"))?
+            .port();
+        let redirect_uri = format!("http://localhost:{port}{CODEX_CALLBACK_PATH}");
+        let state = random_urlsafe();
+        let code_verifier = format!("{}{}", random_urlsafe(), random_urlsafe());
+        let challenge = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(Sha256::digest(code_verifier.as_bytes()));
+        let authorization_url = authorize_url(
+            &config.issuer,
+            &config.client_id,
+            &redirect_uri,
+            &state,
+            &challenge,
+        );
+
+        let (outcome_tx, outcome_rx) = mpsc::channel(1);
+        let callback_state = Arc::new(CallbackState {
+            expected_state: state,
+            outcome_tx,
+            handled: AtomicBool::new(false),
+        });
+        let app = Router::new()
+            .route(CODEX_CALLBACK_PATH, get(callback))
+            .with_state(callback_state);
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            let _ = axum::serve(listener, app)
+                .with_graceful_shutdown(async {
+                    let _ = shutdown_rx.await;
+                })
+                .await;
+        });
+
+        Ok(Self {
+            config,
+            redirect_uri,
+            authorization_url,
+            code_verifier,
+            outcome_rx,
+            shutdown_tx: Some(shutdown_tx),
+            server,
+        })
+    }
+
+    /// URL the operator must open after the listener has been bound.
+    #[must_use]
+    pub fn authorization_url(&self) -> &str {
+        &self.authorization_url
+    }
+
+    /// Actual loopback port, including when port zero selected a free one.
+    #[must_use]
+    pub fn port(&self) -> u16 {
+        self.redirect_uri
+            .split(':')
+            .nth(2)
+            .and_then(|tail| tail.split('/').next())
+            .and_then(|value| value.parse().ok())
+            .expect("redirect URI was built from a u16 port")
+    }
+
+    /// Wait for a valid callback, exchange its code, persist the credential,
+    /// and stop the callback server on every exit path.
+    pub async fn complete(mut self) -> Result<PathBuf, String> {
+        let callback = tokio::time::timeout(self.config.timeout, self.outcome_rx.recv()).await;
+        // The listener's only job is receiving one valid callback. Release the
+        // port before doing a potentially slow token exchange.
+        self.stop().await;
+        match callback {
+            Ok(Some(Ok(code))) => {
+                exchange_and_store(&self.config, &self.redirect_uri, &self.code_verifier, &code)
+                    .await
+            }
+            Ok(Some(Err(error))) => Err(error),
+            Ok(None) => Err("Codex callback listener stopped before authorization".to_string()),
+            Err(_) => Err("timed out waiting for the Codex callback".to_string()),
+        }
+    }
+
+    async fn stop(&mut self) {
+        if let Some(shutdown) = self.shutdown_tx.take() {
+            let _ = shutdown.send(());
+        }
+        let _ = (&mut self.server).await;
+    }
+}
+
+impl Drop for CodexLogin {
+    fn drop(&mut self) {
+        if let Some(shutdown) = self.shutdown_tx.take() {
+            let _ = shutdown.send(());
+        }
+        self.server.abort();
+    }
+}
+
+async fn callback(
+    State(state): State<Arc<CallbackState>>,
+    Query(query): Query<HashMap<String, String>>,
+) -> (StatusCode, &'static str) {
+    if query.get("state") != Some(&state.expected_state) {
+        return (
+            StatusCode::BAD_REQUEST,
+            "OAuth state did not match; authorization is still waiting",
+        );
+    }
+    if state
+        .handled
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return (
+            StatusCode::CONFLICT,
+            "Authorization callback was already handled",
+        );
+    }
+    let outcome = query.get("error").map_or_else(
+        || {
+            query
+                .get("code")
+                .filter(|value| !value.is_empty())
+                .cloned()
+                .ok_or_else(|| "Codex callback contained no authorization code".to_string())
+        },
+        |error| Err(format!("Codex authorization failed: {error}")),
+    );
+    let success = outcome.is_ok();
+    if state.outcome_tx.try_send(outcome).is_ok() {
+        if success {
+            (
+                StatusCode::OK,
+                "Authorization received. You can close this window.",
+            )
+        } else {
+            (
+                StatusCode::BAD_REQUEST,
+                "Authorization failed. You can close this window.",
+            )
+        }
+    } else {
+        state.handled.store(false, Ordering::Release);
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Authorization callback could not be queued",
+        )
+    }
+}
+
+fn random_urlsafe() -> String {
+    uuid::Uuid::new_v4().simple().to_string()
+}
+
+fn authorize_url(
+    issuer: &str,
+    client_id: &str,
+    redirect_uri: &str,
+    state: &str,
+    challenge: &str,
+) -> String {
+    let pairs = [
+        ("response_type", "code"),
+        ("client_id", client_id),
+        ("redirect_uri", redirect_uri),
+        (
+            "scope",
+            "openid profile email offline_access api.connectors.read api.connectors.invoke",
+        ),
+        ("code_challenge", challenge),
+        ("code_challenge_method", "S256"),
+        ("id_token_add_organizations", "true"),
+        ("codex_cli_simplified_flow", "true"),
+        ("state", state),
+        ("originator", "link_assistant_router"),
+    ];
+    format!(
+        "{}/oauth/authorize?{}",
+        issuer.trim_end_matches('/'),
+        form_encode(&pairs)
+    )
+}
+
+#[allow(clippy::struct_field_names)]
+#[derive(Deserialize)]
+struct TokenResponse {
+    id_token: String,
+    access_token: String,
+    refresh_token: String,
+}
+
+async fn exchange_and_store(
+    config: &CodexAuthConfig,
+    redirect_uri: &str,
+    verifier: &str,
+    code: &str,
+) -> Result<PathBuf, String> {
+    let body = form_encode(&[
+        ("grant_type", "authorization_code"),
+        ("code", code),
+        ("redirect_uri", redirect_uri),
+        ("client_id", &config.client_id),
+        ("code_verifier", verifier),
+    ]);
+    let response = reqwest::Client::new()
+        .post(format!(
+            "{}/oauth/token",
+            config.issuer.trim_end_matches('/')
+        ))
+        .header("content-type", "application/x-www-form-urlencoded")
+        .body(body)
+        .send()
+        .await
+        .map_err(|error| format!("Codex token exchange failed: {error}"))?;
+    let status = response.status();
+    if !status.is_success() {
+        let detail = response.text().await.unwrap_or_default();
+        return Err(format!("Codex token endpoint returned {status}: {detail}"));
+    }
+    let tokens: TokenResponse = response
+        .json()
+        .await
+        .map_err(|error| format!("invalid Codex token response: {error}"))?;
+    persist_codex_auth(&config.codex_home, &tokens)
+}
+
+fn persist_codex_auth(home: &Path, tokens: &TokenResponse) -> Result<PathBuf, String> {
+    std::fs::create_dir_all(home)
+        .map_err(|error| format!("could not create {}: {error}", home.display()))?;
+    let path = home.join("auth.json");
+    let value = serde_json::json!({
+        "auth_mode": "chatgpt",
+        "tokens": {
+            "id_token": tokens.id_token,
+            "access_token": tokens.access_token,
+            "refresh_token": tokens.refresh_token,
+        },
+        "last_refresh": chrono::Utc::now().to_rfc3339(),
+    });
+    let temporary = home.join(format!(".auth.json.{}.tmp", uuid::Uuid::new_v4()));
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temporary)
+        .map_err(|error| format!("could not create {}: {error}", temporary.display()))?;
+    file.write_all(&serde_json::to_vec_pretty(&value).map_err(|e| e.to_string())?)
+        .and_then(|()| file.sync_all())
+        .map_err(|error| format!("could not write {}: {error}", temporary.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(&temporary, std::fs::Permissions::from_mode(0o600))
+            .map_err(|error| format!("could not secure {}: {error}", temporary.display()))?;
+    }
+    std::fs::rename(&temporary, &path)
+        .map_err(|error| format!("could not install {}: {error}", path.display()))?;
+    Ok(path)
+}
+
+fn form_encode(pairs: &[(&str, &str)]) -> String {
+    pairs
+        .iter()
+        .map(|(key, value)| format!("{}={}", percent_encode(key), percent_encode(value)))
+        .collect::<Vec<_>>()
+        .join("&")
+}
+
+fn percent_encode(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~') {
+            out.push(char::from(byte));
+        } else {
+            use std::fmt::Write as _;
+            let _ = write!(out, "%{byte:02X}");
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+    async fn token_stub() -> (String, tokio::task::JoinHandle<String>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let issuer = format!("http://{}", listener.local_addr().unwrap());
+        let task = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut bytes = Vec::new();
+            let mut buf = [0_u8; 2048];
+            loop {
+                let read = socket.read(&mut buf).await.unwrap();
+                bytes.extend_from_slice(&buf[..read]);
+                if read == 0 || String::from_utf8_lossy(&bytes).contains("code_verifier=") {
+                    break;
+                }
+            }
+            let body = r#"{"id_token":"header.payload.sig","access_token":"access","refresh_token":"refresh"}"#;
+            socket.write_all(format!("HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}", body.len()).as_bytes()).await.unwrap();
+            String::from_utf8(bytes).unwrap()
+        });
+        (issuer, task)
+    }
+
+    #[tokio::test]
+    async fn mismatched_state_is_rejected_and_listener_closes_after_valid_callback() {
+        let (issuer, token_request) = token_stub().await;
+        let home = tempfile::tempdir().unwrap();
+        let login = CodexLogin::bind(CodexAuthConfig {
+            issuer,
+            client_id: CODEX_CLIENT_ID.to_string(),
+            port: 0,
+            codex_home: home.path().to_path_buf(),
+            timeout: Duration::from_secs(3),
+            bind_host: "127.0.0.1".to_string(),
+        })
+        .await
+        .unwrap();
+        let port = login.port();
+        let auth_url = login.authorization_url().to_string();
+        let state = auth_url
+            .split("state=")
+            .nth(1)
+            .unwrap()
+            .split('&')
+            .next()
+            .unwrap();
+        let client = reqwest::Client::new();
+        let wrong = client
+            .get(format!(
+                "http://127.0.0.1:{port}{CODEX_CALLBACK_PATH}?code=bad&state=wrong"
+            ))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(wrong.status(), StatusCode::BAD_REQUEST);
+
+        let completion = tokio::spawn(login.complete());
+        let good = client
+            .get(format!(
+                "http://127.0.0.1:{port}{CODEX_CALLBACK_PATH}?code=good-code&state={state}"
+            ))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(good.status(), StatusCode::OK);
+        let path = completion.await.unwrap().unwrap();
+        let saved: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap();
+        assert_eq!(saved["tokens"]["access_token"], "access");
+        let request = token_request.await.unwrap();
+        assert!(request.contains("code=good-code"));
+        assert!(request.contains("code_verifier="));
+        assert!(
+            tokio::net::TcpListener::bind(("127.0.0.1", port))
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn callback_listener_closes_on_timeout() {
+        let home = tempfile::tempdir().unwrap();
+        let login = CodexLogin::bind(CodexAuthConfig {
+            issuer: "http://127.0.0.1:1".to_string(),
+            client_id: CODEX_CLIENT_ID.to_string(),
+            port: 0,
+            codex_home: home.path().to_path_buf(),
+            timeout: Duration::from_millis(10),
+            bind_host: "127.0.0.1".to_string(),
+        })
+        .await
+        .unwrap();
+        let port = login.port();
+        assert!(login.complete().await.unwrap_err().contains("timed out"));
+        assert!(
+            tokio::net::TcpListener::bind(("127.0.0.1", port))
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn provider_error_closes_listener_immediately() {
+        let home = tempfile::tempdir().unwrap();
+        let login = CodexLogin::bind(CodexAuthConfig {
+            issuer: "http://127.0.0.1:1".to_string(),
+            client_id: CODEX_CLIENT_ID.to_string(),
+            port: 0,
+            codex_home: home.path().to_path_buf(),
+            timeout: Duration::from_secs(3),
+            bind_host: "127.0.0.1".to_string(),
+        })
+        .await
+        .unwrap();
+        let port = login.port();
+        let state = login
+            .authorization_url()
+            .split("state=")
+            .nth(1)
+            .unwrap()
+            .split('&')
+            .next()
+            .unwrap()
+            .to_string();
+        let completion = tokio::spawn(login.complete());
+        let response = reqwest::get(format!(
+            "http://127.0.0.1:{port}{CODEX_CALLBACK_PATH}?error=access_denied&state={state}"
+        ))
+        .await
+        .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert!(
+            completion
+                .await
+                .unwrap()
+                .unwrap_err()
+                .contains("access_denied")
+        );
+        assert!(
+            tokio::net::TcpListener::bind(("127.0.0.1", port))
+                .await
+                .is_ok()
+        );
+    }
+}

--- a/src/auth_cli.rs
+++ b/src/auth_cli.rs
@@ -1,0 +1,140 @@
+//! Foreground provider authorization commands.
+
+use std::process::ExitCode;
+
+use link_assistant_router::cli::{AuthFlow, AuthOp};
+use link_assistant_router::config::Config;
+use link_assistant_router::login::{LoginManager, LoginStatus};
+use link_assistant_router::subscription::{SubscriptionProvider, SubscriptionReader};
+
+pub async fn run(config: &Config, op: &AuthOp) -> ExitCode {
+    match op {
+        AuthOp::Claude { code, flow } => run_claude(config, code.clone(), *flow).await,
+        AuthOp::Codex { flow, port } => run_codex(config, *flow, *port).await,
+        AuthOp::Status => status(config),
+    }
+}
+
+async fn run_claude(config: &Config, code: Option<String>, flow: AuthFlow) -> ExitCode {
+    if !matches!(flow, AuthFlow::Auto | AuthFlow::Code) {
+        eprintln!("error: Claude does not support {flow:?}; use --flow code");
+        return ExitCode::from(2);
+    }
+    let mut login_config = config.login.clone();
+    // Disabling HTTP login routes must not disable this local CLI command.
+    login_config.enabled = true;
+    let manager = LoginManager::new(login_config);
+    let begun = match manager.begin().await {
+        Ok(view) => view,
+        Err(error) => {
+            eprintln!("error: {error}");
+            return ExitCode::from(1);
+        }
+    };
+    println!("Open this URL:\n{}", begun.url.as_deref().unwrap_or(""));
+    let submitted = match code {
+        Some(code) => code,
+        None => match read_code().await {
+            Ok(code) => code,
+            Err(error) => {
+                eprintln!("error: {error}");
+                return ExitCode::from(1);
+            }
+        },
+    };
+    match manager.submit_code(&begun.login_id, submitted.trim()).await {
+        Ok(view) if view.status == LoginStatus::Authorized => {
+            println!(
+                "Claude authorization saved in {}",
+                config.login.claude_code_home.display()
+            );
+            ExitCode::SUCCESS
+        }
+        Ok(view) => {
+            eprintln!(
+                "error: {}",
+                view.error
+                    .unwrap_or_else(|| "authorization failed".to_string())
+            );
+            ExitCode::from(1)
+        }
+        Err(error) => {
+            eprintln!("error: {error}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+async fn read_code() -> Result<String, String> {
+    println!("Paste authorization code:");
+    tokio::task::spawn_blocking(|| {
+        let mut line = String::new();
+        std::io::stdin()
+            .read_line(&mut line)
+            .map(|_| line)
+            .map_err(|error| format!("could not read authorization code: {error}"))
+    })
+    .await
+    .map_err(|error| format!("authorization prompt failed: {error}"))?
+}
+
+async fn run_codex(config: &Config, flow: AuthFlow, port: u16) -> ExitCode {
+    if !matches!(flow, AuthFlow::Auto | AuthFlow::Loopback) {
+        eprintln!("error: Codex does not support {flow:?}; use --flow loopback");
+        return ExitCode::from(2);
+    }
+    if !matches!(port, 1455 | 1457) {
+        eprintln!("error: Codex OAuth registers loopback ports 1455 and 1457 only");
+        return ExitCode::from(2);
+    }
+    let settings = link_assistant_router::auth::CodexAuthConfig::production(
+        config.login.codex_home.clone(),
+        port,
+        config.login.session_ttl,
+    );
+    let login = match link_assistant_router::auth::CodexLogin::bind(settings).await {
+        Ok(login) => login,
+        Err(error) => {
+            eprintln!("error: {error}");
+            return ExitCode::from(1);
+        }
+    };
+    println!("Open this URL:\n{}", login.authorization_url());
+    println!("Waiting for the browser callback on port {}…", login.port());
+    match login.complete().await {
+        Ok(path) => {
+            println!("Codex authorization saved in {}", path.display());
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            eprintln!("error: {error}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+fn status(config: &Config) -> ExitCode {
+    let user_home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+    let now = chrono::Utc::now().timestamp_millis();
+    for provider in SubscriptionProvider::ALL {
+        let home = match provider {
+            SubscriptionProvider::Claude => config.login.claude_code_home.clone(),
+            SubscriptionProvider::Codex => config.login.codex_home.clone(),
+            SubscriptionProvider::Gemini | SubscriptionProvider::Qwen => {
+                provider.resolve_home(&user_home)
+            }
+        };
+        let reader = SubscriptionReader::new(provider, home);
+        let value = match reader.read_token() {
+            Ok(token) if token.is_expired(now) => "expired",
+            Ok(_) => "usable",
+            Err(_) => "absent",
+        };
+        println!(
+            "{:<8} {value:<7} {}",
+            reader.provider(),
+            reader.home().display()
+        );
+    }
+    ExitCode::SUCCESS
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,7 +23,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-use clap::Subcommand;
+use clap::{Subcommand, ValueEnum};
 use lino_arguments::Parser as LinoParser;
 
 use crate::clients::ClientKind;
@@ -438,8 +438,52 @@ pub enum Command {
         #[command(subcommand)]
         op: ClientOp,
     },
+    /// Obtain or inspect vendor subscription credentials.
+    Auth {
+        #[command(subcommand)]
+        op: AuthOp,
+    },
     /// Print environment + config diagnostics.
     Doctor,
+}
+
+/// Authorization-flow override. `auto` selects the provider's supported flow.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, ValueEnum)]
+pub enum AuthFlow {
+    /// Select the best supported flow automatically.
+    #[default]
+    Auto,
+    /// OAuth device authorization (only when advertised by the provider).
+    Device,
+    /// Copy/paste authorization code flow.
+    Code,
+    /// Local OAuth callback listener.
+    Loopback,
+}
+
+/// Provider authorization operations.
+#[derive(Debug, Subcommand)]
+pub enum AuthOp {
+    /// Authorize an Anthropic Claude subscription.
+    Claude {
+        /// Supply the copied code without prompting on stdin.
+        #[arg(long)]
+        code: Option<String>,
+        /// Force an OAuth flow instead of automatic selection.
+        #[arg(long, value_enum, default_value_t)]
+        flow: AuthFlow,
+    },
+    /// Authorize an `OpenAI` Codex / `ChatGPT` subscription.
+    Codex {
+        /// Force an OAuth flow instead of automatic selection.
+        #[arg(long, value_enum, default_value_t)]
+        flow: AuthFlow,
+        /// Local callback port registered for the Codex OAuth client.
+        #[arg(long, default_value_t = 1455)]
+        port: u16,
+    },
+    /// Report whether each provider credential is usable, expired, or absent.
+    Status,
 }
 
 #[derive(Debug, Subcommand)]
@@ -561,6 +605,8 @@ impl Cli {
             std::env::var("HOME")
                 .map_or_else(|_| "/root/.claude".to_string(), |h| format!("{h}/.claude"))
         });
+        let codex_home = crate::subscription::SubscriptionProvider::Codex
+            .resolve_home(&std::env::var("HOME").unwrap_or_else(|_| "/root".to_string()));
         let api_format = self.api_format.as_deref().and_then(ApiFormat::from_str_opt);
         let routing_mode =
             RoutingMode::from_str_opt(&self.routing_mode).ok_or(ConfigError::InvalidRoutingMode)?;
@@ -672,6 +718,7 @@ impl Cli {
                 args: self.login_cli_args.clone(),
                 session_ttl: Duration::from_secs(self.login_session_ttl_secs),
                 max_sessions: self.login_max_sessions,
+                codex_home,
                 ..crate::login::LoginConfig::default()
             },
             mpp: crate::mpp::MppConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,7 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use crate::accounts::SelectionStrategy;
+use crate::subscription::SubscriptionProvider;
 
 /// Supported upstream inference providers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -270,6 +271,8 @@ impl Config {
             let home = env::var("HOME").unwrap_or_else(|_| "/root".to_string());
             format!("{home}/.claude")
         });
+        let codex_home = SubscriptionProvider::Codex
+            .resolve_home(&env::var("HOME").unwrap_or_else(|_| "/root".to_string()));
         let upstream_base_url = env::var("UPSTREAM_BASE_URL")
             .unwrap_or_else(|_| "https://api.anthropic.com".to_string());
         let verbose = env::var("VERBOSE").is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"));
@@ -388,6 +391,7 @@ impl Config {
                 .map_or_else(Vec::new, |raw| parse_csv(&raw)),
             session_ttl: Duration::from_secs(parse_u64_env("LOGIN_SESSION_TTL_SECS", 900)),
             max_sessions: usize::try_from(parse_u64_env("LOGIN_MAX_SESSIONS", 4)).unwrap_or(4),
+            codex_home,
             ..crate::login::LoginConfig::default()
         };
         let mpp = crate::mpp::MppConfig {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod anthropic_bridge;
 pub mod anthropic_stream;
 pub mod app_state;
 pub mod audit;
+pub mod auth;
 pub mod chat_admin;
 pub mod chat_commands;
 pub mod chat_config;

--- a/src/login.rs
+++ b/src/login.rs
@@ -78,6 +78,10 @@ pub struct LoginConfig {
     /// Directory the resulting credential must land in. This is the same
     /// directory [`crate::oauth::OAuthProvider`] reads.
     pub claude_code_home: PathBuf,
+    /// Directory where Codex credentials are written.
+    pub codex_home: PathBuf,
+    /// Loopback callback port registered for the Codex OAuth client.
+    pub codex_callback_port: u16,
     /// How long a pending session stays valid while waiting for the human.
     pub session_ttl: Duration,
     /// Maximum number of simultaneously pending sessions.
@@ -98,6 +102,8 @@ impl Default for LoginConfig {
             command: "claude".to_string(),
             args: vec![],
             claude_code_home: PathBuf::from("/data/claude"),
+            codex_home: PathBuf::from("/data/codex"),
+            codex_callback_port: 1455,
             session_ttl: Duration::from_secs(900),
             max_sessions: 4,
             idle_settle: Duration::from_millis(750),
@@ -113,6 +119,8 @@ impl Default for LoginConfig {
 pub enum LoginStatus {
     /// The URL was returned; the router is waiting for the human's code.
     AwaitingCode,
+    /// The URL was returned; a provider-owned loopback listener awaits OAuth.
+    AwaitingCallback,
     /// A credential is now readable by the router.
     Authorized,
     /// The flow ended without a credential; restarting is required.
@@ -126,6 +134,8 @@ pub enum LoginStatus {
 pub struct LoginView {
     /// Identifier used to address this session.
     pub login_id: String,
+    /// Subscription provider being authorized.
+    pub provider: SubscriptionProvider,
     /// Current lifecycle state.
     pub status: LoginStatus,
     /// Authorization URL the human must open. Present while pending.
@@ -183,6 +193,7 @@ impl std::error::Error for LoginError {}
 /// One pending or finished login.
 struct Session {
     id: String,
+    provider: SubscriptionProvider,
     url: String,
     deadline: DateTime<Utc>,
     state: Mutex<SessionState>,
@@ -195,6 +206,8 @@ struct SessionState {
     error: Option<String>,
     /// Dropped (and thus killed) as soon as the session stops being pending.
     pty: Option<Arc<PtySession>>,
+    /// Codex loopback completion task; aborting it drops the listener.
+    loopback_task: Option<tokio::task::JoinHandle<()>>,
     /// When the session reached a terminal state, which starts the clock on
     /// [`TERMINAL_RETENTION`].
     settled_at: Option<DateTime<Utc>>,
@@ -208,8 +221,13 @@ impl Session {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         LoginView {
             login_id: self.id.clone(),
+            provider: self.provider,
             status: state.status.clone(),
-            url: (state.status == LoginStatus::AwaitingCode).then(|| self.url.clone()),
+            url: matches!(
+                state.status,
+                LoginStatus::AwaitingCode | LoginStatus::AwaitingCallback
+            )
+            .then(|| self.url.clone()),
             session_expires_at: self.deadline,
             expires_at: state.expires_at,
             error: state.error.clone(),
@@ -260,6 +278,11 @@ impl LoginManager {
     /// Start a login: spawn the CLI, wait for its authorization URL, and
     /// register the still-running session so a later request can finish it.
     pub async fn begin(&self) -> Result<LoginView, LoginError> {
+        self.begin_for(SubscriptionProvider::Claude).await
+    }
+
+    /// Start the authorization flow supported by `provider`.
+    pub async fn begin_for(&self, provider: SubscriptionProvider) -> Result<LoginView, LoginError> {
         if !self.config.enabled {
             return Err(LoginError::Disabled);
         }
@@ -267,6 +290,14 @@ impl LoginManager {
         let pending = self.count_pending();
         if pending >= self.config.max_sessions {
             return Err(LoginError::TooManySessions(self.config.max_sessions));
+        }
+        if provider == SubscriptionProvider::Codex {
+            return self.begin_codex().await;
+        }
+        if provider != SubscriptionProvider::Claude {
+            return Err(LoginError::Spawn(format!(
+                "{provider} authorization is not implemented; supported providers: claude, codex"
+            )));
         }
         ensure_writable_dir(&self.config.claude_code_home)?;
 
@@ -278,6 +309,7 @@ impl LoginManager {
         let id = uuid::Uuid::new_v4().to_string();
         let session = Arc::new(Session {
             id: id.clone(),
+            provider,
             url,
             deadline: Utc::now()
                 + chrono::Duration::from_std(self.config.session_ttl)
@@ -287,10 +319,74 @@ impl LoginManager {
                 expires_at: None,
                 error: None,
                 pty: Some(pty),
+                loopback_task: None,
                 settled_at: None,
             }),
         });
         self.lock_sessions().insert(id, Arc::clone(&session));
+        Ok(session.view())
+    }
+
+    async fn begin_codex(&self) -> Result<LoginView, LoginError> {
+        let codex_home = self.config.codex_home.clone();
+        ensure_writable_dir(&codex_home)?;
+        let mut codex_config = crate::auth::CodexAuthConfig::production(
+            codex_home,
+            self.config.codex_callback_port,
+            self.config.session_ttl,
+        );
+        // HTTP logins commonly run in a container. Publishing/forwarding the
+        // registered loopback port can only reach a listener on its interface.
+        codex_config.bind_host = "0.0.0.0".to_string();
+        let login = crate::auth::CodexLogin::bind(codex_config)
+            .await
+            .map_err(LoginError::Spawn)?;
+        let id = uuid::Uuid::new_v4().to_string();
+        let session = Arc::new(Session {
+            id: id.clone(),
+            provider: SubscriptionProvider::Codex,
+            url: login.authorization_url().to_string(),
+            deadline: Utc::now()
+                + chrono::Duration::from_std(self.config.session_ttl)
+                    .unwrap_or_else(|_| chrono::Duration::seconds(900)),
+            state: Mutex::new(SessionState {
+                status: LoginStatus::AwaitingCallback,
+                expires_at: None,
+                error: None,
+                pty: None,
+                loopback_task: None,
+                settled_at: None,
+            }),
+        });
+        self.lock_sessions().insert(id, Arc::clone(&session));
+        let task_session = Arc::clone(&session);
+        let task = tokio::spawn(async move {
+            let outcome = login.complete().await;
+            let mut state = task_session
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            match outcome {
+                Ok(_) => {
+                    state.status = LoginStatus::Authorized;
+                    state.error = None;
+                }
+                Err(error) => {
+                    state.status = if Utc::now() >= task_session.deadline {
+                        LoginStatus::Expired
+                    } else {
+                        LoginStatus::Failed
+                    };
+                    state.error = Some(error);
+                }
+            }
+            state.settled_at = Some(Utc::now());
+        });
+        session
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .loopback_task = Some(task);
         Ok(session.view())
     }
 
@@ -369,11 +465,17 @@ impl LoginManager {
                 .state
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            let expired = state.status == LoginStatus::AwaitingCode && session.deadline <= now;
+            let expired = matches!(
+                state.status,
+                LoginStatus::AwaitingCode | LoginStatus::AwaitingCallback
+            ) && session.deadline <= now;
             if expired {
                 state.status = LoginStatus::Expired;
                 state.error = Some("login session expired before a code was submitted".into());
                 state.pty = None; // dropping the PTY kills the child
+                if let Some(task) = state.loopback_task.take() {
+                    task.abort();
+                }
                 state.settled_at = Some(now);
             } else if state
                 .settled_at
@@ -411,6 +513,7 @@ impl LoginManager {
             }
         }
         state.pty = None;
+        state.loopback_task = None;
         state.settled_at = Some(Utc::now());
     }
 
@@ -420,7 +523,13 @@ impl LoginManager {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         state.pty = None;
-        if state.status == LoginStatus::AwaitingCode {
+        if let Some(task) = state.loopback_task.take() {
+            task.abort();
+        }
+        if matches!(
+            state.status,
+            LoginStatus::AwaitingCode | LoginStatus::AwaitingCallback
+        ) {
             state.status = LoginStatus::Failed;
             state.error = Some("login session cancelled".into());
         }
@@ -430,12 +539,16 @@ impl LoginManager {
         self.lock_sessions()
             .values()
             .filter(|session| {
-                session
+                let status = session
                     .state
                     .lock()
                     .unwrap_or_else(std::sync::PoisonError::into_inner)
                     .status
-                    == LoginStatus::AwaitingCode
+                    .clone();
+                matches!(
+                    status,
+                    LoginStatus::AwaitingCode | LoginStatus::AwaitingCallback
+                )
             })
             .count()
     }
@@ -811,164 +924,4 @@ fn tail(text: &str, limit: usize) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn tui_only_types_into_recognized_screens() {
-        let progress = TuiProgress::default();
-        let rendered_theme = crate::login_pty::strip_ansi(
-            "Choose\x1b[9Gthe\x1b[13Gtext\x1b[18Gstyle\x1b[24Gthat\x1b[29Glooks\x1b[35Gbest\x1b[40Gwith\x1b[45Gyour\x1b[50Gterminal",
-        );
-        assert_eq!(
-            next_tui_action(&rendered_theme, &progress),
-            Some(TuiAction::AcceptTheme)
-        );
-        assert_eq!(
-            next_tui_action("A future, unknown onboarding screen", &progress),
-            None
-        );
-    }
-
-    #[test]
-    fn login_config_defaults_to_bare_tui() {
-        assert!(LoginConfig::default().args.is_empty());
-    }
-
-    #[test]
-    fn compacted_oauth_verdicts_are_restored_for_api_errors() {
-        assert_eq!(
-            rejection_verdict("promptOAutherror:Invalidcode.Pleasemakesurethefullcodewascopied"),
-            "OAuth error: Invalid code. Please make sure the full code was copied"
-        );
-        assert_eq!(
-            rejection_verdict("promptOAutherror:Requestfailedwithstatuscode400"),
-            "OAuth error: Request failed with status code 400"
-        );
-    }
-
-    /// Build a session that already reached `status`, settled `age` ago.
-    fn settled_session(id: &str, status: LoginStatus, age: chrono::Duration) -> Arc<Session> {
-        Arc::new(Session {
-            id: id.to_string(),
-            url: "https://claude.ai/oauth/authorize".to_string(),
-            deadline: Utc::now() + chrono::Duration::seconds(900),
-            state: Mutex::new(SessionState {
-                status,
-                expires_at: None,
-                error: None,
-                pty: None,
-                settled_at: Some(Utc::now() - age),
-            }),
-        })
-    }
-
-    /// The registry must not grow for the lifetime of the process. A finished
-    /// session keeps its entry only long enough for the client to read the
-    /// verdict; after that it is forgotten.
-    #[test]
-    fn finished_sessions_are_evicted_once_their_result_has_been_retained() {
-        let manager = LoginManager::new(LoginConfig::default());
-        let fresh = settled_session("fresh", LoginStatus::Authorized, chrono::Duration::zero());
-        let stale = settled_session(
-            "stale",
-            LoginStatus::Failed,
-            terminal_retention() + chrono::Duration::seconds(1),
-        );
-        {
-            let mut sessions = manager.lock_sessions();
-            sessions.insert("fresh".to_string(), fresh);
-            sessions.insert("stale".to_string(), stale);
-        }
-
-        manager.sweep();
-
-        assert!(
-            manager.status("fresh").is_some(),
-            "a just-finished login must still be pollable"
-        );
-        assert!(
-            manager.status("stale").is_none(),
-            "a long-finished login must not occupy the registry forever"
-        );
-    }
-
-    /// A session that expires waiting for the human is terminal too, so it
-    /// must start the retention clock rather than living on.
-    #[test]
-    fn an_expired_session_becomes_evictable() {
-        let manager = LoginManager::new(LoginConfig::default());
-        let session = Arc::new(Session {
-            id: "gone".to_string(),
-            url: String::new(),
-            deadline: Utc::now() - chrono::Duration::seconds(1),
-            state: Mutex::new(SessionState {
-                status: LoginStatus::AwaitingCode,
-                expires_at: None,
-                error: None,
-                pty: None,
-                settled_at: None,
-            }),
-        });
-        manager
-            .lock_sessions()
-            .insert("gone".to_string(), Arc::clone(&session));
-
-        manager.sweep();
-        assert_eq!(
-            session.view().status,
-            LoginStatus::Expired,
-            "the TTL must still expire the session"
-        );
-        let settled = session
-            .state
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .settled_at;
-        assert!(settled.is_some(), "expiry must start the retention clock");
-    }
-
-    /// A failed login quotes the terminal back to the caller. `SUCCESS_MARKERS`
-    /// contains `sk-ant-oat` precisely because the token is printed there, so
-    /// the excerpt must not carry it — nor the code the human pasted.
-    #[test]
-    fn a_failure_excerpt_carries_neither_the_token_nor_the_pasted_code() {
-        let code = "authcode-9f3a2b7c";
-        let transcript =
-            format!("Paste code: {code}\nrejected\nleftover token sk-ant-oat01-SECRETVALUE0001\n");
-        let text = excerpt(&transcript, code, 400);
-        assert!(!text.contains("SECRETVALUE0001"), "{text}");
-        assert!(!text.contains(code), "{text}");
-        assert!(text.contains("rejected"), "context is still useful: {text}");
-    }
-
-    #[test]
-    fn write_credential_is_readable_by_the_oauth_reader() {
-        let dir = tempfile::tempdir().unwrap();
-        write_credential(dir.path(), "sk-ant-oat01-testtoken").unwrap();
-        let provider = crate::oauth::OAuthProvider::new(dir.path().to_str().unwrap());
-        assert_eq!(provider.get_token().unwrap(), "sk-ant-oat01-testtoken");
-    }
-
-    #[test]
-    fn ensure_writable_dir_creates_missing_directories() {
-        let dir = tempfile::tempdir().unwrap();
-        let nested = dir.path().join("a/b/claude");
-        ensure_writable_dir(&nested).unwrap();
-        assert!(nested.is_dir());
-    }
-
-    #[test]
-    fn disabled_manager_refuses_to_begin() {
-        let manager = LoginManager::new(LoginConfig {
-            enabled: false,
-            ..LoginConfig::default()
-        });
-        let result = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap()
-            .block_on(manager.begin());
-        assert!(matches!(result, Err(LoginError::Disabled)));
-    }
-}
+mod tests;

--- a/src/login/tests.rs
+++ b/src/login/tests.rs
@@ -1,0 +1,141 @@
+use super::*;
+
+#[test]
+fn tui_only_types_into_recognized_screens() {
+    let progress = TuiProgress::default();
+    let rendered_theme = crate::login_pty::strip_ansi(
+        "Choose\x1b[9Gthe\x1b[13Gtext\x1b[18Gstyle\x1b[24Gthat\x1b[29Glooks\x1b[35Gbest\x1b[40Gwith\x1b[45Gyour\x1b[50Gterminal",
+    );
+    assert_eq!(
+        next_tui_action(&rendered_theme, &progress),
+        Some(TuiAction::AcceptTheme)
+    );
+    assert_eq!(
+        next_tui_action("A future, unknown onboarding screen", &progress),
+        None
+    );
+}
+
+#[test]
+fn login_config_defaults_to_bare_tui() {
+    assert!(LoginConfig::default().args.is_empty());
+}
+
+#[test]
+fn compacted_oauth_verdicts_are_restored_for_api_errors() {
+    assert_eq!(
+        rejection_verdict("promptOAutherror:Invalidcode.Pleasemakesurethefullcodewascopied"),
+        "OAuth error: Invalid code. Please make sure the full code was copied"
+    );
+    assert_eq!(
+        rejection_verdict("promptOAutherror:Requestfailedwithstatuscode400"),
+        "OAuth error: Request failed with status code 400"
+    );
+}
+
+fn settled_session(id: &str, status: LoginStatus, age: chrono::Duration) -> Arc<Session> {
+    Arc::new(Session {
+        id: id.to_string(),
+        provider: SubscriptionProvider::Claude,
+        url: "https://claude.ai/oauth/authorize".to_string(),
+        deadline: Utc::now() + chrono::Duration::seconds(900),
+        state: Mutex::new(SessionState {
+            status,
+            expires_at: None,
+            error: None,
+            pty: None,
+            loopback_task: None,
+            settled_at: Some(Utc::now() - age),
+        }),
+    })
+}
+
+#[test]
+fn finished_sessions_are_evicted_once_their_result_has_been_retained() {
+    let manager = LoginManager::new(LoginConfig::default());
+    let fresh = settled_session("fresh", LoginStatus::Authorized, chrono::Duration::zero());
+    let stale = settled_session(
+        "stale",
+        LoginStatus::Failed,
+        terminal_retention() + chrono::Duration::seconds(1),
+    );
+    {
+        let mut sessions = manager.lock_sessions();
+        sessions.insert("fresh".to_string(), fresh);
+        sessions.insert("stale".to_string(), stale);
+    }
+    manager.sweep();
+    assert!(manager.status("fresh").is_some());
+    assert!(manager.status("stale").is_none());
+}
+
+#[test]
+fn an_expired_session_becomes_evictable() {
+    let manager = LoginManager::new(LoginConfig::default());
+    let session = Arc::new(Session {
+        id: "gone".to_string(),
+        provider: SubscriptionProvider::Claude,
+        url: String::new(),
+        deadline: Utc::now() - chrono::Duration::seconds(1),
+        state: Mutex::new(SessionState {
+            status: LoginStatus::AwaitingCode,
+            expires_at: None,
+            error: None,
+            pty: None,
+            loopback_task: None,
+            settled_at: None,
+        }),
+    });
+    manager
+        .lock_sessions()
+        .insert("gone".to_string(), Arc::clone(&session));
+    manager.sweep();
+    assert_eq!(session.view().status, LoginStatus::Expired);
+    let settled = session
+        .state
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .settled_at;
+    assert!(settled.is_some());
+}
+
+#[test]
+fn a_failure_excerpt_carries_neither_the_token_nor_the_pasted_code() {
+    let code = "authcode-9f3a2b7c";
+    let transcript =
+        format!("Paste code: {code}\nrejected\nleftover token sk-ant-oat01-SECRETVALUE0001\n");
+    let text = excerpt(&transcript, code, 400);
+    assert!(!text.contains("SECRETVALUE0001"), "{text}");
+    assert!(!text.contains(code), "{text}");
+    assert!(text.contains("rejected"), "{text}");
+}
+
+#[test]
+fn write_credential_is_readable_by_the_oauth_reader() {
+    let dir = tempfile::tempdir().unwrap();
+    write_credential(dir.path(), "sk-ant-oat01-testtoken").unwrap();
+    let provider = crate::oauth::OAuthProvider::new(dir.path().to_str().unwrap());
+    assert_eq!(provider.get_token().unwrap(), "sk-ant-oat01-testtoken");
+}
+
+#[test]
+fn ensure_writable_dir_creates_missing_directories() {
+    let dir = tempfile::tempdir().unwrap();
+    let nested = dir.path().join("a/b/claude");
+    ensure_writable_dir(&nested).unwrap();
+    assert!(nested.is_dir());
+}
+
+#[test]
+fn disabled_manager_refuses_to_begin() {
+    let manager = LoginManager::new(LoginConfig {
+        enabled: false,
+        ..LoginConfig::default()
+    });
+    let result = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(manager.begin());
+    assert!(matches!(result, Err(LoginError::Disabled)));
+}

--- a/src/login_api.rs
+++ b/src/login_api.rs
@@ -1,8 +1,8 @@
 //! HTTP endpoints for authorizing a deployment (issue #47).
 //!
 //! ```text
-//! POST   /api/login            -> { login_id, url, status: "awaiting_code", ... }
-//! GET    /api/login/{id}       -> { status: "awaiting_code" | "authorized" | "failed" | "expired", ... }
+//! POST   /api/login            -> { login_id, provider, url, status, ... }
+//! GET    /api/login/{id}       -> { status: "awaiting_code" | "awaiting_callback" | ... }
 //! POST   /api/login/{id}/code  -> { status: "authorized", expires_at, ... }
 //! DELETE /api/login/{id}       -> { cancelled: true }
 //! ```
@@ -23,18 +23,52 @@ use axum::response::IntoResponse;
 
 use crate::login::{LoginError, LoginManager};
 use crate::proxy::{AppState, error_response, is_admin_authorised};
+use crate::subscription::SubscriptionProvider;
 
 /// Start a login and return the URL the human must open.
 ///
 /// The spawned CLI keeps running after this responds — the session is what
 /// [`submit_code`] later writes to.
-pub async fn begin_login(State(state): State<AppState>, headers: HeaderMap) -> impl IntoResponse {
+pub async fn begin_login(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    request: Option<axum::Json<BeginLoginRequest>>,
+) -> impl IntoResponse {
     let Some(manager) = guard(&state, &headers) else {
         return unauthorised();
     };
-    match manager.begin().await {
+    let provider = requested_provider(request.as_ref().and_then(|body| body.provider.as_deref()));
+    let Some(provider) = provider else {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_request_error",
+            "`provider` must be `claude` or `codex`",
+        );
+    };
+    match manager.begin_for(provider).await {
         Ok(view) => (StatusCode::OK, axum::Json(view)).into_response(),
         Err(e) => login_error_response(&e),
+    }
+}
+
+/// Optional body for [`begin_login`]. An empty request remains Claude for
+/// compatibility with the original endpoint.
+#[derive(Default, serde::Deserialize)]
+pub struct BeginLoginRequest {
+    /// Subscription provider (`claude` or `codex`).
+    pub provider: Option<String>,
+}
+
+fn requested_provider(value: Option<&str>) -> Option<SubscriptionProvider> {
+    match value
+        .unwrap_or("claude")
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "claude" => Some(SubscriptionProvider::Claude),
+        "codex" => Some(SubscriptionProvider::Codex),
+        _ => None,
     }
 }
 
@@ -135,4 +169,20 @@ fn login_error_response(error: &LoginError) -> axum::response::Response {
         }
     };
     error_response(status, kind, &error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_defaults_to_claude_and_rejects_unexposed_aliases() {
+        assert_eq!(requested_provider(None), Some(SubscriptionProvider::Claude));
+        assert_eq!(
+            requested_provider(Some("codex")),
+            Some(SubscriptionProvider::Codex)
+        );
+        assert_eq!(requested_provider(Some("chatgpt")), None);
+        assert_eq!(requested_provider(Some("gemini")), None);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,8 @@ use std::process::ExitCode;
 use std::sync::Arc;
 use std::time::Duration;
 
+mod auth_cli;
+
 use axum::Router;
 use axum::routing::{get, post};
 use link_assistant_router::accounts::{AccountRouter, AccountRouterOptions};
@@ -76,6 +78,7 @@ async fn main() -> ExitCode {
         Some(Command::Clients { op }) => {
             link_assistant_router::client_command::run(&config, op).await
         }
+        Some(Command::Auth { op }) => auth_cli::run(&config, op).await,
         Some(Command::Doctor) => run_doctor(&config).await,
     }
 }

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -16,7 +16,8 @@ use serde::Deserialize;
 use std::path::{Path, PathBuf};
 
 /// A subscription-backed upstream that authenticates with vendor OAuth tokens.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum SubscriptionProvider {
     /// Anthropic Claude (Pro/Max) via Claude Code — `~/.claude`.
     Claude,
@@ -408,6 +409,7 @@ impl RawCredentials {
     fn codex_token(self) -> Option<SubscriptionToken> {
         let tokens = self.tokens.unwrap_or_default();
         let access = non_empty(tokens.access_token)?;
+        let expires_at_ms = self.expiry_date.or_else(|| jwt_expiry_ms(&access));
         let account_id = non_empty(tokens.account_id)
             .or_else(|| non_empty(self.account_id))
             .or_else(|| {
@@ -419,7 +421,7 @@ impl RawCredentials {
         Some(SubscriptionToken {
             access_token: access,
             refresh_token: non_empty(tokens.refresh_token),
-            expires_at_ms: self.expiry_date,
+            expires_at_ms,
             account_id,
             resource_url: None,
         })
@@ -435,6 +437,18 @@ impl RawCredentials {
             resource_url: non_empty(self.resource_url),
         })
     }
+}
+
+/// Read a JWT `exp` claim without verifying the signature. This is only a
+/// local expiry hint; the token endpoint and upstream remain authoritative.
+fn jwt_expiry_ms(token: &str) -> Option<i64> {
+    use base64::Engine as _;
+    let payload = token.split('.').nth(1)?;
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .ok()?;
+    let claims: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    claims.get("exp")?.as_i64()?.checked_mul(1000)
 }
 
 /// Extract the `ChatGPT` account id from a Codex `id_token` JWT.
@@ -524,6 +538,24 @@ mod tests {
         let reader = SubscriptionReader::new(SubscriptionProvider::Codex, &dir);
         let token = reader.read_token().expect("codex token");
         assert_eq!(token.account_id.as_deref(), Some("acct_from_jwt"));
+    }
+
+    #[test]
+    fn reads_codex_expiry_from_access_token() {
+        use base64::Engine as _;
+        let dir = tempdir();
+        let payload =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(br#"{"exp":1770000000}"#);
+        let access = format!("header.{payload}.signature");
+        fs::write(
+            dir.join("auth.json"),
+            format!(r#"{{"tokens":{{"access_token":"{access}"}}}}"#),
+        )
+        .unwrap();
+        let token = SubscriptionReader::new(SubscriptionProvider::Codex, &dir)
+            .read_token()
+            .unwrap();
+        assert_eq!(token.expires_at_ms, Some(1_770_000_000_000));
     }
 
     #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -557,7 +557,7 @@ mod metrics_rendering_tests {
 }
 
 mod cli_parser_tests {
-    use link_assistant_router::cli::{Cli, Command, TokenOp};
+    use link_assistant_router::cli::{AuthFlow, AuthOp, Cli, Command, TokenOp};
     use lino_arguments::Parser;
 
     #[test]
@@ -602,6 +602,37 @@ mod cli_parser_tests {
     fn cli_parses_doctor_subcommand() {
         let cli = Cli::try_parse_from(["bin", "doctor"]).expect("parses doctor");
         assert!(matches!(cli.command, Some(Command::Doctor)));
+    }
+
+    #[test]
+    fn cli_parses_provider_auth_flows() {
+        let claude = Cli::try_parse_from(["bin", "auth", "claude", "--code", "copied"])
+            .expect("parses Claude auth");
+        assert!(matches!(
+            claude.command,
+            Some(Command::Auth {
+                op: AuthOp::Claude { code: Some(code), flow: AuthFlow::Auto }
+            }) if code == "copied"
+        ));
+
+        let codex = Cli::try_parse_from([
+            "bin", "auth", "codex", "--flow", "loopback", "--port", "1457",
+        ])
+        .expect("parses Codex auth");
+        assert!(matches!(
+            codex.command,
+            Some(Command::Auth {
+                op: AuthOp::Codex {
+                    flow: AuthFlow::Loopback,
+                    port: 1457
+                }
+            })
+        ));
+        let status = Cli::try_parse_from(["bin", "auth", "status"]).expect("parses auth status");
+        assert!(matches!(
+            status.command,
+            Some(Command::Auth { op: AuthOp::Status })
+        ));
     }
 
     #[test]

--- a/tests/login_flow_test.rs
+++ b/tests/login_flow_test.rs
@@ -20,6 +20,7 @@
 
 use link_assistant_router::login::{LoginConfig, LoginManager, LoginStatus};
 use link_assistant_router::oauth::OAuthProvider;
+use link_assistant_router::subscription::SubscriptionProvider;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -279,4 +280,30 @@ async fn a_disabled_manager_serves_nothing() {
     });
     assert!(!manager.is_enabled());
     assert!(manager.begin().await.is_err());
+}
+
+#[tokio::test]
+async fn codex_login_waits_for_a_callback_instead_of_a_pasted_code() {
+    let home = temp_home();
+    let manager = LoginManager::new(LoginConfig {
+        codex_home: home,
+        codex_callback_port: 0,
+        ..LoginConfig::default()
+    });
+    let begun = manager
+        .begin_for(SubscriptionProvider::Codex)
+        .await
+        .expect("Codex loopback login should start");
+    assert_eq!(begun.provider, SubscriptionProvider::Codex);
+    assert_eq!(begun.status, LoginStatus::AwaitingCallback);
+    let url = begun.url.as_deref().expect("authorization URL");
+    assert!(url.contains("redirect_uri=http%3A%2F%2Flocalhost%3A"));
+    assert!(url.contains("code_challenge_method=S256"));
+    assert!(
+        manager
+            .submit_code(&begun.login_id, "there-is-no-codex-paste-code")
+            .await
+            .is_err()
+    );
+    assert!(manager.cancel(&begun.login_id));
 }


### PR DESCRIPTION
## Summary

- add `auth claude`, `auth codex`, and `auth status` commands with explicit flow selection
- add a router-owned Codex PKCE loopback flow with strict state validation and deterministic listener cleanup
- make `POST /api/login` provider-aware while preserving Claude as the no-body default
- persist Codex credentials in `CODEX_HOME` and report JWT expiry through the existing subscription reader
- document Docker/SSH callback forwarding and add a minor-release changelog fragment

## Reproduction

Previously, `POST /api/login` was hardwired to Claude. Running a Codex CLI merely long enough to capture its URL closed its loopback listener before the browser returned to `localhost:1455`, so an otherwise successful authorization was lost.

The regression tests now bind the listener before exposing the URL, reject a mismatched state without ending the wait, perform a valid callback and token exchange, verify the resulting `auth.json`, and confirm the callback port can immediately be rebound after success, denial, or timeout. A manager-level test covers explicit cancellation.

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features`
- `cargo test --all-targets`
- `cargo test --doc`
- repository 1,000-line file-size policy (equivalent local check; `rust-script` is unavailable in the prepared environment)

Fixes #87
