### PR TITLE
fix(proxy): relay vendor response headers

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-12T03:49:00.568Z for PR creation at branch issue-104-1284ecf6cd3e for issue https://github.com/link-assistant/router/issues/104

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-12T03:49:00.568Z for PR creation at branch issue-104-1284ecf6cd3e for issue https://github.com/link-assistant/router/issues/104

--- a/changelog.d/20260812_040000_relay_subscription_headers.md
+++ b/changelog.d/20260812_040000_relay_subscription_headers.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Fixed
+- Relay vendor quota and request-id response headers consistently across Claude and subscription providers without exposing upstream credentials.

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -19,7 +19,7 @@ use axum::http::{HeaderMap, HeaderValue, StatusCode};
 use axum::response::{IntoResponse, Response};
 use futures_util::StreamExt;
 use log_lazy::LogLazy;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 
 use crate::accounts::RoutingContext;
 pub use crate::app_state::AppState;
@@ -65,7 +65,58 @@ pub fn merge_oauth_beta(existing: Option<&str>) -> String {
 }
 
 /// Hop-by-hop headers that must not be forwarded.
-const HOP_BY_HOP_HEADERS: &[&str] = &["host", "connection", "transfer-encoding", "keep-alive"];
+const HOP_BY_HOP_HEADERS: &[&str] = &[
+    "host",
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+];
+
+/// Upstream response fields that can contain credentials or establish client state.
+const RESPONSE_CREDENTIAL_HEADERS: &[&str] = &[
+    "authorization",
+    "proxy-authorization",
+    "set-cookie",
+    "set-cookie2",
+    "x-api-key",
+];
+
+/// Select end-to-end upstream response headers that are safe to relay to a client.
+///
+/// This policy is shared by Claude and subscription provider paths so vendor
+/// quota fields and request IDs are preserved consistently. Besides standard
+/// hop-by-hop fields, it removes fields named by `Connection`, upstream
+/// credentials, and `Content-Length` (response bodies may be translated).
+pub(crate) fn relay_response_headers(headers: &HeaderMap) -> HeaderMap {
+    let connection_headers: HashSet<String> = headers
+        .get_all("connection")
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .flat_map(|value| value.split(','))
+        .map(|name| name.trim().to_ascii_lowercase())
+        .filter(|name| !name.is_empty())
+        .collect();
+    let mut relayed = HeaderMap::new();
+
+    for (name, value) in headers {
+        let name_lower = name.as_str();
+        if HOP_BY_HOP_HEADERS.contains(&name_lower)
+            || RESPONSE_CREDENTIAL_HEADERS.contains(&name_lower)
+            || name_lower == "content-length"
+            || connection_headers.contains(name_lower)
+        {
+            continue;
+        }
+        relayed.append(name.clone(), value.clone());
+    }
+
+    relayed
+}
 
 /// Health check endpoint.
 #[allow(clippy::unused_async)]
@@ -350,14 +401,7 @@ pub async fn proxy_handler(State(state): State<AppState>, req: Request) -> Respo
     }
 
     // Build the response -- stream it back to preserve SSE
-    let mut response_headers = HeaderMap::new();
-    for (name, value) in upstream_resp.headers() {
-        let name_lower = name.as_str().to_lowercase();
-        if HOP_BY_HOP_HEADERS.contains(&name_lower.as_str()) {
-            continue;
-        }
-        response_headers.insert(name.clone(), value.clone());
-    }
+    let response_headers = relay_response_headers(upstream_resp.headers());
 
     // Stream the response body
     let response_log = std::sync::Arc::clone(&state.request_log);

--- a/src/subscription_proxy.rs
+++ b/src/subscription_proxy.rs
@@ -21,8 +21,8 @@ use std::collections::BTreeMap;
 
 use crate::metrics::Surface;
 use crate::proxy::{
-    AppState, error_response, extract_client_token, maybe_mpp_challenge, request_routing_context,
-    retry_after_duration,
+    AppState, error_response, extract_client_token, maybe_mpp_challenge, relay_response_headers,
+    request_routing_context, retry_after_duration,
 };
 use crate::subscription::{SubscriptionProvider, SubscriptionToken};
 
@@ -267,9 +267,9 @@ async fn forward_subscription_openai_inner(
         .get("content-type")
         .cloned()
         .unwrap_or_else(|| HeaderValue::from_static("application/json"));
-    // Preserve rate-limit signals (Retry-After, x-ratelimit-*) so clients can
-    // back off intelligently when a subscription upstream throttles us.
-    let rate_limit_headers = rate_limit_headers(upstream_resp.headers());
+    // Relay the same safe end-to-end response fields as the Claude path,
+    // including provider-specific quota signals and request IDs.
+    let response_headers = relay_response_headers(upstream_resp.headers());
 
     let codex = provider == SubscriptionProvider::Codex;
     if stream_requested || (!codex && is_event_stream(&content_type)) {
@@ -301,10 +301,10 @@ async fn forward_subscription_openai_inner(
         });
         let mut response = Response::new(Body::from_stream(stream));
         *response.status_mut() = status;
+        *response.headers_mut() = response_headers;
         response
             .headers_mut()
             .insert("content-type", stream_content_type);
-        apply_headers(response.headers_mut(), rate_limit_headers);
         return response;
     }
 
