### PR TITLE
feat(auth): add Codex device authorization

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-11T09:57:25.112Z for PR creation at branch issue-87-48a5a39e18d7 for issue https://github.com/link-assistant/router/issues/87

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-11T09:57:25.112Z for PR creation at branch issue-87-48a5a39e18d7 for issue https://github.com/link-assistant/router/issues/87

--- a/README.md
+++ b/README.md
@@ -315,20 +315,21 @@ Authorizes a deployment that has no credential file — see
 `provider` request field selects `claude` (the backwards-compatible default)
 or `codex`. Claude drives the TUI `/login` flow and requests its full scope set;
 `LOGIN_CLI_ARGS=setup-token` explicitly selects the narrower `user:inference`
-flow. Codex binds a temporary PKCE loopback listener and needs no vendor CLI.
-The use-case guide lists the networking requirement and every requested scope.
+flow. Codex defaults to its device-code flow, which needs no callback port or
+vendor CLI; its PKCE loopback flow remains available as a CLI fallback.
 
 | Endpoint | Method | Description |
 |---|---|---|
 | `/api/login` | POST | (admin) Start a login; optional body: `{"provider":"claude"|"codex"}` |
-| `/api/login/{id}` | GET | (admin) Status includes `awaiting_code` (Claude) or `awaiting_callback` (Codex) |
+| `/api/login/{id}` | GET | (admin) Status includes `awaiting_code` (Claude) or `awaiting_device` plus `user_code` (Codex) |
 | `/api/login/{id}` | DELETE | (admin) Cancel a pending login and kill its process |
 | `/api/login/{id}/code` | POST | (admin) Submit the code the human copied from the browser |
 
 For a foreground local login, use `link-assistant-router auth claude`,
 `auth claude --code <code>`, or `auth codex`. `auth status` reports each
-provider credential as `usable`, `expired`, or `absent`. `--flow` can enforce
-`code` or `loopback`; unsupported forced flows fail instead of falling back.
+provider credential as `usable`, `expired`, or `absent`. `auth codex` defaults
+to device authorization; `--flow device` or `--flow loopback` makes the choice
+explicit. Unsupported forced flows fail instead of falling back.
 
 ### Admin UI surface (`--admin-port` to opt in)
 

--- a/changelog.d/20260811_110000_codex_device_authorization.md
+++ b/changelog.d/20260811_110000_codex_device_authorization.md
@@ -1,0 +1,7 @@
+---
+bump: minor
+---
+
+### Added
+
+- Added port-free Codex device authorization as the default CLI and HTTP login flow, while retaining loopback login as an explicit CLI fallback.

--- a/docs/use-cases/remote-login.md
+++ b/docs/use-cases/remote-login.md
@@ -7,17 +7,17 @@ problem this solves:
 > that was produced somewhere else. There is no way to log in *to the
 > deployment*.
 
-This document covers Claude's copied-code flow and Codex's PKCE loopback flow.
-In both cases the human only opens the returned URL and approves access.
+This document covers Claude's copied-code flow and Codex's device-code flow.
+In both cases the human opens the returned URL and approves access.
 
 ## The flow
 
 | Request | Does |
 | --- | --- |
-| `POST /api/login` | Starts Claude by default; `{"provider":"codex"}` binds Codex's callback listener before returning its URL |
-| *(human)* | Opens that URL and approves; Claude displays a code, while Codex redirects to its listener |
+| `POST /api/login` | Starts Claude by default; `{"provider":"codex"}` requests a Codex device code without binding a port |
+| *(human)* | Opens that URL and approves; Claude displays a code to copy, while Codex asks for the returned `user_code` |
 | `POST /api/login/{id}/code` | Claude only: types the copied code into the **same, still-running** process |
-| `GET /api/login/{id}` | Reports `awaiting_code`, `awaiting_callback`, `authorized`, `failed` or `expired` |
+| `GET /api/login/{id}` | Reports `awaiting_code`, `awaiting_device`, `authorized`, `failed` or `expired` |
 | `DELETE /api/login/{id}` | Cancels a pending login and kills its process |
 
 The middle step can take minutes, so the process started by the first request
@@ -64,7 +64,7 @@ is refreshed, so the very next `/v1/messages` request works without a restart.
 
 ### Codex / ChatGPT
 
-Codex displays no code to paste. Start its provider-aware session instead:
+Start a provider-aware Codex device session:
 
 ```console
 $ curl -s -X POST http://localhost:8080/api/login \
@@ -74,22 +74,17 @@ $ curl -s -X POST http://localhost:8080/api/login \
 {
   "login_id": "7ab1…",
   "provider": "codex",
-  "status": "awaiting_callback",
-  "url": "https://auth.openai.com/oauth/authorize?…redirect_uri=http%3A%2F%2Flocalhost%3A1455%2Fauth%2Fcallback…"
+  "status": "awaiting_device",
+  "url": "https://auth.openai.com/codex/device",
+  "user_code": "ABCD-EFGH"
 }
 ```
 
