### PR TITLE
fix: translate tools for Codex subscriptions

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-11T12:50:10.690Z for PR creation at branch issue-92-ec4e16dd2db9 for issue https://github.com/link-assistant/router/issues/92

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-11T12:50:10.690Z for PR creation at branch issue-92-ec4e16dd2db9 for issue https://github.com/link-assistant/router/issues/92

--- a/changelog.d/20260811_133000_codex_tool_translation.md
+++ b/changelog.d/20260811_133000_codex_tool_translation.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+### Fixed
+
+- Translate tool definitions, calls, and results from Anthropic and Chat Completions requests into the native Responses format required by Codex subscriptions.

--- a/src/anthropic_bridge_tests.rs
+++ b/src/anthropic_bridge_tests.rs
@@ -109,6 +109,35 @@ fn translates_tool_use_and_tool_result_blocks() {
 }
 
 #[test]
+fn codex_projection_uses_native_responses_tool_items() {
+    let body = json!({
+        "tools": [{
+            "name": "get_time",
+            "description": "current time",
+            "input_schema": {"type": "object", "properties": {"tz": {"type": "string"}}}
+        }],
+        "messages": [
+            {"role": "assistant", "content": [
+                {"type": "tool_use", "id": "toolu_1", "name": "get_time", "input": {"tz": "UTC"}}
+            ]},
+            {"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": "toolu_1", "content": "12:00"}
+            ]}
+        ]
+    });
+
+    let chat = anthropic_to_chat_request(&body, "gpt-5.6-sol");
+    let responses = crate::responses::chat_completion_to_responses(&chat);
+
+    assert_eq!(responses["tools"][0]["name"], "get_time");
+    assert!(responses["tools"][0].get("function").is_none());
+    assert_eq!(responses["input"][0]["type"], "function_call");
+    assert_eq!(responses["input"][0]["call_id"], "toolu_1");
+    assert_eq!(responses["input"][1]["type"], "function_call_output");
+    assert_eq!(responses["input"][1]["call_id"], "toolu_1");
+}
+
+#[test]
 fn drops_thinking_blocks() {
     let body = json!({
         "messages": [{"role": "assistant", "content": [

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -162,9 +162,10 @@ pub fn chat_completion_to_responses(body: &Value) -> Value {
                 _ => {
                     let text = extract_text(&content).unwrap_or_default();
                     let tool_calls = msg.get("tool_calls").and_then(Value::as_array);
+                    let has_tool_calls = matches!(tool_calls, Some(calls) if !calls.is_empty());
                     // A tool-only assistant turn is represented by its
                     // `function_call` items, without an empty message item.
-                    if !text.is_empty() || tool_calls.map_or(true, Vec::is_empty) {
+                    if !text.is_empty() || !has_tool_calls {
                         // Responses input uses `input_text` for user-side
                         // content and `output_text` for prior assistant turns.
                         let part_type = if role == "assistant" {

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -151,19 +151,35 @@ pub fn chat_completion_to_responses(body: &Value) -> Value {
                         instructions.push(text);
                     }
                 }
+                "tool" => input.push(json!({
+                    "type": "function_call_output",
+                    "call_id": msg
+                        .get("tool_call_id")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default(),
+                    "output": extract_text(&content).unwrap_or_default(),
+                })),
                 _ => {
                     let text = extract_text(&content).unwrap_or_default();
-                    // Responses input uses `input_text` for user-side content
-                    // and `output_text` for prior assistant turns.
-                    let part_type = if role == "assistant" {
-                        "output_text"
-                    } else {
-                        "input_text"
-                    };
-                    input.push(json!({
-                        "role": role,
-                        "content": [{ "type": part_type, "text": text }],
-                    }));
+                    let tool_calls = msg.get("tool_calls").and_then(Value::as_array);
+                    // A tool-only assistant turn is represented by its
+                    // `function_call` items, without an empty message item.
+                    if !text.is_empty() || tool_calls.map_or(true, Vec::is_empty) {
+                        // Responses input uses `input_text` for user-side
+                        // content and `output_text` for prior assistant turns.
+                        let part_type = if role == "assistant" {
+                            "output_text"
+                        } else {
+                            "input_text"
+                        };
+                        input.push(json!({
+                            "role": role,
+                            "content": [{ "type": part_type, "text": text }],
+                        }));
+                    }
+                    if let Some(tool_calls) = tool_calls {
+                        input.extend(tool_calls.iter().filter_map(chat_tool_call_to_responses));
+                    }
                 }
             }
         }
@@ -190,9 +206,70 @@ pub fn chat_completion_to_responses(body: &Value) -> Value {
         out["top_p"] = json!(t);
     }
     if let Some(tools) = body.get("tools") {
-        out["tools"] = tools.clone();
+        out["tools"] = chat_tools_to_responses(tools);
+    }
+    if let Some(choice) = body.get("tool_choice") {
+        out["tool_choice"] = chat_tool_choice_to_responses(choice);
     }
     out
+}
+
+fn chat_tool_call_to_responses(call: &Value) -> Option<Value> {
+    let function = call.get("function")?;
+    Some(json!({
+        "type": "function_call",
+        "call_id": call.get("id").and_then(Value::as_str).unwrap_or_default(),
+        "name": function.get("name").and_then(Value::as_str).unwrap_or_default(),
+        "arguments": function
+            .get("arguments")
+            .and_then(Value::as_str)
+            .unwrap_or("{}"),
+    }))
+}
+
+fn chat_tools_to_responses(tools: &Value) -> Value {
+    let Value::Array(tools) = tools else {
+        return tools.clone();
+    };
+    Value::Array(
+        tools
+            .iter()
+            .map(|tool| {
+                if tool.get("type").and_then(Value::as_str) != Some("function") {
+                    return tool.clone();
+                }
+                let Some(function) = tool.get("function") else {
+                    return tool.clone();
+                };
+                let mut mapped = json!({
+                    "type": "function",
+                    "name": function.get("name").cloned().unwrap_or(Value::Null),
+                    "description": function
+                        .get("description")
+                        .cloned()
+                        .unwrap_or(Value::String(String::new())),
+                    "parameters": function
+                        .get("parameters")
+                        .cloned()
+                        .unwrap_or_else(|| json!({})),
+                });
+                if let Some(strict) = function.get("strict") {
+                    mapped["strict"] = strict.clone();
+                }
+                mapped
+            })
+            .collect(),
+    )
+}
+
+fn chat_tool_choice_to_responses(choice: &Value) -> Value {
+    let Some(function) = choice.get("function") else {
+        return choice.clone();
+    };
+    json!({
+        "type": "function",
+        "name": function.get("name").cloned().unwrap_or(Value::Null),
+    })
 }
 
 /// Translate an Anthropic JSON response to an `OpenAI` Responses-API response.
@@ -342,6 +419,83 @@ mod tests {
         assert_eq!(out["input"][0]["role"], "user");
         assert_eq!(out["input"][0]["content"][0]["type"], "input_text");
         assert_eq!(out["input"][1]["content"][0]["type"], "output_text");
+    }
+
+    #[test]
+    fn chat_completion_projects_tools_and_results_to_responses() {
+        let body = json!({
+            "model": "gpt-5.6-sol",
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get the weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}}
+                    },
+                    "strict": true
+                }
+            }],
+            "tool_choice": {"type": "function", "function": {"name": "get_weather"}},
+            "messages": [
+                {"role": "user", "content": "weather in Moscow?"},
+                {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_weather_1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": "{\"city\":\"Moscow\"}"
+                        }
+                    }]
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_weather_1",
+                    "content": "cold"
+                }
+            ]
+        });
+
+        let out = chat_completion_to_responses(&body);
+
+        assert_eq!(
+            out["tools"][0],
+            json!({
+                "type": "function",
+                "name": "get_weather",
+                "description": "Get the weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}}
+                },
+                "strict": true
+            })
+        );
+        assert_eq!(
+            out["tool_choice"],
+            json!({"type": "function", "name": "get_weather"})
+        );
+        assert_eq!(
+            out["input"][1],
+            json!({
+                "type": "function_call",
+                "call_id": "call_weather_1",
+                "name": "get_weather",
+                "arguments": "{\"city\":\"Moscow\"}"
+            })
+        );
+        assert_eq!(
+            out["input"][2],
+            json!({
+                "type": "function_call_output",
+                "call_id": "call_weather_1",
+                "output": "cold"
+            })
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #92\n\n## Summary\n\n- flatten Chat Completions function definitions and tool choices into the Responses schema required by Codex subscriptions\n- translate assistant tool calls into function_call input items\n- translate tool results into function_call_output items with matching call IDs\n- apply the same projection after the Anthropic-to-Chat bridge\n- preserve strict function declarations and non-function Responses tools\n\n## Reproduction\n\nOn a Codex subscription, send either an Anthropic Messages request with a tool using name and input_schema or a Chat Completions request with a nested function definition. Before this fix, the nested definition reached the Responses backend unchanged and failed with Missing required parameter: tools[0].name.\n\nContinue the conversation with the returned tool call and a tool result. Before this fix, the assistant call was discarded and the result became a role: tool message, which the Responses backend rejects.\n\n## Automated regression coverage\n\n- chat_completion_projects_tools_and_results_to_responses covers flat definitions, strict mode, tool choice, assistant function calls, and matching function outputs\n- codex_projection_uses_native_responses_tool_items covers the full Anthropic bridge into the Codex Responses projection\n\n## Local verification\n\n- cargo fmt --all -- --check\n- cargo check --locked --all-targets --all-features\n- cargo clippy --locked --all-targets --all-features\n- RUSTDOCFLAGS=-D warnings cargo doc --locked --no-deps --all-features\n- rust-script scripts/check-file-size.rs\n- rust-script --test scripts/version-and-commit.rs\n- rust-script scripts/check-changelog-fragment.rs\n- cargo test --locked --all-features: 321 library tests and all integration, release, and security suites passed
