### PR TITLE
fix(codex): reject unsupported output limits

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-11T18:37:42.289Z for PR creation at branch issue-102-0e736e883951 for issue https://github.com/link-assistant/router/issues/102

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-11T18:37:42.289Z for PR creation at branch issue-102-0e736e883951 for issue https://github.com/link-assistant/router/issues/102

--- a/changelog.d/20260811_190000_codex_output_limits.md
+++ b/changelog.d/20260811_190000_codex_output_limits.md
@@ -1,0 +1,10 @@
+---
+bump: patch
+---
+
+### Fixed
+
+- Codex subscription requests with `max_output_tokens`, `max_tokens`, or
+  `max_completion_tokens` are now rejected clearly before reaching the
+  ChatGPT backend, instead of silently discarding the caller's output and
+  spend limit.

--- a/src/subscription_proxy.rs
+++ b/src/subscription_proxy.rs
@@ -123,6 +123,9 @@ async fn forward_subscription_openai_inner(
             "active upstream is not a subscription provider",
         );
     };
+    if let Some(response) = reject_unsupported_codex_output_limit(provider, &body) {
+        return response;
+    }
     let pinned_account = match state.token_manager.account_for(&claims.sub) {
         Ok(account) => account,
         Err(error) => {
@@ -594,6 +597,32 @@ fn normalize_subscription_request(provider: SubscriptionProvider, body: &mut ser
     }
 }
 
+/// Reject a caller-supplied output cap that the `ChatGPT` backend cannot honor.
+///
+/// Every client surface has already converged on Responses shape at this point,
+/// so this single gate covers `max_output_tokens` from Responses and translated
+/// `max_tokens` / `max_completion_tokens` from Chat Completions and Messages.
+/// The backend rejects the parameter, and enforcing only visible text in the
+/// router would still leave hidden reasoning tokens unbounded. Failing before
+/// the upstream call is therefore the only way to preserve the cap's spend-
+/// control guarantee.
+fn reject_unsupported_codex_output_limit(
+    provider: SubscriptionProvider,
+    body: &serde_json::Value,
+) -> Option<Response> {
+    let has_limit = body
+        .get("max_output_tokens")
+        .is_some_and(|value| !value.is_null());
+    if provider != SubscriptionProvider::Codex || !has_limit {
+        return None;
+    }
+    Some(error_response(
+        StatusCode::BAD_REQUEST,
+        "invalid_request_error",
+        "Codex subscriptions cannot honor output-token limits because the ChatGPT backend rejects max_output_tokens. Remove the limit or select a provider that supports it; the router rejected this request instead of silently ignoring the cap.",
+    ))
+}
+
 /// Shape a Responses-API request body for the `ChatGPT` Codex backend.
 ///
 /// The Codex backend is stricter than the generic `OpenAI` Responses API: it
@@ -655,6 +684,62 @@ fn normalize_codex_responses_body(body: &mut serde_json::Value) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn codex_rejects_output_limits_from_every_client_surface() {
+        let responses = serde_json::json!({
+            "model": "gpt-5.6-sol",
+            "input": "hi",
+            "max_output_tokens": 16,
+        });
+        let chat = crate::responses::chat_completion_to_responses(&serde_json::json!({
+            "model": "gpt-5.6-sol",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 16,
+        }));
+        let chat_completion = crate::responses::chat_completion_to_responses(&serde_json::json!({
+            "model": "gpt-5.6-sol",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_completion_tokens": 16,
+        }));
+        let anthropic_chat = crate::anthropic_bridge::anthropic_to_chat_request(
+            &serde_json::json!({
+                "model": "claude-sonnet-4-5",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 16,
+            }),
+            "gpt-5.6-sol",
+        );
+        let anthropic = crate::responses::chat_completion_to_responses(&anthropic_chat);
+
+        for body in [&responses, &chat, &chat_completion, &anthropic] {
+            let response = reject_unsupported_codex_output_limit(SubscriptionProvider::Codex, body)
+                .expect("Codex must reject a limit it cannot honor");
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            let error = axum::body::to_bytes(response.into_body(), 4096)
+                .await
+                .expect("read error body");
+            let error: serde_json::Value =
+                serde_json::from_slice(&error).expect("valid JSON error");
+            assert_eq!(error["error"]["type"], "invalid_request_error");
+            assert!(error["error"]["message"].as_str().is_some_and(|message| {
+                message.contains("rejected this request instead of silently ignoring")
+            }));
+        }
+    }
+
+    #[test]
+    fn output_limit_gate_leaves_uncapped_codex_and_other_providers_unchanged() {
+        let capped = serde_json::json!({"max_output_tokens": 16});
+        let uncapped = serde_json::json!({"model": "gpt-5.6-sol", "input": "hi"});
+
+        assert!(
+            reject_unsupported_codex_output_limit(SubscriptionProvider::Codex, &uncapped).is_none()
+        );
+        assert!(
+            reject_unsupported_codex_output_limit(SubscriptionProvider::Qwen, &capped).is_none()
+        );
+    }
 
     #[test]
     fn codex_normalizes_responses_body_for_chatgpt_backend() {


### PR DESCRIPTION
## Summary

- reject Codex subscription requests that contain an output-token limit with a clear HTTP 400
- cover Responses `max_output_tokens`, Chat Completions `max_tokens` / `max_completion_tokens`, and Anthropic Messages `max_tokens`
- leave uncapped Codex requests and providers that support output limits unchanged
- add a patch changelog fragment

## Problem and reproduction

A Codex subscription request such as:

```json
{"model":"gpt-5.6-sol","input":"hi","max_output_tokens":16}
```

previously reached the ChatGPT backend only after the router silently removed `max_output_tokens`. The request could therefore produce substantially more than 16 tokens and report a natural stop.

## Solution

The ChatGPT subscription backend rejects `max_output_tokens`. Router-side visible-text truncation would not preserve the requested spend cap because the Responses limit also accounts for hidden reasoning tokens. The shared subscription forwarding path now rejects the request before selecting credentials or contacting upstream:

```
400 invalid_request_error
Codex subscriptions cannot honor output-token limits ...
```

All three public client surfaces converge on Responses shape before this gate, so the behavior is consistent. Anthropic Messages requires `max_tokens`, which means Codex-backed Messages requests are rejected clearly until the backend can honor that contract.

## Tests

The regression test translates requests from every affected surface and verifies the clear 400 response. It also verifies that uncapped Codex and capped non-Codex requests remain unaffected.

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features`
- `cargo test --locked --all-features`
- `cargo test --locked --doc`
- `cargo check --locked --all-targets --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps --all-features`
- `rust-script scripts/check-file-size.rs`
- `rust-script scripts/check-version-modification.rs`
- `rust-script --test scripts/version-and-commit.rs`
- `rust-script --test scripts/check-docker-platforms.rs`

Fixes #102