### PR TITLE
fix(auth): protect live model catalogs

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-11T13:02:38.085Z for PR creation at branch issue-93-0745b3b1497e for issue https://github.com/link-assistant/router/issues/93

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-11T13:02:38.085Z for PR creation at branch issue-93-0745b3b1497e for issue https://github.com/link-assistant/router/issues/93

--- a/changelog.d/20260811_133000_models_authentication.md
+++ b/changelog.d/20260811_133000_models_authentication.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Require a valid client token before returning live model catalogs from `/v1/models` and its provider aliases.

--- a/src/model_routing.rs
+++ b/src/model_routing.rs
@@ -2,7 +2,7 @@
 
 use axum::body::Body;
 use axum::extract::{Request, State};
-use axum::http::StatusCode;
+use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use serde_json::{Value, json};
 
@@ -176,7 +176,23 @@ pub async fn pinned_model_catalog(state: &AppState, provider: SubscriptionProvid
 }
 
 /// `GET /v1/models` across automatic or explicitly pinned providers.
-pub async fn models(State(state): State<AppState>) -> impl IntoResponse {
+pub async fn models(State(state): State<AppState>, headers: HeaderMap) -> Response {
+    let Some(token) = crate::proxy::extract_client_token(&headers) else {
+        return crate::proxy::error_response(
+            StatusCode::UNAUTHORIZED,
+            "authentication_error",
+            "Missing Authorization Bearer token or x-api-key",
+        );
+    };
+    if let Err(error) = state.token_manager.validate_token(token) {
+        let status = if matches!(error, crate::token::TokenError::Revoked) {
+            StatusCode::FORBIDDEN
+        } else {
+            StatusCode::UNAUTHORIZED
+        };
+        return crate::proxy::error_response(status, "authentication_error", &error.to_string());
+    }
+
     let models = match state.upstream_provider {
         UpstreamProvider::Auto => model_catalog(
             &healthy_providers(
@@ -315,12 +331,15 @@ pub async fn route_state(state: &AppState, body: &Value) -> Result<AppState, Mod
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::body::Body;
     use axum::extract::Query;
-    use axum::http::HeaderMap;
+    use axum::http::{HeaderMap, Request};
+    use axum::routing::get;
     use http_body_util::BodyExt;
     use std::fs;
     use std::sync::Arc;
     use tempfile::tempdir;
+    use tower::ServiceExt;
 
     fn auto_state(readers: Vec<SubscriptionReader>, data_dir: &std::path::Path) -> AppState {
         AppState {
@@ -372,6 +391,53 @@ mod tests {
             data.iter()
                 .any(|m| m["id"] == "gpt-5" && m["owned_by"] == "openai")
         );
+    }
+
+    #[tokio::test]
+    async fn model_catalog_routes_require_a_valid_client_token() {
+        let data = tempdir().unwrap();
+        let state = auto_state(Vec::new(), data.path());
+        let valid_token = state.token_manager.issue_token(1, "catalog test").unwrap();
+        let app = axum::Router::new()
+            .route("/v1/models", get(models))
+            .route("/api/codex/v1/models", get(models))
+            .with_state(state);
+
+        for path in ["/v1/models", "/api/codex/v1/models"] {
+            for authorization in [None, Some("Bearer la_sk_garbage")] {
+                let mut request = Request::builder().uri(path);
+                if let Some(value) = authorization {
+                    request = request.header("authorization", value);
+                }
+                let response = app
+                    .clone()
+                    .oneshot(request.body(Body::empty()).unwrap())
+                    .await
+                    .unwrap();
+                assert_eq!(
+                    response.status(),
+                    StatusCode::UNAUTHORIZED,
+                    "{path} accepted {authorization:?}"
+                );
+            }
+
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .uri(path)
+                        .header("authorization", format!("Bearer {valid_token}"))
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                response.status(),
+                StatusCode::OK,
+                "{path} rejected a valid token"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- require a valid router-issued client credential before serving the live model catalog
- protect `/v1/models` and every provider alias through their shared handler
- preserve inference authentication semantics: Bearer and `x-api-key` credentials are accepted, malformed tokens return 401, and revoked tokens return 403
- add a changelog fragment for the security fix

## Reproduction

Before this change, both an anonymous request and an obviously invalid token returned 200 with the connected subscriptions' live catalog:

```console
curl -i http://127.0.0.1:8080/v1/models
curl -i -H 'Authorization: Bearer la_sk_garbage' http://127.0.0.1:8080/api/codex/v1/models
```

The regression test drives both routes through Axum. It failed against the old handler because the anonymous request returned 200, and now verifies 401 for missing and malformed credentials plus 200 for a valid client token.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features`
- `cargo test --locked --all-features --verbose`
- `cargo test --locked --doc --verbose`
- `rust-script scripts/check-file-size.rs`
- `rust-script scripts/check-version-modification.rs` with pull-request environment variables
- `rust-script --test scripts/version-and-commit.rs`
- merged current `main` (including v0.42.0) and repeated the full check set

Fixes #93