-The router has already bound port 1455 when this response arrives. The browser
-callback exchanges the code with its PKCE verifier and atomically writes
-`$CODEX_HOME/auth.json`; a mismatched `state` is rejected without ending the
-wait. The listener closes on success, failure, cancellation, or timeout.
-
-Because OpenAI registers a loopback redirect, the browser's `localhost:1455`
-must reach the router process. For Docker, publish both ports with
-`-p 8080:8080 -p 1455:1455`. For a remote host, forward it first, for example
-`ssh -L 1455:localhost:1455 router-host`. The foreground
-`link-assistant-router auth codex` command is simpler when run on the browser's
-machine and does not require the Codex CLI to be installed.
+Open the URL, enter `user_code`, and approve the device. The router polls at
+the server-provided interval, handles pending, slowdown, denial and expiry,
+then exchanges the returned authorization code with its PKCE verifier and
+atomically writes `$CODEX_HOME/auth.json`. No inbound port is opened, so this
+works unchanged in Docker, over SSH and on headless hosts.
 
 Polling is available for clients that would rather not block:
 
@@ -103,7 +98,8 @@ $ curl -s http://localhost:8080/api/login/3f2b… -H "Authorization: Bearer $ADM
 | `status` | Meaning |
 | --- | --- |
 | `awaiting_code` | The URL is live and the process is parked, waiting for a code |
-| `awaiting_callback` | The Codex loopback listener is bound and waiting for the browser |
+| `awaiting_device` | Codex is polling while the operator enters `user_code` at the URL |
+| `awaiting_callback` | A forced Codex CLI loopback flow is waiting for the browser |
 | `authorized` | A credential exists and is readable by the proxy |
 | `failed` | The CLI rejected the code, or no credential was produced; `error` says which |
 | `expired` | The session's TTL elapsed before a code arrived; its process was killed |
