### PR TITLE
fix(ci): publish multi-architecture Docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,7 +189,9 @@ jobs:
         run: rust-script scripts/check-file-size.rs
 
       - name: Test release automation
-        run: rust-script --test scripts/version-and-commit.rs
+        run: |
+          rust-script --test scripts/version-and-commit.rs
+          rust-script --test scripts/check-docker-platforms.rs
 
   # === DEPENDENCY AUDIT ===
   # Both dependency surfaces the router carries: the Rust crates and the JS
@@ -408,6 +410,10 @@ jobs:
           username: konard
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Set up QEMU
+        if: steps.check.outputs.should_release == 'true'
+        uses: docker/setup-qemu-action@v4
+
       - name: Set up Docker Buildx
         if: steps.check.outputs.should_release == 'true'
         uses: docker/setup-buildx-action@v4
@@ -432,6 +438,7 @@ jobs:
         with:
           context: .
           target: runtime
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.docker-meta.outputs.tags }}
           labels: ${{ steps.docker-meta.outputs.labels }}
@@ -456,9 +463,23 @@ jobs:
         with:
           context: .
           target: with-claude-cli
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.docker-meta-claude-cli.outputs.tags }}
           labels: ${{ steps.docker-meta-claude-cli.outputs.labels }}
+
+      - name: Verify multi-platform Docker manifests
+        if: steps.check.outputs.should_release == 'true'
+        run: |
+          rust-script scripts/check-docker-platforms.rs \
+            "ghcr.io/${{ github.repository }}:latest" \
+            "ghcr.io/${{ github.repository }}:${{ steps.current_version.outputs.version }}" \
+            "ghcr.io/${{ github.repository }}:with-claude-cli" \
+            "ghcr.io/${{ github.repository }}:${{ steps.current_version.outputs.version }}-with-claude-cli" \
+            "${{ env.DOCKERHUB_IMAGE }}:latest" \
+            "${{ env.DOCKERHUB_IMAGE }}:${{ steps.current_version.outputs.version }}" \
+            "${{ env.DOCKERHUB_IMAGE }}:with-claude-cli" \
+            "${{ env.DOCKERHUB_IMAGE }}:${{ steps.current_version.outputs.version }}-with-claude-cli"
 
       - name: Create GitHub Release
         if: steps.check.outputs.should_release == 'true'
@@ -538,6 +559,10 @@ jobs:
           username: konard
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Set up QEMU
+        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
+        uses: docker/setup-qemu-action@v4
+
       - name: Set up Docker Buildx
         if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
         uses: docker/setup-buildx-action@v4
@@ -562,6 +587,7 @@ jobs:
         with:
           context: .
           target: runtime
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.docker-meta.outputs.tags }}
           labels: ${{ steps.docker-meta.outputs.labels }}
@@ -586,9 +612,23 @@ jobs:
         with:
           context: .
           target: with-claude-cli
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.docker-meta-claude-cli.outputs.tags }}
           labels: ${{ steps.docker-meta-claude-cli.outputs.labels }}
+
+      - name: Verify multi-platform Docker manifests
+        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
+        run: |
+          rust-script scripts/check-docker-platforms.rs \
+            "ghcr.io/${{ github.repository }}:latest" \
+            "ghcr.io/${{ github.repository }}:${{ steps.version.outputs.new_version }}" \
+            "ghcr.io/${{ github.repository }}:with-claude-cli" \
+            "ghcr.io/${{ github.repository }}:${{ steps.version.outputs.new_version }}-with-claude-cli" \
+            "${{ env.DOCKERHUB_IMAGE }}:latest" \
+            "${{ env.DOCKERHUB_IMAGE }}:${{ steps.version.outputs.new_version }}" \
+            "${{ env.DOCKERHUB_IMAGE }}:with-claude-cli" \
+            "${{ env.DOCKERHUB_IMAGE }}:${{ steps.version.outputs.new_version }}-with-claude-cli"
 
       - name: Create GitHub Release
         if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-11T12:24:57.763Z for PR creation at branch issue-90-1a19c3b4dc48 for issue https://github.com/link-assistant/router/issues/90

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-11T12:24:57.763Z for PR creation at branch issue-90-1a19c3b4dc48 for issue https://github.com/link-assistant/router/issues/90

--- a/changelog.d/20260811_130000_multi_arch_docker_images.md
+++ b/changelog.d/20260811_130000_multi_arch_docker_images.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Fixed
+- Publish and verify native `linux/amd64` and `linux/arm64` manifests for the default and Claude CLI Docker image variants on GHCR and Docker Hub.

