### PR TITLE
fix(api): translate Codex chat responses

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-11T12:30:47.946Z for PR creation at branch issue-91-ced77c4ada00 for issue https://github.com/link-assistant/router/issues/91

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-11T12:30:47.946Z for PR creation at branch issue-91-ced77c4ada00 for issue https://github.com/link-assistant/router/issues/91

--- a/changelog.d/20260811_124000_codex_chat_completion_responses.md
+++ b/changelog.d/20260811_124000_codex_chat_completion_responses.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Fixed
+- Convert Codex subscription Responses JSON and SSE back into the Chat Completions shape requested through `/v1/chat/completions`, including token usage and returned tool calls.

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -556,12 +556,11 @@ pub async fn openai_chat_completions(
         // The ChatGPT backend speaks only the Responses API; translate the
         // Chat Completions request before forwarding.
         let responses_body = responses::chat_completion_to_responses(&body);
-        return crate::subscription_proxy::forward_subscription_openai(
+        return crate::subscription_proxy::forward_codex_chat_completions(
             &state,
             &headers,
             responses_body,
             &body,
-            "/v1/responses",
             crate::metrics::Surface::OpenAIChat,
         )
         .await;

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -761,7 +761,10 @@ data: {"type":"response.completed","response":{"id":"resp_1","created_at":178644
 
         assert!(out["choices"][0]["message"]["content"].is_null());
         assert_eq!(out["choices"][0]["finish_reason"], "tool_calls");
-        assert_eq!(out["choices"][0]["message"]["tool_calls"][0]["id"], "call_1");
+        assert_eq!(
+            out["choices"][0]["message"]["tool_calls"][0]["id"],
+            "call_1"
+        );
         assert_eq!(
             out["choices"][0]["message"]["tool_calls"][0]["function"]["name"],
             "get_weather"

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -192,7 +192,330 @@ pub fn chat_completion_to_responses(body: &Value) -> Value {
     if let Some(tools) = body.get("tools") {
         out["tools"] = tools.clone();
     }
+    if body.get("stream").and_then(Value::as_bool) == Some(true) {
+        out["stream"] = Value::Bool(true);
+    }
     out
+}
+
+/// Translate a completed Responses object into a Chat Completions object.
+#[must_use]
+pub fn response_to_chat_completion(response: &Value, requested_model: &str) -> Value {
+    let response_id = response
+        .get("id")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let id = response_id.strip_prefix("chatcmpl-").map_or_else(
+        || format!("chatcmpl-{response_id}"),
+        |_| response_id.to_string(),
+    );
+    let model = response
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or(requested_model);
+    let created = response
+        .get("created_at")
+        .and_then(Value::as_i64)
+        .unwrap_or_else(|| chrono::Utc::now().timestamp());
+
+    let mut content = String::new();
+    let mut tool_calls = Vec::new();
+    if let Some(output) = response.get("output").and_then(Value::as_array) {
+        for item in output {
+            match item.get("type").and_then(Value::as_str) {
+                Some("message") => {
+                    if let Some(parts) = item.get("content").and_then(Value::as_array) {
+                        for part in parts {
+                            if matches!(
+                                part.get("type").and_then(Value::as_str),
+                                Some("output_text" | "text")
+                            ) {
+                                if let Some(text) = part.get("text").and_then(Value::as_str) {
+                                    content.push_str(text);
+                                }
+                            }
+                        }
+                    }
+                }
+                Some("function_call") => {
+                    let call_id = item
+                        .get("call_id")
+                        .or_else(|| item.get("id"))
+                        .and_then(Value::as_str)
+                        .unwrap_or_default();
+                    tool_calls.push(json!({
+                        "id": call_id,
+                        "type": "function",
+                        "function": {
+                            "name": item.get("name").and_then(Value::as_str).unwrap_or_default(),
+                            "arguments": item.get("arguments").and_then(Value::as_str).unwrap_or_default(),
+                        }
+                    }));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let finish_reason = if !tool_calls.is_empty() {
+        "tool_calls"
+    } else if response.get("status").and_then(Value::as_str) == Some("incomplete") {
+        "length"
+    } else {
+        "stop"
+    };
+    let mut message = json!({"role": "assistant", "content": content});
+    if !tool_calls.is_empty() {
+        message["tool_calls"] = Value::Array(tool_calls);
+        if content.is_empty() {
+            message["content"] = Value::Null;
+        }
+    }
+
+    let input_tokens = response
+        .pointer("/usage/input_tokens")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let output_tokens = response
+        .pointer("/usage/output_tokens")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let total_tokens = response
+        .pointer("/usage/total_tokens")
+        .and_then(Value::as_u64)
+        .unwrap_or(input_tokens + output_tokens);
+    let mut usage = json!({
+        "prompt_tokens": input_tokens,
+        "completion_tokens": output_tokens,
+        "total_tokens": total_tokens,
+    });
+    if let Some(details) = response.pointer("/usage/input_tokens_details") {
+        usage["prompt_tokens_details"] = details.clone();
+    }
+    if let Some(details) = response.pointer("/usage/output_tokens_details") {
+        usage["completion_tokens_details"] = details.clone();
+    }
+
+    json!({
+        "id": id,
+        "object": "chat.completion",
+        "created": created,
+        "model": model,
+        "choices": [{
+            "index": 0,
+            "message": message,
+            "finish_reason": finish_reason,
+        }],
+        "usage": usage,
+    })
+}
+
+/// Incrementally translate Responses SSE events into Chat Completions chunks.
+pub struct ResponsesChatStreamTranslator {
+    model: String,
+    id: String,
+    created: i64,
+    buffer: String,
+    sent_role: bool,
+    sent_final: bool,
+    tool_indices: std::collections::BTreeSet<u64>,
+}
+
+impl ResponsesChatStreamTranslator {
+    /// Create a translator for one Codex-backed Chat Completions request.
+    #[must_use]
+    pub fn new(requested_model: &str) -> Self {
+        Self {
+            model: requested_model.to_string(),
+            id: format!("chatcmpl-{}", uuid::Uuid::new_v4()),
+            created: chrono::Utc::now().timestamp(),
+            buffer: String::new(),
+            sent_role: false,
+            sent_final: false,
+            tool_indices: std::collections::BTreeSet::new(),
+        }
+    }
+
+    /// Push raw upstream bytes and return complete Chat Completions SSE frames.
+    pub fn push(&mut self, chunk: &[u8]) -> Vec<String> {
+        self.buffer.push_str(&String::from_utf8_lossy(chunk));
+        let mut frames = Vec::new();
+        while let Some((index, separator_len)) = find_sse_separator(&self.buffer) {
+            let block = self.buffer[..index].to_string();
+            self.buffer.drain(..index + separator_len);
+            frames.extend(self.translate_block(&block));
+        }
+        frames
+    }
+
+    fn translate_block(&mut self, block: &str) -> Vec<String> {
+        let data = extract_sse_data(block);
+        if data.is_empty() {
+            return Vec::new();
+        }
+        if data == "[DONE]" {
+            return if self.sent_final {
+                Vec::new()
+            } else {
+                self.sent_final = true;
+                vec![done_frame()]
+            };
+        }
+        let Ok(event) = serde_json::from_str::<Value>(&data) else {
+            return Vec::new();
+        };
+        self.translate_event(&event)
+    }
+
+    fn translate_event(&mut self, event: &Value) -> Vec<String> {
+        match event.get("type").and_then(Value::as_str) {
+            Some("response.created") => {
+                if let Some(response) = event.get("response") {
+                    self.capture_identity(response);
+                }
+                self.role_frame()
+            }
+            Some("response.output_text.delta") => {
+                let text = event
+                    .get("delta")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default();
+                let mut frames = self.role_frame();
+                frames.push(self.chat_frame(&json!({"content": text}), None));
+                frames
+            }
+            Some("response.output_item.added" | "response.output_item.done") => {
+                self.translate_function_call(event)
+            }
+            Some("response.function_call_arguments.delta") => {
+                let index = event
+                    .get("output_index")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0);
+                let delta = event
+                    .get("delta")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default();
+                vec![self.chat_frame(
+                    &json!({"tool_calls": [{
+                        "index": index,
+                        "function": {"arguments": delta}
+                    }]}),
+                    None,
+                )]
+            }
+            Some("response.completed" | "response.incomplete" | "response.failed") => {
+                if self.sent_final {
+                    return Vec::new();
+                }
+                if let Some(response) = event.get("response") {
+                    self.capture_identity(response);
+                }
+                let finish_reason = if !self.tool_indices.is_empty() {
+                    "tool_calls"
+                } else if event.get("type").and_then(Value::as_str) == Some("response.incomplete") {
+                    "length"
+                } else {
+                    "stop"
+                };
+                self.sent_final = true;
+                vec![
+                    self.chat_frame(&json!({}), Some(finish_reason)),
+                    done_frame(),
+                ]
+            }
+            _ => Vec::new(),
+        }
+    }
+
+    fn translate_function_call(&mut self, event: &Value) -> Vec<String> {
+        let item = event.get("item").unwrap_or(&Value::Null);
+        if item.get("type").and_then(Value::as_str) != Some("function_call") {
+            return Vec::new();
+        }
+        let index = event
+            .get("output_index")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        if !self.tool_indices.insert(index) {
+            return Vec::new();
+        }
+        let mut frames = self.role_frame();
+        frames.push(self.chat_frame(
+            &json!({"tool_calls": [{
+                "index": index,
+                "id": item.get("call_id").or_else(|| item.get("id")).and_then(Value::as_str).unwrap_or_default(),
+                "type": "function",
+                "function": {
+                    "name": item.get("name").and_then(Value::as_str).unwrap_or_default(),
+                    "arguments": item.get("arguments").and_then(Value::as_str).unwrap_or_default(),
+                }
+            }]}),
+            None,
+        ));
+        frames
+    }
+
+    fn capture_identity(&mut self, response: &Value) {
+        if let Some(id) = response.get("id").and_then(Value::as_str) {
+            self.id = format!("chatcmpl-{id}");
+        }
+        if let Some(model) = response.get("model").and_then(Value::as_str) {
+            self.model = model.to_string();
+        }
+        if let Some(created) = response.get("created_at").and_then(Value::as_i64) {
+            self.created = created;
+        }
+    }
+
+    fn role_frame(&mut self) -> Vec<String> {
+        if self.sent_role {
+            Vec::new()
+        } else {
+            self.sent_role = true;
+            vec![self.chat_frame(&json!({"role": "assistant"}), None)]
+        }
+    }
+
+    fn chat_frame(&self, delta: &Value, finish_reason: Option<&str>) -> String {
+        format!(
+            "data: {}\n\n",
+            json!({
+                "id": self.id,
+                "object": "chat.completion.chunk",
+                "created": self.created,
+                "model": self.model,
+                "choices": [{
+                    "index": 0,
+                    "delta": delta,
+                    "finish_reason": finish_reason,
+                }]
+            })
+        )
+    }
+}
+
+fn find_sse_separator(buffer: &str) -> Option<(usize, usize)> {
+    buffer
+        .find("\r\n\r\n")
+        .map(|index| (index, 4))
+        .or_else(|| buffer.find("\n\n").map(|index| (index, 2)))
+}
+
+fn extract_sse_data(block: &str) -> String {
+    block
+        .lines()
+        .filter_map(|line| {
+            line.trim_end_matches('\r')
+                .strip_prefix("data:")
+                .map(str::trim_start)
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn done_frame() -> String {
+    "data: [DONE]\n\n".to_string()
 }
 
 /// Translate an Anthropic JSON response to an `OpenAI` Responses-API response.
@@ -342,6 +665,107 @@ mod tests {
         assert_eq!(out["input"][0]["role"], "user");
         assert_eq!(out["input"][0]["content"][0]["type"], "input_text");
         assert_eq!(out["input"][1]["content"][0]["type"], "output_text");
+    }
+
+    #[test]
+    fn chat_completion_preserves_stream_request_for_codex() {
+        let body = json!({
+            "model": "gpt-5.6-sol",
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": true,
+        });
+
+        let out = chat_completion_to_responses(&body);
+
+        assert_eq!(out["stream"], true);
+    }
+
+    #[test]
+    fn codex_response_converts_to_chat_completion() {
+        let response = json!({
+            "id": "resp_1",
+            "object": "response",
+            "created_at": 1_786_448_400,
+            "model": "gpt-5.6-sol",
+            "status": "completed",
+            "output": [{
+                "id": "msg_1",
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "13"}]
+            }],
+            "usage": {"input_tokens": 9, "output_tokens": 2, "total_tokens": 11}
+        });
+
+        let out = response_to_chat_completion(&response, "gpt-5.6-sol");
+
+        assert_eq!(out["object"], "chat.completion");
+        assert_eq!(out["choices"][0]["message"]["role"], "assistant");
+        assert_eq!(out["choices"][0]["message"]["content"], "13");
+        assert_eq!(out["choices"][0]["finish_reason"], "stop");
+        assert_eq!(out["usage"]["prompt_tokens"], 9);
+        assert_eq!(out["usage"]["completion_tokens"], 2);
+        assert_eq!(out["usage"]["total_tokens"], 11);
+        assert!(out.get("output").is_none());
+        assert!(out.get("instructions").is_none());
+    }
+
+    #[test]
+    fn codex_response_stream_converts_to_chat_chunks() {
+        let mut translator = ResponsesChatStreamTranslator::new("gpt-5.6-sol");
+        let first = translator.push(
+            br#"event: response.created
+data: {"type":"response.created","response":{"id":"resp_1","created_at":1786448400,"model":"gpt-5.6-sol","status":"in_progress"}}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"content_index":0,"delta":"1"}
+
+"#,
+        );
+        let second = translator.push(
+            br#"event: response.output_text.delta
+data: {"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"content_index":0,"delta":"3"}
+
+event: response.completed
+data: {"type":"response.completed","response":{"id":"resp_1","created_at":1786448400,"model":"gpt-5.6-sol","status":"completed","output":[]}}
+
+"#,
+        );
+        let joined = first.into_iter().chain(second).collect::<String>();
+
+        assert!(joined.contains("\"object\":\"chat.completion.chunk\""));
+        assert!(joined.contains("\"role\":\"assistant\""));
+        assert!(joined.contains("\"content\":\"1\""));
+        assert!(joined.contains("\"content\":\"3\""));
+        assert!(joined.contains("\"finish_reason\":\"stop\""));
+        assert!(joined.ends_with("data: [DONE]\n\n"));
+        assert!(!joined.contains("response.output_text.delta"));
+    }
+
+    #[test]
+    fn codex_function_calls_convert_to_chat_tool_calls() {
+        let response = json!({
+            "id": "resp_tools",
+            "model": "gpt-5.6-sol",
+            "status": "completed",
+            "output": [{
+                "id": "fc_1",
+                "call_id": "call_1",
+                "type": "function_call",
+                "name": "get_weather",
+                "arguments": "{\"city\":\"Paris\"}"
+            }]
+        });
+
+        let out = response_to_chat_completion(&response, "gpt-5.6-sol");
+
+        assert!(out["choices"][0]["message"]["content"].is_null());
+        assert_eq!(out["choices"][0]["finish_reason"], "tool_calls");
+        assert_eq!(out["choices"][0]["message"]["tool_calls"][0]["id"], "call_1");
+        assert_eq!(
+            out["choices"][0]["message"]["tool_calls"][0]["function"]["name"],
+            "get_weather"
+        );
     }
 
     #[test]

--- a/src/subscription_proxy.rs
+++ b/src/subscription_proxy.rs
@@ -33,10 +33,58 @@ use crate::subscription::{SubscriptionProvider, SubscriptionToken};
 pub async fn forward_subscription_openai(
     state: &AppState,
     headers: &HeaderMap,
+    body: serde_json::Value,
+    routing_body: &serde_json::Value,
+    path: &str,
+    surface: Surface,
+) -> Response {
+    forward_subscription_openai_inner(
+        state,
+        headers,
+        body,
+        routing_body,
+        path,
+        surface,
+        SubscriptionResponseShape::Passthrough,
+    )
+    .await
+}
+
+/// Forward a Chat Completions request translated to the Codex Responses API,
+/// then translate the upstream response back to the caller's requested shape.
+pub async fn forward_codex_chat_completions(
+    state: &AppState,
+    headers: &HeaderMap,
+    body: serde_json::Value,
+    routing_body: &serde_json::Value,
+    surface: Surface,
+) -> Response {
+    forward_subscription_openai_inner(
+        state,
+        headers,
+        body,
+        routing_body,
+        "/v1/responses",
+        surface,
+        SubscriptionResponseShape::ChatCompletion,
+    )
+    .await
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum SubscriptionResponseShape {
+    Passthrough,
+    ChatCompletion,
+}
+
+async fn forward_subscription_openai_inner(
+    state: &AppState,
+    headers: &HeaderMap,
     mut body: serde_json::Value,
     routing_body: &serde_json::Value,
     path: &str,
     surface: Surface,
+    response_shape: SubscriptionResponseShape,
 ) -> Response {
     if let Some(resp) = maybe_mpp_challenge(state, headers, path) {
         return resp;
@@ -216,7 +264,7 @@ pub async fn forward_subscription_openai(
     let rate_limit_headers = rate_limit_headers(upstream_resp.headers());
 
     let codex = provider == SubscriptionProvider::Codex;
-    if stream_requested || is_event_stream(&content_type) {
+    if stream_requested || (!codex && is_event_stream(&content_type)) {
         // The Codex backend streams SSE but labels it `application/json`; re-label
         // so SSE-aware clients treat the body as the stream it is.
         let stream_content_type = if codex {
@@ -224,9 +272,23 @@ pub async fn forward_subscription_openai(
         } else {
             content_type
         };
-        let stream = upstream_resp
-            .bytes_stream()
-            .map(|chunk| chunk.map_err(std::io::Error::other));
+        let requested_model = routing_body
+            .get("model")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default();
+        let mut translator = crate::responses::ResponsesChatStreamTranslator::new(requested_model);
+        let stream = upstream_resp.bytes_stream().map(move |chunk| {
+            chunk.map_or_else(
+                |error| Err(std::io::Error::other(error)),
+                |bytes| {
+                    if codex && response_shape == SubscriptionResponseShape::ChatCompletion {
+                        Ok(bytes::Bytes::from(translator.push(&bytes).join("")))
+                    } else {
+                        Ok(bytes)
+                    }
+                },
+            )
+        });
         let mut response = Response::new(Body::from_stream(stream));
         *response.status_mut() = status;
         response
@@ -259,19 +321,45 @@ pub async fn forward_subscription_openai(
     // then parses the raw event stream as a single JSON object and fails with an
     // incomplete result. Collapse the SSE into the final `response.completed`
     // payload and return it as a normal JSON Responses object.
+    let mut response_body = upstream_body;
     if codex && status.is_success() {
-        if let Some(json) = codex_sse_to_response_json(&upstream_body) {
-            let mut response = Response::new(Body::from(json));
-            *response.status_mut() = status;
-            response
-                .headers_mut()
-                .insert("content-type", HeaderValue::from_static("application/json"));
-            apply_headers(response.headers_mut(), rate_limit_headers);
-            return response;
+        if let Some(json) = codex_sse_to_response_json(&response_body) {
+            response_body = bytes::Bytes::from(json);
         }
+        if response_shape == SubscriptionResponseShape::ChatCompletion {
+            let requested_model = routing_body
+                .get("model")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default();
+            let parsed = match serde_json::from_slice::<serde_json::Value>(&response_body) {
+                Ok(value) => value,
+                Err(error) => {
+                    return error_response(
+                        StatusCode::BAD_GATEWAY,
+                        "api_error",
+                        &format!(
+                            "Codex subscription upstream returned an invalid response: {error}"
+                        ),
+                    );
+                }
+            };
+            let translated =
+                crate::responses::response_to_chat_completion(&parsed, requested_model);
+            response_body = bytes::Bytes::from(
+                serde_json::to_vec(&translated).expect("JSON values always serialize"),
+            );
+        }
+
+        let mut response = Response::new(Body::from(response_body));
+        *response.status_mut() = status;
+        response
+            .headers_mut()
+            .insert("content-type", HeaderValue::from_static("application/json"));
+        apply_headers(response.headers_mut(), rate_limit_headers);
+        return response;
     }
 
-    let mut response = Response::new(Body::from(upstream_body));
+    let mut response = Response::new(Body::from(response_body));
     *response.status_mut() = status;
     response.headers_mut().insert("content-type", content_type);
     apply_headers(response.headers_mut(), rate_limit_headers);


### PR DESCRIPTION
## Summary

- translate completed Codex Responses objects back into Chat Completions JSON for `/v1/chat/completions`
- translate Codex Responses SSE events into Chat Completions chunks and preserve `stream: true` upstream
- preserve direct `/v1/responses` behavior while mapping usage and returned function calls for Chat Completions callers

## Reproduction

Before this change, a Codex subscription request to `/v1/chat/completions` returned a raw Responses API object (`object: "response"`) instead of `choices`. Requests with `stream: true` also received Responses events rather than Chat Completions SSE chunks.

The added regression tests reproduce both response-shape failures and verify the corrected JSON and SSE contracts.

## Tests

- `cargo fmt --all -- --check`
- `cargo check --locked --all-targets --all-features`
- `cargo clippy --locked --all-targets --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --no-deps --all-features`
- `rust-script scripts/check-file-size.rs`
- `rust-script --test scripts/version-and-commit.rs`
- `cargo test --locked --all-features --verbose`
- `cargo test --locked --doc --verbose`

Closes #91