@@ -170,9 +166,10 @@ link-assistant-router auth codex
 link-assistant-router auth status
 ```
 
-Claude supports `--flow code`; Codex supports `--flow loopback`. A forced
-`device` flow fails clearly because neither vendor currently advertises one
-for these clients.
+Claude supports `--flow code`. Codex defaults to `--flow device`; use
+`--flow loopback` as an explicit fallback when device authorization is disabled
+for the account. Loopback binds port 1455 (or 1457 via `--port`) and validates
+OAuth state; the listener closes on success, denial, timeout and cancellation.
 
 ## Requirements
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,7 +1,7 @@
 //! Provider-aware interactive subscription authorization.
 //!
-//! Claude uses its vendor CLI's copy/paste flow. Codex uses an OAuth 2.0
-//! authorization-code flow with PKCE and a temporary loopback callback server.
+//! Claude uses its vendor CLI's copy/paste flow. Codex defaults to device-code
+//! authorization, with its PKCE loopback callback server available as fallback.
 
 use std::collections::HashMap;
 use std::io::Write as _;
@@ -25,8 +25,10 @@ pub const CODEX_CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
 pub const CODEX_ISSUER: &str = "https://auth.openai.com";
 /// Callback path registered for the Codex public client.
 pub const CODEX_CALLBACK_PATH: &str = "/auth/callback";
+/// Product-specific callback URI used by Codex device authorization.
+pub const CODEX_DEVICE_CALLBACK_PATH: &str = "/deviceauth/callback";
 
-/// Settings for one Codex loopback authorization.
+/// Settings shared by Codex device and loopback authorization.
 #[derive(Clone, Debug)]
 pub struct CodexAuthConfig {
     /// OAuth issuer; overridable so tests can use a local token endpoint.
@@ -55,6 +57,235 @@ impl CodexAuthConfig {
             timeout,
             bind_host: "127.0.0.1".to_string(),
         }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum PollInterval {
+    Number(u64),
+    String(String),
+}
+
+impl PollInterval {
+    fn seconds(self) -> Result<u64, String> {
+        match self {
+            Self::Number(value) => Ok(value),
+            Self::String(value) => value
+                .trim()
+                .parse()
+                .map_err(|error| format!("invalid Codex device polling interval: {error}")),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct DeviceCodeResponse {
+    device_auth_id: String,
+    #[serde(alias = "usercode")]
+    user_code: String,
+    interval: PollInterval,
+}
+
+#[derive(Deserialize)]
+struct DeviceAuthorizationResponse {
+    authorization_code: String,
+    code_challenge: String,
+    code_verifier: String,
+}
+
+#[derive(Default, Deserialize)]
+struct DeviceErrorResponse {
+    #[serde(default)]
+    error: String,
+    #[serde(default)]
+    error_description: String,
+}
+
+enum DevicePoll {
+    Pending,
+    SlowDown,
+    Complete(DeviceAuthorizationResponse),
+}
+
+/// A Codex device-code authorization that never opens a local listener.
+pub struct CodexDeviceLogin {
+    config: CodexAuthConfig,
+    verification_url: String,
+    user_code: String,
+    device_auth_id: String,
+    interval: Duration,
+}
+
+impl CodexDeviceLogin {
+    /// Request a one-time code from Codex without binding a callback port.
+    pub async fn begin(config: CodexAuthConfig) -> Result<Self, String> {
+        let endpoint = format!(
+            "{}/api/accounts/deviceauth/usercode",
+            config.issuer.trim_end_matches('/')
+        );
+        let response = reqwest::Client::new()
+            .post(endpoint)
+            .json(&serde_json::json!({ "client_id": config.client_id }))
+            .send()
+            .await
+            .map_err(|error| format!("Codex device-code request failed: {error}"))?;
+        let status = response.status();
+        if !status.is_success() {
+            let detail = response.text().await.unwrap_or_default();
+            let hint = if status == StatusCode::NOT_FOUND {
+                "device authorization is not enabled; use --flow loopback"
+            } else {
+                "device authorization could not be started"
+            };
+            return Err(format!(
+                "Codex device-code endpoint returned {status}: {hint}{}",
+                response_detail(&detail)
+            ));
+        }
+        let device: DeviceCodeResponse = response
+            .json()
+            .await
+            .map_err(|error| format!("invalid Codex device-code response: {error}"))?;
+        if device.device_auth_id.trim().is_empty() || device.user_code.trim().is_empty() {
+            return Err("invalid Codex device-code response: missing id or user code".to_string());
+        }
+        let interval = Duration::from_secs(device.interval.seconds()?);
+        Ok(Self {
+            verification_url: format!("{}/codex/device", config.issuer.trim_end_matches('/')),
+            config,
+            user_code: device.user_code,
+            device_auth_id: device.device_auth_id,
+            interval,
+        })
+    }
+
+    /// URL at which the operator enters [`Self::user_code`].
+    #[must_use]
+    pub fn verification_url(&self) -> &str {
+        &self.verification_url
+    }
+
+    /// Compatibility alias for callers that expose every login as a URL.
+    #[must_use]
+    pub fn authorization_url(&self) -> &str {
+        self.verification_url()
+    }
+
+    /// One-time code the operator enters at [`Self::verification_url`].
+    #[must_use]
+    pub fn user_code(&self) -> &str {
+        &self.user_code
+    }
+
+    /// Poll until the browser authorizes this device, then persist `auth.json`.
+    pub async fn complete(self) -> Result<PathBuf, String> {
+        let timeout = self.config.timeout;
+        tokio::time::timeout(timeout, self.poll_and_store())
+            .await
+            .unwrap_or_else(|_| {
+                Err(format!(
+                    "Codex device authorization expired after {} seconds",
+                    timeout.as_secs()
+                ))
+            })
+    }
+
+    async fn poll_and_store(mut self) -> Result<PathBuf, String> {
+        loop {
+            match self.poll_once().await? {
+                DevicePoll::Pending => tokio::time::sleep(self.interval).await,
+                DevicePoll::SlowDown => {
+                    self.interval += Duration::from_secs(5);
+                    tokio::time::sleep(self.interval).await;
+                }
+                DevicePoll::Complete(code) => {
+                    let expected_challenge = base64::engine::general_purpose::URL_SAFE_NO_PAD
+                        .encode(Sha256::digest(code.code_verifier.as_bytes()));
+                    if code.code_challenge != expected_challenge {
+                        return Err(
+                            "Codex device authorization returned inconsistent PKCE values"
+                                .to_string(),
+                        );
+                    }
+                    let redirect_uri = format!(
+                        "{}{}",
+                        self.config.issuer.trim_end_matches('/'),
+                        CODEX_DEVICE_CALLBACK_PATH
+                    );
+                    return exchange_and_store(
+                        &self.config,
+                        &redirect_uri,
+                        &code.code_verifier,
+                        &code.authorization_code,
+                    )
+                    .await;
+                }
+            }
+        }
+    }
+
+    async fn poll_once(&self) -> Result<DevicePoll, String> {
+        let response = reqwest::Client::new()
+            .post(format!(
+                "{}/api/accounts/deviceauth/token",
+                self.config.issuer.trim_end_matches('/')
+            ))
+            .json(&serde_json::json!({
+                "device_auth_id": self.device_auth_id,
+                "user_code": self.user_code,
+            }))
+            .send()
+            .await
+            .map_err(|error| format!("Codex device authorization poll failed: {error}"))?;
+        let status = response.status();
+        if status.is_success() {
+            return response
+                .json()
+                .await
+                .map(DevicePoll::Complete)
+                .map_err(|error| format!("invalid Codex device authorization response: {error}"));
+        }
+        let body = response.text().await.unwrap_or_default();
+        classify_device_error(status, &body)
+    }
+}
+
+fn classify_device_error(status: StatusCode, body: &str) -> Result<DevicePoll, String> {
+    let provider_error = serde_json::from_str::<DeviceErrorResponse>(body).unwrap_or_default();
+    let error = provider_error.error.to_ascii_lowercase();
+    if status == StatusCode::TOO_MANY_REQUESTS || error == "slow_down" {
+        return Ok(DevicePoll::SlowDown);
+    }
+    if matches!(error.as_str(), "expired_token" | "access_denied") {
+        let detail = if provider_error.error_description.is_empty() {
+            error
+        } else {
+            provider_error.error_description
+        };
+        return Err(format!("Codex device authorization failed: {detail}"));
+    }
+    if matches!(status, StatusCode::FORBIDDEN | StatusCode::NOT_FOUND)
+        || error == "authorization_pending"
+    {
+        return Ok(DevicePoll::Pending);
+    }
+    Err(format!(
+        "Codex device authorization endpoint returned {status}{}",
+        response_detail(body)
+    ))
+}
+
+fn response_detail(body: &str) -> String {
+    let detail = body.trim();
+    if detail.is_empty() {
+        String::new()
+    } else {
+        let safe_end = detail
+            .char_indices()
+            .nth(500)
+            .map_or(detail.len(), |(index, _)| index);
+        format!(": {}", &detail[..safe_end])
     }
 }
 
@@ -365,7 +596,166 @@ fn percent_encode(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::Json;
+    use axum::body::Bytes;
+    use axum::response::{IntoResponse as _, Response};
+    use axum::routing::post;
+    use std::sync::atomic::AtomicUsize;
     use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+    #[derive(Default)]
+    struct DeviceStubState {
+        polls: AtomicUsize,
+    }
+
+    async fn issue_device_code(Json(body): Json<serde_json::Value>) -> Json<serde_json::Value> {
+        assert_eq!(body["client_id"], CODEX_CLIENT_ID);
+        Json(serde_json::json!({
+            "device_auth_id": "device-1",
+            "user_code": "ABCD-EFGH",
+            "interval": "0",
+        }))
+    }
+
+    async fn poll_device_code(
+        State(state): State<Arc<DeviceStubState>>,
+        Json(body): Json<serde_json::Value>,
+    ) -> Response {
+        assert_eq!(body["device_auth_id"], "device-1");
+        assert_eq!(body["user_code"], "ABCD-EFGH");
+        if state.polls.fetch_add(1, Ordering::SeqCst) == 0 {
+            return (
+                StatusCode::FORBIDDEN,
+                Json(serde_json::json!({"error": "authorization_pending"})),
+            )
+                .into_response();
+        }
+        let verifier = "device-verifier";
+        let challenge = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(Sha256::digest(verifier.as_bytes()));
+        Json(serde_json::json!({
+            "authorization_code": "device-authorization-code",
+            "code_challenge": challenge,
+            "code_verifier": verifier,
+        }))
+        .into_response()
+    }
+
+    async fn exchange_device_code(body: Bytes) -> Json<serde_json::Value> {
+        let body = String::from_utf8(body.to_vec()).unwrap();
+        assert!(body.contains("code=device-authorization-code"));
+        assert!(body.contains("code_verifier=device-verifier"));
+        assert!(body.contains("redirect_uri=http%3A%2F%2F"));
+        assert!(body.contains("%2Fdeviceauth%2Fcallback"));
+        Json(serde_json::json!({
+            "id_token": "header.payload.sig",
+            "access_token": "device-access",
+            "refresh_token": "device-refresh",
+        }))
+    }
+
+    async fn device_stub() -> (String, Arc<DeviceStubState>, tokio::task::JoinHandle<()>) {
+        let state = Arc::new(DeviceStubState::default());
+        let app = Router::new()
+            .route("/api/accounts/deviceauth/usercode", post(issue_device_code))
+            .route("/api/accounts/deviceauth/token", post(poll_device_code))
+            .route("/oauth/token", post(exchange_device_code))
+            .with_state(Arc::clone(&state));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let issuer = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (issuer, state, server)
+    }
+
+    #[tokio::test]
+    async fn device_login_starts_without_binding_the_loopback_port() {
+        let issuer_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let issuer = format!("http://{}", issuer_listener.local_addr().unwrap());
+        let user_code_request = tokio::spawn(async move {
+            let (mut socket, _) = issuer_listener.accept().await.unwrap();
+            let mut bytes = vec![0_u8; 2048];
+            let read = socket.read(&mut bytes).await.unwrap();
+            let request = String::from_utf8_lossy(&bytes[..read]);
+            assert!(request.starts_with("POST /api/accounts/deviceauth/usercode "));
+            assert!(request.contains(CODEX_CLIENT_ID));
+            let body = r#"{"device_auth_id":"device-1","user_code":"ABCD-EFGH","interval":"5"}"#;
+            socket
+                .write_all(
+                    format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                        body.len()
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .unwrap();
+        });
+        let occupied = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let occupied_port = occupied.local_addr().unwrap().port();
+        let home = tempfile::tempdir().unwrap();
+
+        let login = CodexDeviceLogin::begin(CodexAuthConfig {
+            issuer,
+            client_id: CODEX_CLIENT_ID.to_string(),
+            port: occupied_port,
+            codex_home: home.path().to_path_buf(),
+            timeout: Duration::from_secs(3),
+            bind_host: "127.0.0.1".to_string(),
+        })
+        .await
+        .expect("device auth must not bind the loopback port");
+
+        assert_eq!(login.verification_url(), login.authorization_url());
+        assert!(login.verification_url().ends_with("/codex/device"));
+        assert_eq!(login.user_code(), "ABCD-EFGH");
+        assert_eq!(occupied.local_addr().unwrap().port(), occupied_port);
+        user_code_request.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn device_login_polls_pending_then_exchanges_and_persists_tokens() {
+        let (issuer, state, server) = device_stub().await;
+        let home = tempfile::tempdir().unwrap();
+        let login = CodexDeviceLogin::begin(CodexAuthConfig {
+            issuer,
+            client_id: CODEX_CLIENT_ID.to_string(),
+            port: 1455,
+            codex_home: home.path().to_path_buf(),
+            timeout: Duration::from_secs(3),
+            bind_host: "127.0.0.1".to_string(),
+        })
+        .await
+        .unwrap();
+
+        let path = login.complete().await.unwrap();
+        let saved: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap();
+        assert_eq!(saved["auth_mode"], "chatgpt");
+        assert_eq!(saved["tokens"]["access_token"], "device-access");
+        assert_eq!(state.polls.load(Ordering::SeqCst), 2);
+        server.abort();
+    }
+
+    #[test]
+    fn device_polling_handles_pending_slow_down_and_expiry() {
+        assert!(matches!(
+            classify_device_error(StatusCode::FORBIDDEN, ""),
+            Ok(DevicePoll::Pending)
+        ));
+        assert!(matches!(
+            classify_device_error(StatusCode::BAD_REQUEST, r#"{"error":"slow_down"}"#),
+            Ok(DevicePoll::SlowDown)
+        ));
+        let expired = classify_device_error(
+            StatusCode::FORBIDDEN,
+            r#"{"error":"expired_token","error_description":"code expired"}"#,
+        )
+        .err()
+        .unwrap();
+        assert!(expired.contains("code expired"));
+    }
 
     async fn token_stub() -> (String, tokio::task::JoinHandle<String>) {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -459,6 +849,31 @@ mod tests {
         .unwrap();
         let port = login.port();
         assert!(login.complete().await.unwrap_err().contains("timed out"));
+        assert!(
+            tokio::net::TcpListener::bind(("127.0.0.1", port))
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn dropping_loopback_login_closes_listener() {
+        let home = tempfile::tempdir().unwrap();
+        let login = CodexLogin::bind(CodexAuthConfig {
+            issuer: "http://127.0.0.1:1".to_string(),
+            client_id: CODEX_CLIENT_ID.to_string(),
+            port: 0,
+            codex_home: home.path().to_path_buf(),
+            timeout: Duration::from_secs(3),
+            bind_host: "127.0.0.1".to_string(),
+        })
+        .await
+        .unwrap();
+        let port = login.port();
+
+        drop(login);
+        tokio::task::yield_now().await;
+
         assert!(
             tokio::net::TcpListener::bind(("127.0.0.1", port))
                 .await

--- a/src/auth_cli.rs
+++ b/src/auth_cli.rs
@@ -79,19 +79,23 @@ async fn read_code() -> Result<String, String> {
 }
 
 async fn run_codex(config: &Config, flow: AuthFlow, port: u16) -> ExitCode {
-    if !matches!(flow, AuthFlow::Auto | AuthFlow::Loopback) {
-        eprintln!("error: Codex does not support {flow:?}; use --flow loopback");
+    if flow == AuthFlow::Code {
+        eprintln!("error: Codex does not support Code; use --flow device or --flow loopback");
         return ExitCode::from(2);
+    }
+    if matches!(flow, AuthFlow::Auto | AuthFlow::Device) {
+        return run_codex_device(config, port).await;
     }
     if !matches!(port, 1455 | 1457) {
         eprintln!("error: Codex OAuth registers loopback ports 1455 and 1457 only");
         return ExitCode::from(2);
     }
-    let settings = link_assistant_router::auth::CodexAuthConfig::production(
+    let mut settings = link_assistant_router::auth::CodexAuthConfig::production(
         config.login.codex_home.clone(),
         port,
         config.login.session_ttl,
     );
+    settings.issuer.clone_from(&config.login.codex_issuer);
     let login = match link_assistant_router::auth::CodexLogin::bind(settings).await {
         Ok(login) => login,
         Err(error) => {
@@ -101,6 +105,38 @@ async fn run_codex(config: &Config, flow: AuthFlow, port: u16) -> ExitCode {
     };
     println!("Open this URL:\n{}", login.authorization_url());
     println!("Waiting for the browser callback on port {}…", login.port());
+    match login.complete().await {
+        Ok(path) => {
+            println!("Codex authorization saved in {}", path.display());
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            eprintln!("error: {error}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+async fn run_codex_device(config: &Config, port: u16) -> ExitCode {
+    let mut settings = link_assistant_router::auth::CodexAuthConfig::production(
+        config.login.codex_home.clone(),
+        port,
+        config.login.session_ttl,
+    );
+    settings.issuer.clone_from(&config.login.codex_issuer);
+    let login = match link_assistant_router::auth::CodexDeviceLogin::begin(settings).await {
+        Ok(login) => login,
+        Err(error) => {
+            eprintln!("error: {error}");
+            return ExitCode::from(1);
+        }
+    };
+    println!(
+        "Open this URL:\n{}\nEnter this one-time code:\n{}",
+        login.verification_url(),
+        login.user_code()
+    );
+    println!("Waiting for device authorization…");
     match login.complete().await {
         Ok(path) => {
             println!("Codex authorization saved in {}", path.display());

--- a/src/login.rs
+++ b/src/login.rs
@@ -6,15 +6,15 @@
 //! Code login is interactive, and the machine that would run it is not the
 //! machine the router runs on (issue #47).
 //!
-//! This module closes that gap by driving the Claude Code CLI on a PTY inside
-//! the deployment and exposing the *only* irreducibly human step — approving
-//! a URL in a browser — as two HTTP calls:
+//! This module closes that gap by driving Claude Code on a PTY and conducting
+//! Codex device authorization directly. It exposes the irreducibly human step
+//! — approving a URL in a browser — through provider-aware HTTP sessions:
 //!
-//! 1. [`LoginManager::begin`] spawns the CLI, waits for the authorization URL
-//!    to settle on screen, and returns it along with a `login_id`.
-//! 2. The human opens the URL, approves, and copies the code back.
-//! 3. [`LoginManager::submit_code`] types that code into the *same* PTY and
-//!    persists the resulting credential where [`crate::oauth`] reads it.
+//! 1. [`LoginManager::begin`] starts the provider flow and returns its URL with
+//!    a `login_id` (and, for Codex, a one-time device code).
+//! 2. The human opens the URL and approves. Claude's code is submitted through
+//!    [`LoginManager::submit_code`]; Codex is completed by background polling.
+//! 3. The resulting credential is persisted in that provider's own home.
 //!
 //! # Why the session outlives the request
 //!
@@ -80,6 +80,8 @@ pub struct LoginConfig {
     pub claude_code_home: PathBuf,
     /// Directory where Codex credentials are written.
     pub codex_home: PathBuf,
+    /// Codex OAuth issuer. Overridable for compatible deployments and tests.
+    pub codex_issuer: String,
     /// Loopback callback port registered for the Codex OAuth client.
     pub codex_callback_port: u16,
     /// How long a pending session stays valid while waiting for the human.
@@ -103,6 +105,7 @@ impl Default for LoginConfig {
             args: vec![],
             claude_code_home: PathBuf::from("/data/claude"),
             codex_home: PathBuf::from("/data/codex"),
+            codex_issuer: crate::auth::CODEX_ISSUER.to_string(),
             codex_callback_port: 1455,
             session_ttl: Duration::from_secs(900),
             max_sessions: 4,
@@ -121,6 +124,8 @@ pub enum LoginStatus {
     AwaitingCode,
     /// The URL was returned; a provider-owned loopback listener awaits OAuth.
     AwaitingCallback,
+    /// A provider-issued user code is waiting for browser approval.
+    AwaitingDevice,
     /// A credential is now readable by the router.
     Authorized,
     /// The flow ended without a credential; restarting is required.
@@ -141,6 +146,9 @@ pub struct LoginView {
     /// Authorization URL the human must open. Present while pending.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
+    /// One-time code entered at `url` for a device authorization.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_code: Option<String>,
     /// When this *session* stops accepting a code.
     pub session_expires_at: DateTime<Utc>,
     /// When the obtained *credential* expires, when the CLI reports it.
@@ -181,7 +189,7 @@ impl std::fmt::Display for LoginError {
             Self::NotPending(status) => {
                 write!(f, "login is not awaiting a code (status: {status:?})")
             }
-            Self::Spawn(msg) => write!(f, "could not start the login CLI: {msg}"),
+            Self::Spawn(msg) => write!(f, "could not start the login flow: {msg}"),
             Self::NoUrl(msg) => write!(f, "no authorization URL appeared: {msg}"),
             Self::Storage(msg) => write!(f, "credential directory is unusable: {msg}"),
         }
@@ -195,6 +203,7 @@ struct Session {
     id: String,
     provider: SubscriptionProvider,
     url: String,
+    user_code: Option<String>,
     deadline: DateTime<Utc>,
     state: Mutex<SessionState>,
 }
@@ -206,8 +215,8 @@ struct SessionState {
     error: Option<String>,
     /// Dropped (and thus killed) as soon as the session stops being pending.
     pty: Option<Arc<PtySession>>,
-    /// Codex loopback completion task; aborting it drops the listener.
-    loopback_task: Option<tokio::task::JoinHandle<()>>,
+    /// Provider authorization task; aborting it stops polling or the listener.
+    auth_task: Option<tokio::task::JoinHandle<()>>,
     /// When the session reached a terminal state, which starts the clock on
     /// [`TERMINAL_RETENTION`].
     settled_at: Option<DateTime<Utc>>,
@@ -225,9 +234,14 @@ impl Session {
             status: state.status.clone(),
             url: matches!(
                 state.status,
-                LoginStatus::AwaitingCode | LoginStatus::AwaitingCallback
+                LoginStatus::AwaitingCode
+                    | LoginStatus::AwaitingCallback
+                    | LoginStatus::AwaitingDevice
             )
             .then(|| self.url.clone()),
+            user_code: (state.status == LoginStatus::AwaitingDevice)
+                .then(|| self.user_code.clone())
+                .flatten(),
             session_expires_at: self.deadline,
             expires_at: state.expires_at,
             error: state.error.clone(),
@@ -311,6 +325,7 @@ impl LoginManager {
             id: id.clone(),
             provider,
             url,
+            user_code: None,
             deadline: Utc::now()
                 + chrono::Duration::from_std(self.config.session_ttl)
                     .unwrap_or_else(|_| chrono::Duration::seconds(900)),
@@ -319,7 +334,7 @@ impl LoginManager {
                 expires_at: None,
                 error: None,
                 pty: Some(pty),
-                loopback_task: None,
+                auth_task: None,
                 settled_at: None,
             }),
         });
@@ -335,26 +350,25 @@ impl LoginManager {
             self.config.codex_callback_port,
             self.config.session_ttl,
         );
-        // HTTP logins commonly run in a container. Publishing/forwarding the
-        // registered loopback port can only reach a listener on its interface.
-        codex_config.bind_host = "0.0.0.0".to_string();
-        let login = crate::auth::CodexLogin::bind(codex_config)
+        codex_config.issuer.clone_from(&self.config.codex_issuer);
+        let login = crate::auth::CodexDeviceLogin::begin(codex_config)
             .await
             .map_err(LoginError::Spawn)?;
         let id = uuid::Uuid::new_v4().to_string();
         let session = Arc::new(Session {
             id: id.clone(),
             provider: SubscriptionProvider::Codex,
-            url: login.authorization_url().to_string(),
+            url: login.verification_url().to_string(),
+            user_code: Some(login.user_code().to_string()),
             deadline: Utc::now()
                 + chrono::Duration::from_std(self.config.session_ttl)
                     .unwrap_or_else(|_| chrono::Duration::seconds(900)),
             state: Mutex::new(SessionState {
-                status: LoginStatus::AwaitingCallback,
+                status: LoginStatus::AwaitingDevice,
                 expires_at: None,
                 error: None,
                 pty: None,
-                loopback_task: None,
+                auth_task: None,
                 settled_at: None,
             }),
         });
@@ -386,7 +400,7 @@ impl LoginManager {
             .state
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .loopback_task = Some(task);
+            .auth_task = Some(task);
         Ok(session.view())
     }
 
@@ -467,13 +481,15 @@ impl LoginManager {
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             let expired = matches!(
                 state.status,
-                LoginStatus::AwaitingCode | LoginStatus::AwaitingCallback
+                LoginStatus::AwaitingCode
+                    | LoginStatus::AwaitingCallback
+                    | LoginStatus::AwaitingDevice
             ) && session.deadline <= now;
             if expired {
                 state.status = LoginStatus::Expired;
-                state.error = Some("login session expired before a code was submitted".into());
+                state.error = Some("login session expired before authorization completed".into());
                 state.pty = None; // dropping the PTY kills the child
-                if let Some(task) = state.loopback_task.take() {
+                if let Some(task) = state.auth_task.take() {
                     task.abort();
                 }
                 state.settled_at = Some(now);
@@ -513,7 +529,7 @@ impl LoginManager {
             }
         }
         state.pty = None;
-        state.loopback_task = None;
+        state.auth_task = None;
         state.settled_at = Some(Utc::now());
     }
 
@@ -523,12 +539,12 @@ impl LoginManager {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         state.pty = None;
-        if let Some(task) = state.loopback_task.take() {
+        if let Some(task) = state.auth_task.take() {
             task.abort();
         }
         if matches!(
             state.status,
-            LoginStatus::AwaitingCode | LoginStatus::AwaitingCallback
+            LoginStatus::AwaitingCode | LoginStatus::AwaitingCallback | LoginStatus::AwaitingDevice
         ) {
             state.status = LoginStatus::Failed;
             state.error = Some("login session cancelled".into());
@@ -547,7 +563,9 @@ impl LoginManager {
                     .clone();
                 matches!(
                     status,
-                    LoginStatus::AwaitingCode | LoginStatus::AwaitingCallback
+                    LoginStatus::AwaitingCode
+                        | LoginStatus::AwaitingCallback
+                        | LoginStatus::AwaitingDevice
                 )
             })
             .count()

--- a/src/login/tests.rs
+++ b/src/login/tests.rs
@@ -38,13 +38,14 @@ fn settled_session(id: &str, status: LoginStatus, age: chrono::Duration) -> Arc<
         id: id.to_string(),
         provider: SubscriptionProvider::Claude,
         url: "https://claude.ai/oauth/authorize".to_string(),
+        user_code: None,
         deadline: Utc::now() + chrono::Duration::seconds(900),
         state: Mutex::new(SessionState {
             status,
             expires_at: None,
             error: None,
             pty: None,
-            loopback_task: None,
+            auth_task: None,
             settled_at: Some(Utc::now() - age),
         }),
     })
@@ -76,13 +77,14 @@ fn an_expired_session_becomes_evictable() {
         id: "gone".to_string(),
         provider: SubscriptionProvider::Claude,
         url: String::new(),
+        user_code: None,
         deadline: Utc::now() - chrono::Duration::seconds(1),
         state: Mutex::new(SessionState {
             status: LoginStatus::AwaitingCode,
             expires_at: None,
             error: None,
             pty: None,
-            loopback_task: None,
+            auth_task: None,
             settled_at: None,
         }),
     });

--- a/src/login_api.rs
+++ b/src/login_api.rs
@@ -2,7 +2,7 @@
 //!
 //! ```text
 //! POST   /api/login            -> { login_id, provider, url, status, ... }