--- a/scripts/check-docker-platforms.rs
+++ b/scripts/check-docker-platforms.rs
@@ -1,0 +1,141 @@
+#!/usr/bin/env rust-script
+//! Verify that published Docker image indexes contain every supported runtime platform.
+//!
+//! Usage: rust-script scripts/check-docker-platforms.rs <image> [<image> ...]
+//!
+//! ```cargo
+//! [dependencies]
+//! serde_json = "1"
+//! ```
+
+use serde_json::Value;
+use std::collections::BTreeSet;
+use std::env;
+use std::process::{self, Command};
+
+const REQUIRED_PLATFORMS: [&str; 2] = ["linux/amd64", "linux/arm64"];
+const ATTESTATION_PLATFORM: &str = "unknown/unknown";
+
+fn platforms_from_index(raw_manifest: &str) -> Result<BTreeSet<String>, String> {
+    let index: Value = serde_json::from_str(raw_manifest)
+        .map_err(|error| format!("invalid image manifest JSON: {error}"))?;
+    let manifests = index
+        .get("manifests")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "image is not a multi-platform manifest list".to_string())?;
+
+    let platforms = manifests
+        .iter()
+        .filter_map(|manifest| {
+            let platform = manifest.get("platform")?;
+            let os = platform.get("os")?.as_str()?;
+            let architecture = platform.get("architecture")?.as_str()?;
+            Some(format!("{os}/{architecture}"))
+        })
+        // BuildKit publishes provenance attestations as unknown/unknown entries.
+        // They are expected metadata, not runnable architectures.
+        .filter(|platform| platform != ATTESTATION_PLATFORM)
+        .collect();
+
+    Ok(platforms)
+}
+
+fn verify_index(image: &str, raw_manifest: &str) -> Result<(), String> {
+    let platforms = platforms_from_index(raw_manifest)?;
+    let missing: Vec<_> = REQUIRED_PLATFORMS
+        .iter()
+        .filter(|required| !platforms.contains(**required))
+        .copied()
+        .collect();
+
+    if missing.is_empty() {
+        println!(
+            "Verified {image}: {}",
+            REQUIRED_PLATFORMS.join(", ")
+        );
+        Ok(())
+    } else {
+        Err(format!(
+            "{image} is missing runnable platform(s): {}; found: {}",
+            missing.join(", "),
+            platforms.into_iter().collect::<Vec<_>>().join(", ")
+        ))
+    }
+}
+
+fn inspect_image(image: &str) -> Result<String, String> {
+    let output = Command::new("docker")
+        .args(["buildx", "imagetools", "inspect", image, "--raw"])
+        .output()
+        .map_err(|error| format!("failed to run docker for {image}: {error}"))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "failed to inspect {image}: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+
+    String::from_utf8(output.stdout)
+        .map_err(|error| format!("docker returned non-UTF-8 manifest data for {image}: {error}"))
+}
+
+fn main() {
+    let images: Vec<_> = env::args().skip(1).collect();
+    if images.is_empty() {
+        eprintln!("Usage: check-docker-platforms.rs <image> [<image> ...]");
+        process::exit(2);
+    }
+
+    let mut failed = false;
+    for image in images {
+        let result = inspect_image(&image).and_then(|manifest| verify_index(&image, &manifest));
+        if let Err(error) = result {
+            eprintln!("Error: {error}");
+            failed = true;
+        }
+    }
+
+    if failed {
+        process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MULTI_ARCH_INDEX: &str = r#"{
+      "manifests": [
+        {"platform": {"os": "linux", "architecture": "amd64"}},
+        {"platform": {"os": "linux", "architecture": "arm64", "variant": "v8"}},
+        {"platform": {"os": "unknown", "architecture": "unknown"}}
+      ]
+    }"#;
+
+    #[test]
+    fn accepts_required_platforms_and_ignores_attestations() {
+        assert!(verify_index("example/image:tag", MULTI_ARCH_INDEX).is_ok());
+    }
+
+    #[test]
+    fn rejects_an_index_without_arm64() {
+        let manifest = r#"{
+          "manifests": [
+            {"platform": {"os": "linux", "architecture": "amd64"}},
+            {"platform": {"os": "unknown", "architecture": "unknown"}}
+          ]
+        }"#;
+
+        let error = verify_index("example/image:tag", manifest).unwrap_err();
+        assert!(error.contains("linux/arm64"));
+        assert!(!error.contains("missing runnable platform(s): unknown/unknown"));
+    }
+
+    #[test]
+    fn rejects_a_single_platform_manifest() {
+        let manifest = r#"{"config": {"digest": "sha256:abc"}}"#;
+        let error = verify_index("example/image:tag", manifest).unwrap_err();
+        assert!(error.contains("not a multi-platform manifest list"));
+    }
+}

