### PR TITLE
fix(models): hide rejected subscription catalogs

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-12T05:22:38.615Z for PR creation at branch issue-109-f8c988b35e34 for issue https://github.com/link-assistant/router/issues/109

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-12T05:22:38.615Z for PR creation at branch issue-109-f8c988b35e34 for issue https://github.com/link-assistant/router/issues/109

--- a/changelog.d/20260812_052800_revoked_catalog_credentials.md
+++ b/changelog.d/20260812_052800_revoked_catalog_credentials.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Fixed
+- Stop advertising and routing models from subscriptions rejected during live catalog discovery, and mark fallback-backed model lists explicitly.

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1,6 +1,6 @@
 //! Subscription diagnostics shared by the `doctor` CLI command.
 
-use crate::model_catalog::fetch_provider_catalog;
+use crate::model_catalog::{fetch_provider_catalog, is_credential_rejection};
 use crate::subscription::{SubscriptionProvider, all_subscription_readers};
 
 /// Report credential and live-catalog health for every provider.
@@ -47,7 +47,7 @@ pub async fn subscription_catalog_diagnostics(
         let catalog = fetch_provider_catalog(&client, provider, &token, None).await;
         let rejected = catalog
             .as_ref()
-            .is_err_and(|error| error.starts_with("HTTP 401") || error.starts_with("HTTP 403"));
+            .is_err_and(|error| is_credential_rejection(error));
         let status = match (was_expired, still_expired, rejected) {
             (_, true, true) => "found, token EXPIRED and REJECTED",
             (_, true, false) => "found, token EXPIRED on disk but ACCEPTED upstream",

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -147,13 +147,16 @@ pub async fn refresh_catalogs(
                     "refreshed {provider} model catalog with {} model(s)",
                     models.len()
                 );
+                token_cache.record_credential_working(provider);
                 cache.record_success(provider, models);
             }
             Err(error) => {
-                // A catalog rejection is evidence about the catalog endpoint
-                // only. The provider keeps serving from its last known models
-                // (`using_fallback` says whether those are the bundled ones),
-                // and routing keeps offering it until inference itself fails.
+                // Keep the last known models in the cache for transient
+                // failures, but an authentication rejection makes them unsafe
+                // to advertise or route until a later probe succeeds.
+                if is_credential_rejection(&error) {
+                    token_cache.record_credential_rejected(provider);
+                }
                 let error = if stamped_expired {
                     format!("{error} (credential is stamped expired; last known catalog retained)")
                 } else {
@@ -164,6 +167,12 @@ pub async fn refresh_catalogs(
             }
         }
     }
+}
+
+/// Whether a catalog response proves that the supplied credential is unusable.
+#[must_use]
+pub(crate) fn is_credential_rejection(error: &str) -> bool {
+    error.starts_with("HTTP 401") || error.starts_with("HTTP 403")
 }
 
 /// Continuously refresh live catalogs, beginning immediately at startup.
@@ -424,17 +433,22 @@ mod tests {
                 resource_url: Some(format!("http://{address}")),
             },
         );
+        token_cache.record_credential_rejected(SubscriptionProvider::Qwen);
         let catalogs = ModelCatalogCache::new();
 
         refresh_catalogs(&reqwest::Client::new(), &readers, &token_cache, &catalogs).await;
 
         assert_eq!(catalogs.models(SubscriptionProvider::Qwen), ["qwen-live"]);
         assert!(!catalogs.status(SubscriptionProvider::Qwen).using_fallback);
+        assert_eq!(
+            token_cache.evidence(SubscriptionProvider::Qwen),
+            Some(crate::refresh::CredentialEvidence::Working)
+        );
     }
 