@@ -365,17 +365,17 @@ async fn forward_subscription_openai_inner(
 
         let mut response = Response::new(Body::from(response_body));
         *response.status_mut() = status;
+        *response.headers_mut() = response_headers;
         response
             .headers_mut()
             .insert("content-type", HeaderValue::from_static("application/json"));
-        apply_headers(response.headers_mut(), rate_limit_headers);
         return response;
     }
 
     let mut response = Response::new(Body::from(response_body));
     *response.status_mut() = status;
+    *response.headers_mut() = response_headers;
     response.headers_mut().insert("content-type", content_type);
-    apply_headers(response.headers_mut(), rate_limit_headers);
     response
 }
 
@@ -487,26 +487,6 @@ fn update_codex_output_text(
         item["status"] = serde_json::Value::String("completed".to_string());
     } else if let Some(current) = content[content_index]["text"].as_str() {
         content[content_index]["text"] = serde_json::Value::String(format!("{current}{text}"));
-    }
-}
-
-/// Collect rate-limit-related headers (`retry-after`, `x-ratelimit-*`) from an
-/// upstream response so they can be relayed to the client.
-fn rate_limit_headers(headers: &HeaderMap) -> Vec<(axum::http::HeaderName, HeaderValue)> {
-    headers
-        .iter()
-        .filter(|(name, _)| {
-            let n = name.as_str();
-            n == "retry-after" || n.starts_with("x-ratelimit")
-        })
-        .map(|(name, value)| (name.clone(), value.clone()))
-        .collect()
-}
-
-/// Insert collected headers into an outgoing response header map.
-fn apply_headers(out: &mut HeaderMap, headers: Vec<(axum::http::HeaderName, HeaderValue)>) {
-    for (name, value) in headers {
-        out.insert(name, value);
     }
 }
 
@@ -928,22 +908,48 @@ mod tests {
     }
 
     #[test]
-    fn rate_limit_headers_are_selected() {
+    fn safe_upstream_response_headers_are_selected() {
         let mut headers = HeaderMap::new();
         headers.insert("retry-after", HeaderValue::from_static("30"));
         headers.insert(
             "x-ratelimit-remaining-requests",
             HeaderValue::from_static("0"),
         );
-        headers.insert("content-type", HeaderValue::from_static("application/json"));
-        let selected = rate_limit_headers(&headers);
-        assert_eq!(selected.len(), 2);
-        assert!(selected.iter().any(|(n, _)| n.as_str() == "retry-after"));
-        assert!(
-            selected
-                .iter()
-                .any(|(n, _)| n.as_str() == "x-ratelimit-remaining-requests")
+        headers.insert("x-codex-active-limit", HeaderValue::from_static("75"));
+        headers.insert(
+            "x-oai-request-id",
+            HeaderValue::from_static("req_codex_123"),
         );
+        headers.insert(
+            "authorization",
+            HeaderValue::from_static("Bearer upstream-secret"),
+        );
+        headers.insert("x-api-key", HeaderValue::from_static("upstream-secret"));
+        headers.insert("set-cookie", HeaderValue::from_static("session=secret"));
+        headers.insert("connection", HeaderValue::from_static("x-remove-me"));
+        headers.insert("x-remove-me", HeaderValue::from_static("hop-by-hop"));
+        headers.insert("content-length", HeaderValue::from_static("999"));
+        headers.insert("content-type", HeaderValue::from_static("application/json"));
+        let selected = relay_response_headers(&headers);
+        for relayed in [
+            "retry-after",
+            "x-ratelimit-remaining-requests",
+            "x-codex-active-limit",
+            "x-oai-request-id",
+            "content-type",
+        ] {
+            assert!(selected.contains_key(relayed), "missing {relayed}");
+        }
+        for excluded in [
+            "authorization",
+            "x-api-key",
+            "set-cookie",
+            "connection",
+            "x-remove-me",
+            "content-length",
+        ] {
+            assert!(!selected.contains_key(excluded), "relayed {excluded}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- relay safe end-to-end upstream response headers consistently across Claude and subscription provider paths
- preserve Codex quota fields (`x-codex-*`), OpenAI request IDs (`x-oai-request-id`), and existing rate-limit headers
- strip upstream credentials, hop-by-hop and connection-nominated fields, and stale content lengths
- add a patch changelog fragment

## Reproduction

On v0.45.0, a Codex subscription upstream response containing `x-codex-active-limit` and `x-oai-request-id` reached the subscription response allow-list. The allow-list accepted only `retry-after` and `x-ratelimit-*`, so neither Codex header reached the client. The equivalent Claude proxy path copied end-to-end headers.

## Solution

Both paths now call one shared safe response-header relay policy. This prevents provider drift while preserving arbitrary vendor quota and diagnostic headers. The policy explicitly rejects `authorization`, `x-api-key`, `set-cookie`, standard hop-by-hop fields, fields named by `Connection`, and `content-length` because subscription response bodies may be translated.

## Regression test

`safe_upstream_response_headers_are_selected` demonstrates that:

- `retry-after` and `x-ratelimit-*` remain relayed
- `x-codex-*` and `x-oai-request-id` are relayed
- credentials are not relayed
- hop-by-hop, connection-nominated, and stale content-length fields are not relayed

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features`
- `cargo test --locked --all-features`
- `cargo test --locked --doc`
- `cargo check --locked --all-targets --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps --all-features`
- `rust-script scripts/check-file-size.rs`
- `rust-script scripts/check-version-modification.rs`
- `rust-script --test scripts/version-and-commit.rs`
- `rust-script --test scripts/check-docker-platforms.rs`

Fixes #104