--- a/scripts/check-release-workflow.rs
+++ b/scripts/check-release-workflow.rs
@@ -16,9 +16,12 @@ fn main() {
         "DOCKERHUB_IMAGE: konard/link-assistant-router",
         "rust-script scripts/wait-for-crate.rs",
         "docker/login-action@v4",
+        "docker/setup-qemu-action@v4",
         "docker/setup-buildx-action@v4",
         "docker/metadata-action@v6",
         "docker/build-push-action@v7",
+        "platforms: linux/amd64,linux/arm64",
+        "rust-script scripts/check-docker-platforms.rs",
         "username: konard",
         "password: ${{ secrets.DOCKERHUB_TOKEN }}",
         "ghcr.io/${{ github.repository }}",
@@ -55,6 +58,30 @@ fn main() {
         failures.push("auto and manual release jobs must both publish Docker images".to_string());
     }
 
+    if count_occurrences(&workflow, "docker/setup-qemu-action@v4") < 2 {
+        failures.push(
+            "auto and manual release jobs must both enable cross-platform emulation".to_string(),
+        );
+    }
+
+    if count_occurrences(&workflow, "platforms: linux/amd64,linux/arm64") < 4 {
+        failures.push(
+            "auto and manual release jobs must publish both image variants for amd64 and arm64"
+                .to_string(),
+        );
+    }
+
+    if count_occurrences(
+        &workflow,
+        "rust-script scripts/check-docker-platforms.rs",
+    ) < 2
+    {
+        failures.push(
+            "auto and manual release jobs must verify published multi-platform manifests"
+                .to_string(),
+        );
+    }
+
     if count_occurrences(
         &workflow,
         "CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}",
@@ -89,7 +116,9 @@ fn main() {
     }
 
     if failures.is_empty() {
-        println!("release workflow publishes crates, GHCR images, and Docker Hub images");
+        println!(
+            "release workflow publishes crates and verified multi-platform GHCR/Docker Hub images"
+        );
     } else {
         for failure in failures {
             eprintln!("Error: {failure}");

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -552,6 +552,47 @@ fn release_workflow_publishes_both_the_default_and_claude_cli_images() {
     );
 }
 
+#[test]
+fn release_workflow_publishes_and_verifies_multi_platform_images() {
+    let workflow = read_lf(".github/workflows/release.yml");
+    let platform_check = read_lf("scripts/check-docker-platforms.rs");
+
+    assert_eq!(
+        workflow.matches("docker/setup-qemu-action@v4").count(),
+        2,
+        "auto and manual release jobs should install emulation for cross-platform builds"
+    );
+    assert_eq!(
+        workflow
+            .matches("platforms: linux/amd64,linux/arm64")
+            .count(),
+        4,
+        "both image variants in both release paths should publish amd64 and arm64 manifests"
+    );
+    assert_eq!(
+        workflow
+            .matches("rust-script scripts/check-docker-platforms.rs")
+            .count(),
+        2,
+        "auto and manual releases should verify the published manifests"
+    );
+    assert!(
+        workflow.contains("rust-script --test scripts/check-docker-platforms.rs"),
+        "CI should exercise the manifest parser without contacting a registry"
+    );
+
+    for platform in ["linux/amd64", "linux/arm64"] {
+        assert!(
+            platform_check.contains(platform),
+            "published-image verification should require {platform}"
+        );
+    }
+    assert!(
+        platform_check.contains("unknown/unknown"),
+        "published-image verification should explicitly tolerate provenance attestations"
+    );
+}
+
 /// Read a repository file with line endings normalised to `\n`.
 ///
 /// A Windows checkout may convert these files to CRLF, which would otherwise


### PR DESCRIPTION
## Summary

- build the default and `with-claude-cli` images for `linux/amd64` and `linux/arm64` in both automatic and manual release paths
- register QEMU before Buildx while retaining BuildKit provenance attestations
- verify every moving and versioned tag on GHCR and Docker Hub before creating the GitHub release
- add regression coverage for workflow configuration and manifest parsing

## Root cause and reproduction

The release workflow used Buildx without a `platforms` input, so GitHub’s amd64 runner published only `linux/amd64`. There was also no post-publish manifest validation.

The new checker reproduces the current release failure against both Docker Hub variants:

- `konard/link-assistant-router:0.41.0` — missing `linux/arm64`; found `linux/amd64`
- `konard/link-assistant-router:0.41.0-with-claude-cli` — missing `linux/arm64`; found `linux/amd64`

`unknown/unknown` provenance entries are explicitly ignored as attestations rather than counted as runnable platforms.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS=-Dwarnings cargo clippy --locked --all-targets --all-features`
- `RUSTFLAGS=-Dwarnings cargo test --locked --all-features --verbose`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --locked --no-deps --all-features`
- `cargo package --locked --list`
- `rust-script --test scripts/check-docker-platforms.rs` (3 tests)
- `rust-script scripts/check-release-workflow.rs`
- `rust-script scripts/check-file-size.rs`
- workflow YAML parse
- `docker build --target runtime .`

This is a CI/release change, so screenshots are not applicable.

Fixes #90