-    /// A stamped-expired credential is still probed, and when the catalog
-    /// endpoint rejects it the provider keeps serving its last known models
-    /// instead of losing its catalog to a timestamp.
+    /// A stamped-expired credential is still probed. Its last known catalog is
+    /// retained for diagnostics, while rejection evidence prevents it from
+    /// being advertised or routed.
     #[tokio::test]
     async fn expired_credential_is_still_probed_and_keeps_its_cached_catalog() {
         async fn handler() -> (axum::http::StatusCode, &'static str) {
@@ -460,14 +474,9 @@ mod tests {
         )];
         let catalogs = ModelCatalogCache::new();
         catalogs.record_success(SubscriptionProvider::Qwen, vec!["qwen-known".to_string()]);
+        let token_cache = crate::refresh::TokenCache::new();
 
-        refresh_catalogs(
-            &reqwest::Client::new(),
-            &readers,
-            &crate::refresh::TokenCache::new(),
-            &catalogs,
-        )
-        .await;
+        refresh_catalogs(&reqwest::Client::new(), &readers, &token_cache, &catalogs).await;
 
         let status = catalogs.status(SubscriptionProvider::Qwen);
         // The fetch was actually attempted (the 401 proves the request went out)
@@ -475,8 +484,50 @@ mod tests {
         let error = status.last_error.expect("catalog fetch was attempted");
         assert!(error.starts_with("HTTP 401"), "{error}");
         assert!(error.contains("stamped expired"), "{error}");
-        // ...and the last known catalog survives the failure.
+        // The last known catalog survives internally, but the shared rejection
+        // evidence removes it from routing and public catalog responses.
         assert_eq!(status.models, ["qwen-known"]);
+        assert_eq!(
+            token_cache.evidence(SubscriptionProvider::Qwen),
+            Some(crate::refresh::CredentialEvidence::Rejected)
+        );
+    }
+
+    #[tokio::test]
+    async fn catalog_auth_rejection_is_recorded_as_credential_evidence() {
+        async fn handler() -> (axum::http::StatusCode, &'static str) {
+            (axum::http::StatusCode::UNAUTHORIZED, "revoked token")
+        }
+
+        let app = Router::new().route("/compatible-mode/v1/models", get(handler));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let home = tempdir().unwrap();
+        fs::write(
+            home.path().join("oauth_creds.json"),
+            format!(r#"{{"access_token":"revoked","resource_url":"http://{address}"}}"#),
+        )
+        .unwrap();
+        let readers = vec![SubscriptionReader::new(
+            SubscriptionProvider::Qwen,
+            home.path(),
+        )];
+        let token_cache = crate::refresh::TokenCache::new();
+
+        refresh_catalogs(
+            &reqwest::Client::new(),
+            &readers,
+            &token_cache,
+            &ModelCatalogCache::new(),
+        )
+        .await;
+
+        assert_eq!(
+            token_cache.evidence(SubscriptionProvider::Qwen),
+            Some(crate::refresh::CredentialEvidence::Rejected)
+        );
     }
 
     #[test]

--- a/src/model_routing.rs
+++ b/src/model_routing.rs
@@ -92,12 +92,10 @@ pub fn available_provider_for_model(
 /// Readers whose credential can plausibly serve a request, refreshing an
 /// expired on-disk token into the shared in-memory cache when possible.
 ///
-/// `expiresAt` is treated as a *hint*, not a verdict. Vendors have been
-/// observed to keep honouring a stamped-expired access token on the inference
-/// endpoint while rejecting it on `/v1/models`, so a credential that cannot be
-/// refreshed is still offered for routing — the upstream gets to decide. Only
-/// positive evidence (an upstream 401/403 recorded by a real call, see
-/// [`crate::refresh::CredentialEvidence`]) removes a provider.
+/// `expiresAt` is treated as a *hint*, not a verdict, so a stamped-expired
+/// credential remains available until an upstream call supplies stronger
+/// evidence. A 401/403 from inference or live catalog discovery removes the
+/// provider regardless of its local expiry timestamp.
 pub async fn healthy_providers(
     client: &reqwest::Client,
     readers: &[SubscriptionReader],
@@ -114,15 +112,13 @@ pub async fn healthy_providers(
             let token = token_cache
                 .get_fresh(client, provider, disk_token, now_ms)
                 .await;
-            if !token.is_expired(now_ms) {
-                return Some(provider);
-            }
             if token_cache.evidence(provider) == Some(crate::refresh::CredentialEvidence::Rejected)
             {
-                tracing::debug!(
-                    "{provider} credential is expired and was rejected upstream; not routable"
-                );
+                tracing::debug!("{provider} credential was rejected upstream; not routable");
                 return None;
+            }
+            if !token.is_expired(now_ms) {
+                return Some(provider);
             }
             tracing::debug!(
                 "{provider} credential is stamped expired and could not be refreshed; keeping it \
@@ -141,6 +137,13 @@ pub async fn healthy_providers(
 #[must_use]
 pub fn model_catalog(providers: &[SubscriptionProvider], catalogs: &ModelCatalogCache) -> Value {
     let now = chrono::Utc::now().timestamp();
+    let using_fallback = providers
+        .iter()
+        .any(|provider| catalogs.status(*provider).using_fallback);
+    let healthy_providers = providers
+        .iter()
+        .map(|provider| provider.as_str())
+        .collect::<Vec<_>>();
     let data = providers
         .iter()
         .flat_map(|provider| {
@@ -155,7 +158,12 @@ pub fn model_catalog(providers: &[SubscriptionProvider], catalogs: &ModelCatalog
             })
         })
         .collect::<Vec<_>>();
-    json!({"object": "list", "data": data})
+    json!({
+        "object": "list",
+        "data": data,
+        "using_fallback": using_fallback,
+        "healthy_providers": healthy_providers,
+    })
 }
 
 /// Model catalog for one pinned subscription, empty when its credential is not healthy.
@@ -396,6 +404,74 @@ mod tests {
             data.iter()
                 .any(|m| m["id"] == "gpt-5" && m["owned_by"] == "openai")
         );
+        assert_eq!(catalog["using_fallback"], true);
+        assert_eq!(catalog["healthy_providers"], json!(["claude", "codex"]));
+
+        let unavailable = model_catalog(&[], &catalogs);
+        assert_eq!(unavailable["data"], json!([]));
+        assert_eq!(unavailable["using_fallback"], false);
+        assert_eq!(unavailable["healthy_providers"], json!([]));
+    }
+
+    #[tokio::test]
+    async fn models_omits_a_rejected_provider_and_names_only_healthy_ones() {
+        let data = tempdir().unwrap();
+        let claude = tempdir().unwrap();
+        let codex = tempdir().unwrap();
+        fs::write(
+            claude.path().join(".credentials.json"),
+            r#"{"claudeAiOauth":{"accessToken":"revoked"}}"#,
+        )
+        .unwrap();
+        fs::write(
+            codex.path().join("auth.json"),
+            r#"{"tokens":{"access_token":"healthy"}}"#,
+        )
+        .unwrap();
+        let state = auto_state(
+            vec![
+                SubscriptionReader::new(SubscriptionProvider::Claude, claude.path()),
+                SubscriptionReader::new(SubscriptionProvider::Codex, codex.path()),
+            ],
+            data.path(),
+        );
+        state
+            .subscription_cache
+            .record_credential_rejected(SubscriptionProvider::Claude);
+        let client_token = state.token_manager.issue_token(1, "catalog test").unwrap();
+        let app = axum::Router::new()
+            .route("/v1/models", get(models))
+            .with_state(state.clone());
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/models")
+                    .header("authorization", format!("Bearer {client_token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let catalog: Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(catalog["healthy_providers"], json!(["codex"]));
+        assert_eq!(catalog["using_fallback"], true);
+        assert!(
+            catalog["data"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|model| model["owned_by"] == "openai")
+        );
+
+        let error = route_state(&state, &json!({"model": "claude-opus-4-7"}))
+            .await
+            .err()
+            .expect("rejected Claude credential should not be routable");
+        assert!(error.to_string().contains("no healthy claude credential"));
     }
 
     #[tokio::test]
@@ -574,6 +650,28 @@ mod tests {
 
         // An observed upstream 401/403 is the evidence that does drop it.
         cache.record_credential_rejected(SubscriptionProvider::Gemini);
+        assert!(
+            healthy_providers(&reqwest::Client::new(), &readers, &cache, 2000)
+                .await
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn rejected_credential_is_unhealthy_even_without_an_expiry_timestamp() {
+        let credential = tempdir().unwrap();
+        fs::write(
+            credential.path().join("auth.json"),
+            r#"{"tokens":{"access_token":"revoked"}}"#,
+        )
+        .unwrap();
+        let readers = vec![SubscriptionReader::new(
+            SubscriptionProvider::Codex,
+            credential.path(),
+        )];
+        let cache = crate::refresh::TokenCache::new();
+        cache.record_credential_rejected(SubscriptionProvider::Codex);
+
         assert!(
             healthy_providers(&reqwest::Client::new(), &readers, &cache, 2000)
                 .await


### PR DESCRIPTION
## Summary

- Record live catalog HTTP 401/403 responses as shared credential rejection evidence, and restore working evidence after a successful catalog probe.
- Apply rejection evidence regardless of the credential expiry timestamp, so revoked providers are omitted from discovery and routing immediately.
- Add `healthy_providers` and `using_fallback` to subscription-backed model-list responses so clients can distinguish live availability from bundled fallback data.
- Retain stale catalogs internally across transient failures, while preventing rejected credentials from advertising or routing those models.

## Reproduction

On v0.48.0, configure one healthy subscription and one revoked subscription. After the revoked provider returns HTTP 401 from live catalog discovery, `GET /v1/models` still advertises that provider from its cached or bundled catalog, and requests to those models reach upstream and return a bare authentication error.

After this fix, the rejected provider is absent from `data` and `healthy_providers`; requesting one of its known models fails locally with `no healthy <provider> credential`.

## Tests

Added regressions for:

- catalog authentication rejection entering the shared credential-health cache;
- rejected credentials being unhealthy even when their local expiry timestamp is absent or still current;
- one rejected and one healthy provider through authenticated `GET /v1/models`;
- explicit fallback metadata and the all-unhealthy empty catalog shape;
- successful catalog refresh restoring a previously rejected provider.

Local CI-equivalent checks passed:

- `cargo fmt --all -- --check`
- `cargo check --locked --all-targets --all-features`
- `cargo clippy --locked --all-targets --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps --all-features`
- `rust-script scripts/check-file-size.rs`
- both release automation script test suites
- `cargo test --locked --all-features`

Fixes #109