### PR TITLE
fix(codex): restore Anthropic Messages requests

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-12T05:28:27.414Z for PR creation at branch issue-108-a18689e74c37 for issue https://github.com/link-assistant/router/issues/108

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-12T05:28:27.414Z for PR creation at branch issue-108-a18689e74c37 for issue https://github.com/link-assistant/router/issues/108

--- a/changelog.d/20260812_060000_codex_messages_limits.md
+++ b/changelog.d/20260812_060000_codex_messages_limits.md
@@ -1,0 +1,9 @@
+---
+bump: patch
+---
+
+### Fixed
+
+- Anthropic Messages requests can use Codex subscription models again: the
+  protocol-required `max_tokens` field no longer triggers the rejection kept
+  for optional Responses and Chat Completions output limits.

--- a/src/anthropic_bridge.rs
+++ b/src/anthropic_bridge.rs
@@ -558,10 +558,10 @@ pub async fn forward_anthropic_messages(
     headers: &HeaderMap,
     anthropic_body: Value,
 ) -> Response {
-    if !anthropic_body
+    if anthropic_body
         .get("max_tokens")
         .and_then(Value::as_u64)
-        .is_some_and(|limit| limit > 0)
+        .is_none_or(|limit| limit == 0)
     {
         // Keep authentication ahead of request validation even though the
         // delegated forwarder is not reached for a malformed Messages body.

--- a/src/anthropic_bridge.rs
+++ b/src/anthropic_bridge.rs
@@ -558,6 +558,18 @@ pub async fn forward_anthropic_messages(
     headers: &HeaderMap,
     anthropic_body: Value,
 ) -> Response {
+    if !anthropic_body
+        .get("max_tokens")
+        .and_then(Value::as_u64)
+        .is_some_and(|limit| limit > 0)
+    {
+        // Keep authentication ahead of request validation even though the
+        // delegated forwarder is not reached for a malformed Messages body.
+        if let Err(response) = count_tokens_claims(&state.token_manager, headers) {
+            return *response;
+        }
+        return anthropic_error(StatusCode::BAD_REQUEST, b"max_tokens is required");
+    }
     let requested_model = anthropic_body
         .get("model")
         .and_then(Value::as_str)

--- a/src/subscription_proxy.rs
+++ b/src/subscription_proxy.rs
@@ -584,10 +584,10 @@ fn normalize_subscription_request(provider: SubscriptionProvider, body: &mut ser
 ///
 /// Every client surface has already converged on Responses shape at this point,
 /// so `surface` preserves the otherwise-lost distinction between an optional
-/// OpenAI limit and the protocol-required `max_tokens` on Anthropic Messages.
+/// `OpenAI` limit and the protocol-required `max_tokens` on Anthropic Messages.
 /// The backend rejects the parameter, and enforcing only visible text in the
 /// router would still leave hidden reasoning tokens unbounded. Failing before
-/// the upstream call is therefore the only way to preserve optional OpenAI
+/// the upstream call is therefore the only way to preserve optional `OpenAI`
 /// caps as spend controls. Messages requests remain usable and normalization
 /// removes their mandatory field before the Codex request is serialized.
 fn reject_unsupported_codex_output_limit(

--- a/src/subscription_proxy.rs
+++ b/src/subscription_proxy.rs
@@ -123,7 +123,7 @@ async fn forward_subscription_openai_inner(
             "active upstream is not a subscription provider",
         );
     };
-    if let Some(response) = reject_unsupported_codex_output_limit(provider, &body) {
+    if let Some(response) = reject_unsupported_codex_output_limit(provider, surface, &body) {
         return response;
     }
     let pinned_account = match state.token_manager.account_for(&claims.sub) {
@@ -583,20 +583,22 @@ fn normalize_subscription_request(provider: SubscriptionProvider, body: &mut ser
 /// Reject a caller-supplied output cap that the `ChatGPT` backend cannot honor.
 ///
 /// Every client surface has already converged on Responses shape at this point,
-/// so this single gate covers `max_output_tokens` from Responses and translated
-/// `max_tokens` / `max_completion_tokens` from Chat Completions and Messages.
+/// so `surface` preserves the otherwise-lost distinction between an optional
+/// OpenAI limit and the protocol-required `max_tokens` on Anthropic Messages.
 /// The backend rejects the parameter, and enforcing only visible text in the
 /// router would still leave hidden reasoning tokens unbounded. Failing before
-/// the upstream call is therefore the only way to preserve the cap's spend-
-/// control guarantee.
+/// the upstream call is therefore the only way to preserve optional OpenAI
+/// caps as spend controls. Messages requests remain usable and normalization
+/// removes their mandatory field before the Codex request is serialized.
 fn reject_unsupported_codex_output_limit(
     provider: SubscriptionProvider,
+    surface: Surface,
     body: &serde_json::Value,
 ) -> Option<Response> {
     let has_limit = body
         .get("max_output_tokens")
         .is_some_and(|value| !value.is_null());
-    if provider != SubscriptionProvider::Codex || !has_limit {
+    if provider != SubscriptionProvider::Codex || surface == Surface::Anthropic || !has_limit {
         return None;
     }
     Some(error_response(
@@ -669,7 +671,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn codex_rejects_output_limits_from_every_client_surface() {
+    async fn codex_rejects_optional_openai_output_limits() {
         let responses = serde_json::json!({
             "model": "gpt-5.6-sol",
             "input": "hi",
@@ -685,19 +687,14 @@ mod tests {
             "messages": [{"role": "user", "content": "hi"}],
             "max_completion_tokens": 16,
         }));
-        let anthropic_chat = crate::anthropic_bridge::anthropic_to_chat_request(
-            &serde_json::json!({
-                "model": "claude-sonnet-4-5",
-                "messages": [{"role": "user", "content": "hi"}],
-                "max_tokens": 16,
-            }),
-            "gpt-5.6-sol",
-        );
-        let anthropic = crate::responses::chat_completion_to_responses(&anthropic_chat);
-
-        for body in [&responses, &chat, &chat_completion, &anthropic] {
-            let response = reject_unsupported_codex_output_limit(SubscriptionProvider::Codex, body)
-                .expect("Codex must reject a limit it cannot honor");
+        for (surface, body) in [
+            (Surface::OpenAIResponses, &responses),
+            (Surface::OpenAIChat, &chat),
+            (Surface::OpenAIChat, &chat_completion),
+        ] {
+            let response =
+                reject_unsupported_codex_output_limit(SubscriptionProvider::Codex, surface, body)
+                    .expect("Codex must reject an optional limit it cannot honor");
             assert_eq!(response.status(), StatusCode::BAD_REQUEST);
             let error = axum::body::to_bytes(response.into_body(), 4096)
                 .await
@@ -717,10 +714,28 @@ mod tests {
         let uncapped = serde_json::json!({"model": "gpt-5.6-sol", "input": "hi"});
 
         assert!(
-            reject_unsupported_codex_output_limit(SubscriptionProvider::Codex, &uncapped).is_none()
+            reject_unsupported_codex_output_limit(
+                SubscriptionProvider::Codex,
+                Surface::OpenAIResponses,
+                &uncapped,
+            )
+            .is_none()
         );
         assert!(
-            reject_unsupported_codex_output_limit(SubscriptionProvider::Qwen, &capped).is_none()
+            reject_unsupported_codex_output_limit(
+                SubscriptionProvider::Qwen,
+                Surface::OpenAIResponses,
+                &capped,
+            )
+            .is_none()
+        );
+        assert!(
+            reject_unsupported_codex_output_limit(
+                SubscriptionProvider::Codex,
+                Surface::Anthropic,
+                &capped,
+            )
+            .is_none()
         );
     }
 

--- a/tests/router_e2e_test.rs
+++ b/tests/router_e2e_test.rs
@@ -494,7 +494,7 @@ async fn codex_upstream_is_translated_and_relays_vendor_headers() {
 }
 
 #[tokio::test]
-async fn auth_unknown_models_admin_isolation_and_codex_limits_fail_clearly() {
+async fn auth_unknown_models_and_admin_isolation() {
     let router = TestRouter::start(UpstreamProvider::Anthropic).await;
     for path in [
         "/v1/models",
@@ -576,18 +576,97 @@ async fn auth_unknown_models_admin_isolation_and_codex_limits_fail_clearly() {
         .await
         .expect("admin response");
     assert_eq!(admin.status(), StatusCode::UNAUTHORIZED);
+}
 
+#[tokio::test]
+async fn codex_output_limit_policy_distinguishes_client_surfaces() {
     let codex = TestRouter::start(UpstreamProvider::Codex).await;
-    let capped = codex
+
+    // Messages requires max_tokens, so its required protocol field must not
+    // make the entire Anthropic surface unusable with a Codex subscription.
+    let messages = codex
         .post(
-            "/v1/responses",
-            &json!({"model":"gpt-5","input":"hi","max_output_tokens":16}),
+            "/v1/messages",
+            &json!({
+                "model":"gpt-5",
+                "max_tokens":16,
+                "messages":[{"role":"user","content":"hi"}]
+            }),
         )
         .send()
         .await
-        .expect("capped Codex response");
-    assert_eq!(capped.status(), StatusCode::BAD_REQUEST);
-    let message = capped.text().await.expect("limit error body");
-    assert!(message.contains("cannot honor output-token limits"));
-    assert!(codex.requests.lock().expect("stub requests").is_empty());
+        .expect("capped Codex Messages response");
+    assert_eq!(messages.status(), StatusCode::OK);
+    let payload: Value = messages.json().await.expect("Messages JSON response");
+    assert!(payload["content"].is_array());
+
+    let requests = codex.requests.lock().expect("stub requests");
+    assert_eq!(requests.len(), 1);
+    assert!(
+        requests[0].get("max_output_tokens").is_none(),
+        "the unsupported field must still be omitted from the Codex request"
+    );
+    drop(requests);
+
+    // A Messages request without its required field is a protocol error, not
+    // an unsupported-Codex-cap error, and must not reach the subscription.
+    let missing = codex
+        .post(
+            "/v1/messages",
+            &json!({"model":"gpt-5","messages":[{"role":"user","content":"hi"}]}),
+        )
+        .send()
+        .await
+        .expect("missing max_tokens response");
+    assert_eq!(missing.status(), StatusCode::BAD_REQUEST);
+    let missing_payload: Value = missing.json().await.expect("Messages error response");
+    assert_eq!(missing_payload["error"]["type"], "invalid_request_error");
+    assert!(
+        missing_payload["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("max_tokens is required"))
+    );
+
+    // The optional caps on both OpenAI surfaces retain PR #103's explicit
+    // rejection, including both Chat Completions spellings.
+    for (path, body) in [
+        (
+            "/v1/responses",
+            json!({"model":"gpt-5","input":"hi","max_output_tokens":16}),
+        ),
+        (
+            "/v1/chat/completions",
+            json!({
+                "model":"gpt-5",
+                "max_tokens":16,
+                "messages":[{"role":"user","content":"hi"}]
+            }),
+        ),
+        (
+            "/v1/chat/completions",
+            json!({
+                "model":"gpt-5",
+                "max_completion_tokens":16,
+                "messages":[{"role":"user","content":"hi"}]
+            }),
+        ),
+    ] {
+        let capped = codex
+            .post(path, &body)
+            .send()
+            .await
+            .expect("capped Codex OpenAI response");
+        assert_eq!(capped.status(), StatusCode::BAD_REQUEST, "{path}");
+        let message = capped.text().await.expect("limit error body");
+        assert!(
+            message.contains("cannot honor output-token limits"),
+            "{path}"
+        );
+    }
+
+    assert_eq!(
+        codex.requests.lock().expect("stub requests").len(),
+        1,
+        "rejected requests must not reach the Codex subscription"
+    );
 }

--- a/tests/router_e2e_test.rs
+++ b/tests/router_e2e_test.rs
@@ -600,13 +600,15 @@ async fn codex_output_limit_policy_distinguishes_client_surfaces() {
     let payload: Value = messages.json().await.expect("Messages JSON response");
     assert!(payload["content"].is_array());
 
-    let requests = codex.requests.lock().expect("stub requests");
-    assert_eq!(requests.len(), 1);
-    assert!(
-        requests[0].get("max_output_tokens").is_none(),
-        "the unsupported field must still be omitted from the Codex request"
-    );
-    drop(requests);
+    {
+        let requests = codex.requests.lock().expect("stub requests");
+        assert_eq!(requests.len(), 1);
+        assert!(
+            requests[0].get("max_output_tokens").is_none(),
+            "the unsupported field must still be omitted from the Codex request"
+        );
+        drop(requests);
+    }
 
     // A Messages request without its required field is a protocol error, not
     // an unsupported-Codex-cap error, and must not reach the subscription.


### PR DESCRIPTION
## Summary

- preserve the originating API surface through the shared Codex output-limit gate
- accept Anthropic Messages requests whose protocol requires `max_tokens`, while continuing to omit the unsupported field from the ChatGPT backend request
- keep explicit rejection for optional Responses and Chat Completions caps
- reject Messages requests missing a positive `max_tokens` with an Anthropic `invalid_request_error`

## Reproduction and root cause

PR #103 applied the Codex output-limit rejection after every client dialect had converged on Responses shape. At that point the translated, protocol-required Messages `max_tokens` was indistinguishable from an optional OpenAI cap, so every valid Codex-backed `/v1/messages` request returned HTTP 400.

The end-to-end regression test first reproduced that failure (`expected 200, got 400`). The gate now also receives the retained client `Surface`, allowing Messages through while preserving the spend-control rejection on the two OpenAI surfaces.

## Automated coverage

`codex_output_limit_policy_distinguishes_client_surfaces` verifies:

- Codex-backed `/v1/messages` with required `max_tokens` succeeds
- `max_output_tokens` is still stripped before the Codex upstream request
- Messages without `max_tokens` returns the correct protocol error and does not reach upstream
- `/v1/responses` with `max_output_tokens` remains rejected
- `/v1/chat/completions` with either `max_tokens` or `max_completion_tokens` remains rejected
- rejected OpenAI caps never reach the Codex subscription

## Verification

- `cargo fmt --all -- --check`
- `cargo check --locked --all-targets --all-features`
- `RUSTFLAGS=-Dwarnings cargo clippy --locked --all-targets --all-features`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --locked --no-deps --all-features`
- `cargo test --locked --all-features --verbose`
- `cargo test --locked --doc --verbose`
- `cargo build --locked --release --verbose`
- `cargo package --locked --list`
- repository file-size, changelog, version-policy, version/release, and Docker-platform script checks
- `npm --prefix ui audit --audit-level=high`

Fixes #108