-//! GET    /api/login/{id}       -> { status: "awaiting_code" | "awaiting_callback" | ... }
+//! GET    /api/login/{id}       -> { status: "awaiting_code" | "awaiting_device" | ... }
 //! POST   /api/login/{id}/code  -> { status: "authorized", expires_at, ... }
 //! DELETE /api/login/{id}       -> { cancelled: true }
 //! ```

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -628,6 +628,17 @@ mod cli_parser_tests {
                 }
             })
         ));
+        let codex_device = Cli::try_parse_from(["bin", "auth", "codex", "--flow", "device"])
+            .expect("parses Codex device auth");
+        assert!(matches!(
+            codex_device.command,
+            Some(Command::Auth {
+                op: AuthOp::Codex {
+                    flow: AuthFlow::Device,
+                    port: 1455
+                }
+            })
+        ));
         let status = Cli::try_parse_from(["bin", "auth", "status"]).expect("parses auth status");
         assert!(matches!(
             status.command,

--- a/tests/login_flow_test.rs
+++ b/tests/login_flow_test.rs
@@ -23,6 +23,7 @@ use link_assistant_router::oauth::OAuthProvider;
 use link_assistant_router::subscription::SubscriptionProvider;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 
 fn fake_cli() -> String {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -283,22 +284,62 @@ async fn a_disabled_manager_serves_nothing() {
 }
 
 #[tokio::test]
-async fn codex_login_waits_for_a_callback_instead_of_a_pasted_code() {
+async fn codex_login_defaults_to_device_auth_without_a_callback_listener() {
+    let issuer_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let issuer = format!("http://{}", issuer_listener.local_addr().unwrap());
+    let server = tokio::spawn(async move {
+        let mut first = true;
+        loop {
+            let Ok((mut socket, _)) = issuer_listener.accept().await else {
+                break;
+            };
+            let mut bytes = vec![0_u8; 2048];
+            let read = socket.read(&mut bytes).await.unwrap();
+            let request = String::from_utf8_lossy(&bytes[..read]);
+            let (status, body) = if first {
+                first = false;
+                assert!(request.starts_with("POST /api/accounts/deviceauth/usercode "));
+                (
+                    "200 OK",
+                    r#"{"device_auth_id":"device-1","user_code":"ABCD-EFGH","interval":"5"}"#,
+                )
+            } else {
+                assert!(request.starts_with("POST /api/accounts/deviceauth/token "));
+                ("403 Forbidden", r#"{"error":"authorization_pending"}"#)
+            };
+            socket
+                .write_all(
+                    format!(
+                        "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                        body.len()
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .unwrap();
+        }
+    });
+    let occupied = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let occupied_port = occupied.local_addr().unwrap().port();
     let home = temp_home();
     let manager = LoginManager::new(LoginConfig {
         codex_home: home,
-        codex_callback_port: 0,
+        codex_issuer: issuer,
+        codex_callback_port: occupied_port,
         ..LoginConfig::default()
     });
     let begun = manager
         .begin_for(SubscriptionProvider::Codex)
         .await
-        .expect("Codex loopback login should start");
+        .expect("Codex device login should start");
     assert_eq!(begun.provider, SubscriptionProvider::Codex);
-    assert_eq!(begun.status, LoginStatus::AwaitingCallback);
-    let url = begun.url.as_deref().expect("authorization URL");
-    assert!(url.contains("redirect_uri=http%3A%2F%2Flocalhost%3A"));
-    assert!(url.contains("code_challenge_method=S256"));
+    assert_eq!(begun.status, LoginStatus::AwaitingDevice);
+    assert_eq!(begun.user_code.as_deref(), Some("ABCD-EFGH"));
+    assert!(begun.url.as_deref().unwrap().ends_with("/codex/device"));
+    let response = serde_json::to_value(&begun).unwrap();
+    assert_eq!(response["status"], "awaiting_device");
+    assert_eq!(response["user_code"], "ABCD-EFGH");
+    assert_eq!(occupied.local_addr().unwrap().port(), occupied_port);
     assert!(
         manager
             .submit_code(&begun.login_id, "there-is-no-codex-paste-code")
@@ -306,4 +347,5 @@ async fn codex_login_waits_for_a_callback_instead_of_a_pasted_code() {
             .is_err()
     );
     assert!(manager.cancel(&begun.login_id));
+    server.abort();
 }


### PR DESCRIPTION
## Summary

- default `auth codex` and `--flow auto` to Codex device authorization
- expose the verification URL and user code through the HTTP login API without opening a callback listener
- poll pending/slow-down responses, persist credentials through the existing Codex auth path, and retain `--flow loopback` as an explicit fallback
- document the new flow and add the next minor-release changelog fragment

## Reproduction and verification

Previously, the default Codex flow bound a loopback callback port, which prevented remote and containerized logins when that listener was unavailable. The regression test occupies the configured callback port and verifies that the default HTTP login still starts device authorization and returns `awaiting_device` plus the user code.

Automated coverage also verifies pending polling, slow-down and expiry handling, token exchange and persistence, CLI flow parsing, and listener cleanup for all loopback terminal paths.

## Checks

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features --verbose`
- `cargo check --locked --all-targets --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --no-deps --all-features`
- `cargo build --locked --release`

Closes #87
