### PR TITLE
fix(ci): build release images on native runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -332,6 +332,9 @@ jobs:
   auto-release:
     name: Auto Release
     needs: [lint, test, build, docker-build]
+    outputs:
+      should-release: ${{ steps.check.outputs.should_release }}
+      release-version: ${{ steps.current_version.outputs.version }}
     # Note: always() ensures consistent behavior with other jobs that depend on jobs using always().
     if: |
       always() && !cancelled() &&
@@ -342,7 +345,6 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: write
-      packages: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -395,103 +397,14 @@ jobs:
         if: steps.check.outputs.should_release == 'true'
         run: rust-script scripts/wait-for-crate.rs --release-version "${{ steps.current_version.outputs.version }}"
 
-      - name: Log in to GitHub Container Registry
-        if: steps.check.outputs.should_release == 'true'
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Log in to Docker Hub
-        if: steps.check.outputs.should_release == 'true'
-        uses: docker/login-action@v4
-        with:
-          username: konard
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Set up QEMU
-        if: steps.check.outputs.should_release == 'true'
-        uses: docker/setup-qemu-action@v4
-
-      - name: Set up Docker Buildx
-        if: steps.check.outputs.should_release == 'true'
-        uses: docker/setup-buildx-action@v4
-
-      - name: Extract Docker metadata
-        if: steps.check.outputs.should_release == 'true'
-        id: docker-meta
-        uses: docker/metadata-action@v6
-        with:
-          images: |
-            ghcr.io/${{ github.repository }}
-            ${{ env.DOCKERHUB_IMAGE }}
-          tags: |
-            type=raw,value=latest
-            type=raw,value=${{ steps.current_version.outputs.version }}
-          labels: |
-            org.opencontainers.image.version=${{ steps.current_version.outputs.version }}
-
-      - name: Publish Docker images to registries
-        if: steps.check.outputs.should_release == 'true'
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          target: runtime
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.docker-meta.outputs.tags }}
-          labels: ${{ steps.docker-meta.outputs.labels }}
-
-      - name: Extract Docker metadata for the Claude CLI variant
-        if: steps.check.outputs.should_release == 'true'
-        id: docker-meta-claude-cli
-        uses: docker/metadata-action@v6
-        with:
-          images: |
-            ghcr.io/${{ github.repository }}
-            ${{ env.DOCKERHUB_IMAGE }}
-          tags: |
-            type=raw,value=with-claude-cli
-            type=raw,value=${{ steps.current_version.outputs.version }}-with-claude-cli
-          labels: |
-            org.opencontainers.image.version=${{ steps.current_version.outputs.version }}
-
-      - name: Publish Claude CLI variant image to registries
-        if: steps.check.outputs.should_release == 'true'
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          target: with-claude-cli
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.docker-meta-claude-cli.outputs.tags }}
-          labels: ${{ steps.docker-meta-claude-cli.outputs.labels }}
-
-      - name: Verify multi-platform Docker manifests
-        if: steps.check.outputs.should_release == 'true'
-        run: |
-          rust-script scripts/check-docker-platforms.rs \
-            "ghcr.io/${{ github.repository }}:latest" \
-            "ghcr.io/${{ github.repository }}:${{ steps.current_version.outputs.version }}" \
-            "ghcr.io/${{ github.repository }}:with-claude-cli" \
-            "ghcr.io/${{ github.repository }}:${{ steps.current_version.outputs.version }}-with-claude-cli" \
-            "${{ env.DOCKERHUB_IMAGE }}:latest" \
-            "${{ env.DOCKERHUB_IMAGE }}:${{ steps.current_version.outputs.version }}" \
-            "${{ env.DOCKERHUB_IMAGE }}:with-claude-cli" \
-            "${{ env.DOCKERHUB_IMAGE }}:${{ steps.current_version.outputs.version }}-with-claude-cli"
-
-      - name: Create GitHub Release
-        if: steps.check.outputs.should_release == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: rust-script scripts/create-github-release.rs --release-version "${{ steps.current_version.outputs.version }}" --repository "${{ github.repository }}" --crates-io-url "https://crates.io/crates/link-assistant-router" --docker-hub-url "https://hub.docker.com/r/konard/link-assistant-router"
-
   # === MANUAL INSTANT RELEASE ===
   # Manual release via workflow_dispatch - only after CI passes
   manual-release:
     name: Instant Release
     needs: [lint, test, build, docker-build]
+    outputs:
+      should-release: ${{ steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true' }}
+      release-version: ${{ steps.version.outputs.new_version }}
     # Note: always() is required to evaluate the condition when dependencies use always().
     # The build job ensures lint and test passed before this job runs.
     if: |
@@ -503,7 +416,6 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: write
-      packages: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -544,8 +456,39 @@ jobs:
         if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
         run: rust-script scripts/wait-for-crate.rs --release-version "${{ steps.version.outputs.new_version }}"
 
+  # Build one image per architecture on a native runner. Each matrix leg pushes
+  # content-addressed images; the following job gives those digests their tags.
+  publish-docker-images:
+    name: Build Docker Images (${{ matrix.arch }})
+    needs: [auto-release, manual-release]
+    if: |
+      always() && !cancelled() && (
+        (needs.auto-release.result == 'success' && needs.auto-release.outputs.should-release == 'true') ||
+        (needs.manual-release.result == 'success' && needs.manual-release.outputs.should-release == 'true')
+      )
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: write
+    env:
+      RELEASE_VERSION: ${{ needs.auto-release.outputs.release-version || needs.manual-release.outputs.release-version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+
       - name: Log in to GitHub Container Registry
-        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -553,88 +496,202 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
-        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
         uses: docker/login-action@v4
         with:
           username: konard
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Set up QEMU
-        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
-        uses: docker/setup-qemu-action@v4
-
       - name: Set up Docker Buildx
-        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
         uses: docker/setup-buildx-action@v4
 
       - name: Extract Docker metadata
-        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
         id: docker-meta
         uses: docker/metadata-action@v6
         with:
           images: |
             ghcr.io/${{ github.repository }}
             ${{ env.DOCKERHUB_IMAGE }}
-          tags: |
-            type=raw,value=latest
-            type=raw,value=${{ steps.version.outputs.new_version }}
-          labels: |
-            org.opencontainers.image.version=${{ steps.version.outputs.new_version }}
+          tags: type=raw,value=${{ env.RELEASE_VERSION }}
+          labels: org.opencontainers.image.version=${{ env.RELEASE_VERSION }}
 
-      - name: Publish Docker images to registries
-        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
+      - name: Build and push runtime image by digest
+        id: build-runtime
         uses: docker/build-push-action@v7
         with:
           context: .
           target: runtime
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.docker-meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.docker-meta.outputs.labels }}
+          outputs: type=image,"name=ghcr.io/${{ github.repository }},${{ env.DOCKERHUB_IMAGE }}",push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.arch }}-runtime
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}-runtime
 
-      - name: Extract Docker metadata for the Claude CLI variant
-        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
-        id: docker-meta-claude-cli
-        uses: docker/metadata-action@v6
+      - name: Export runtime digest
+        env:
+          IMAGE_DIGEST: ${{ steps.build-runtime.outputs.digest }}
+        run: |
+          mkdir -p /tmp/digests/runtime
+          touch "/tmp/digests/runtime/${IMAGE_DIGEST#sha256:}"
+
+      - name: Upload runtime digest
+        uses: actions/upload-artifact@v7
         with:
-          images: |
-            ghcr.io/${{ github.repository }}
-            ${{ env.DOCKERHUB_IMAGE }}
-          tags: |
-            type=raw,value=with-claude-cli
-            type=raw,value=${{ steps.version.outputs.new_version }}-with-claude-cli
-          labels: |
-            org.opencontainers.image.version=${{ steps.version.outputs.new_version }}
+          name: runtime-${{ matrix.arch }}
+          path: /tmp/digests/runtime/*
+          if-no-files-found: error
+          retention-days: 1
 
-      - name: Publish Claude CLI variant image to registries
-        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
+      - name: Build and push Claude CLI image by digest
+        id: build-claude-cli
         uses: docker/build-push-action@v7
         with:
           context: .
           target: with-claude-cli
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.docker-meta-claude-cli.outputs.tags }}
-          labels: ${{ steps.docker-meta-claude-cli.outputs.labels }}
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.docker-meta.outputs.labels }}
+          outputs: type=image,"name=ghcr.io/${{ github.repository }},${{ env.DOCKERHUB_IMAGE }}",push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.arch }}-with-claude-cli
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}-with-claude-cli
+
+      - name: Export Claude CLI digest
+        env:
+          IMAGE_DIGEST: ${{ steps.build-claude-cli.outputs.digest }}
+        run: |
+          mkdir -p /tmp/digests/claude-cli
+          touch "/tmp/digests/claude-cli/${IMAGE_DIGEST#sha256:}"
+
+      - name: Upload Claude CLI digest
+        uses: actions/upload-artifact@v7
+        with:
+          name: claude-cli-${{ matrix.arch }}
+          path: /tmp/digests/claude-cli/*
+          if-no-files-found: error
+          retention-days: 1
+
+  publish-docker-manifests:
+    name: Publish Multi-Platform Docker Manifests
+    needs: [auto-release, manual-release, publish-docker-images]
+    if: always() && !cancelled() && needs.publish-docker-images.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
+    env:
+      RELEASE_VERSION: ${{ needs.auto-release.outputs.release-version || needs.manual-release.outputs.release-version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install rust-script
+        run: cargo install rust-script
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: konard
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Download runtime digests
+        uses: actions/download-artifact@v8
+        with:
+          pattern: runtime-*
+          path: /tmp/digests/runtime
+          merge-multiple: true
+
+      - name: Download Claude CLI digests
+        uses: actions/download-artifact@v8
+        with:
+          pattern: claude-cli-*
+          path: /tmp/digests/claude-cli
+          merge-multiple: true
+
+      - name: Create multi-platform manifests
+        shell: bash
+        run: |
+          ghcr_runtime=()
+          dockerhub_runtime=()
+          for digest in /tmp/digests/runtime/*; do
+            hash="$(basename "$digest")"
+            ghcr_runtime+=("ghcr.io/${{ github.repository }}@sha256:$hash")
+            dockerhub_runtime+=("${{ env.DOCKERHUB_IMAGE }}@sha256:$hash")
+          done
+          docker buildx imagetools create \
+            -t "ghcr.io/${{ github.repository }}:latest" \
+            -t "ghcr.io/${{ github.repository }}:${RELEASE_VERSION}" \
+            "${ghcr_runtime[@]}"
+          docker buildx imagetools create \
+            -t "${{ env.DOCKERHUB_IMAGE }}:latest" \
+            -t "${{ env.DOCKERHUB_IMAGE }}:${RELEASE_VERSION}" \
+            "${dockerhub_runtime[@]}"
+
+          ghcr_claude_cli=()
+          dockerhub_claude_cli=()
+          for digest in /tmp/digests/claude-cli/*; do
+            hash="$(basename "$digest")"
+            ghcr_claude_cli+=("ghcr.io/${{ github.repository }}@sha256:$hash")
+            dockerhub_claude_cli+=("${{ env.DOCKERHUB_IMAGE }}@sha256:$hash")
+          done
+          docker buildx imagetools create \
+            -t "ghcr.io/${{ github.repository }}:with-claude-cli" \
+            -t "ghcr.io/${{ github.repository }}:${RELEASE_VERSION}-with-claude-cli" \
+            "${ghcr_claude_cli[@]}"
+          docker buildx imagetools create \
+            -t "${{ env.DOCKERHUB_IMAGE }}:with-claude-cli" \
+            -t "${{ env.DOCKERHUB_IMAGE }}:${RELEASE_VERSION}-with-claude-cli" \
+            "${dockerhub_claude_cli[@]}"
 
       - name: Verify multi-platform Docker manifests
-        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
         run: |
           rust-script scripts/check-docker-platforms.rs \
             "ghcr.io/${{ github.repository }}:latest" \
-            "ghcr.io/${{ github.repository }}:${{ steps.version.outputs.new_version }}" \
+            "ghcr.io/${{ github.repository }}:${{ env.RELEASE_VERSION }}" \
             "ghcr.io/${{ github.repository }}:with-claude-cli" \
-            "ghcr.io/${{ github.repository }}:${{ steps.version.outputs.new_version }}-with-claude-cli" \
+            "ghcr.io/${{ github.repository }}:${{ env.RELEASE_VERSION }}-with-claude-cli" \
             "${{ env.DOCKERHUB_IMAGE }}:latest" \
-            "${{ env.DOCKERHUB_IMAGE }}:${{ steps.version.outputs.new_version }}" \
+            "${{ env.DOCKERHUB_IMAGE }}:${{ env.RELEASE_VERSION }}" \
             "${{ env.DOCKERHUB_IMAGE }}:with-claude-cli" \
-            "${{ env.DOCKERHUB_IMAGE }}:${{ steps.version.outputs.new_version }}-with-claude-cli"
+            "${{ env.DOCKERHUB_IMAGE }}:${{ env.RELEASE_VERSION }}-with-claude-cli"
+
+  create-github-release:
+    name: Create GitHub Release
+    needs: [auto-release, manual-release, publish-docker-manifests]
+    if: always() && !cancelled() && needs.publish-docker-manifests.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    env:
+      RELEASE_VERSION: ${{ needs.auto-release.outputs.release-version || needs.manual-release.outputs.release-version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install rust-script
+        run: cargo install rust-script
 
       - name: Create GitHub Release
-        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: rust-script scripts/create-github-release.rs --release-version "${{ steps.version.outputs.new_version }}" --repository "${{ github.repository }}" --crates-io-url "https://crates.io/crates/link-assistant-router" --docker-hub-url "https://hub.docker.com/r/konard/link-assistant-router"
+        run: rust-script scripts/create-github-release.rs --release-version "${{ env.RELEASE_VERSION }}" --repository "${{ github.repository }}" --crates-io-url "https://crates.io/crates/link-assistant-router" --docker-hub-url "https://hub.docker.com/r/konard/link-assistant-router"
 
   # === MANUAL CHANGELOG PR ===
   changelog-pr:

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-12T07:20:02.592Z for PR creation at branch issue-113-1110124f8fe4 for issue https://github.com/link-assistant/router/issues/113

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-12T07:20:02.592Z for PR creation at branch issue-113-1110124f8fe4 for issue https://github.com/link-assistant/router/issues/113

--- a/changelog.d/20260812_073000_native_arm64_images.md
+++ b/changelog.d/20260812_073000_native_arm64_images.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+---
+
+### Fixed
+
+- Build release images for AMD64 and ARM64 in parallel on native GitHub runners,
+  cache each architecture, and merge their digests without QEMU emulation.

--- a/scripts/check-release-workflow.rs
+++ b/scripts/check-release-workflow.rs
@@ -11,26 +11,31 @@ fn main() {
     let required_snippets = [
         "auto-release:",
         "manual-release:",
+        "publish-docker-images:",
+        "publish-docker-manifests:",
         "packages: write",
         "CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}",
         "DOCKERHUB_IMAGE: konard/link-assistant-router",
         "rust-script scripts/wait-for-crate.rs",
         "docker/login-action@v4",
-        "docker/setup-qemu-action@v4",
         "docker/setup-buildx-action@v4",
         "docker/metadata-action@v6",
         "docker/build-push-action@v7",
-        "platforms: linux/amd64,linux/arm64",
+        "platform: linux/amd64",
+        "platform: linux/arm64",
+        "runner: ubuntu-24.04-arm",
+        "runs-on: ${{ matrix.runner }}",
+        "platforms: ${{ matrix.platform }}",
+        "push-by-digest=true",
+        "cache-from: type=gha",
+        "cache-to: type=gha,mode=max",
+        "docker buildx imagetools create",
         "rust-script scripts/check-docker-platforms.rs",
         "username: konard",
         "password: ${{ secrets.DOCKERHUB_TOKEN }}",
         "ghcr.io/${{ github.repository }}",
         "${{ env.DOCKERHUB_IMAGE }}",
-        "type=raw,value=latest",
-        "type=raw,value=${{ steps.current_version.outputs.version }}",
-        "type=raw,value=${{ steps.version.outputs.new_version }}",
-        "org.opencontainers.image.version=${{ steps.current_version.outputs.version }}",
-        "org.opencontainers.image.version=${{ steps.version.outputs.new_version }}",
+        "labels: ${{ steps.docker-meta.outputs.labels }}",
         "--crates-io-url \"https://crates.io/crates/link-assistant-router\"",
         "--docker-hub-url \"https://hub.docker.com/r/konard/link-assistant-router\"",
     ];
@@ -45,40 +50,42 @@ fn main() {
     }
 
     if count_occurrences(&workflow, "packages: write") < 2 {
-        failures.push("auto and manual release jobs must both grant packages: write".to_string());
+        failures.push("Docker build and manifest jobs must grant packages: write".to_string());
     }
 
     if count_occurrences(&workflow, "docker/login-action@v4") < 4 {
         failures.push(
-            "auto and manual release jobs must both log in to GHCR and Docker Hub".to_string(),
+            "Docker build and manifest jobs must both log in to GHCR and Docker Hub".to_string(),
         );
     }
 
-    if count_occurrences(&workflow, "docker/build-push-action@v7") < 2 {
-        failures.push("auto and manual release jobs must both publish Docker images".to_string());
+    if count_occurrences(&workflow, "docker/build-push-action@v7") != 2 {
+        failures.push("the native matrix must publish both Docker image variants".to_string());
     }
 
-    if count_occurrences(&workflow, "docker/setup-qemu-action@v4") < 2 {
+    if workflow.contains("docker/setup-qemu-action") {
+        failures.push("release images must not use QEMU emulation".to_string());
+    }
+
+    if count_occurrences(&workflow, "push-by-digest=true") != 2 {
         failures.push(
-            "auto and manual release jobs must both enable cross-platform emulation".to_string(),
+            "both image variants must publish native architecture images by digest".to_string(),
         );
     }
 
-    if count_occurrences(&workflow, "platforms: linux/amd64,linux/arm64") < 4 {
+    if count_occurrences(&workflow, "docker buildx imagetools create") != 4 {
         failures.push(
-            "auto and manual release jobs must publish both image variants for amd64 and arm64"
-                .to_string(),
+            "both registries must receive merged runtime and Claude CLI manifests".to_string(),
         );
     }
 
     if count_occurrences(
         &workflow,
         "rust-script scripts/check-docker-platforms.rs",
-    ) < 2
+    ) != 1
     {
         failures.push(
-            "auto and manual release jobs must verify published multi-platform manifests"
-                .to_string(),
+            "the shared manifest job must verify every published multi-platform image".to_string(),
         );
     }
 
@@ -96,29 +103,25 @@ fn main() {
     if count_occurrences(
         &workflow,
         "--crates-io-url \"https://crates.io/crates/link-assistant-router\"",
-    ) < 2
+    ) != 1
     {
         failures.push(
-            "auto and manual GitHub releases must include the crates.io release badge/link"
-                .to_string(),
+            "the shared GitHub release must include the crates.io release badge/link".to_string(),
         );
     }
 
     if count_occurrences(
         &workflow,
         "--docker-hub-url \"https://hub.docker.com/r/konard/link-assistant-router\"",
-    ) < 2
+    ) != 1
     {
         failures.push(
-            "auto and manual GitHub releases must include the Docker Hub release badge/link"
-                .to_string(),
+            "the shared GitHub release must include the Docker Hub release badge/link".to_string(),
         );
     }
 
     if failures.is_empty() {
-        println!(
-            "release workflow publishes crates and verified multi-platform GHCR/Docker Hub images"
-        );
+        println!("release workflow builds native images and publishes verified multi-platform manifests");
     } else {
         for failure in failures {
             eprintln!("Error: {failure}");

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -238,8 +238,8 @@ fn release_workflow_adds_crates_io_link_to_github_releases() {
     let crates_url_arg = "--crates-io-url \"https://crates.io/crates/link-assistant-router\"";
     assert_eq!(
         workflow.matches(crates_url_arg).count(),
-        2,
-        "auto and manual GitHub releases should include the crates.io package URL"
+        1,
+        "the shared GitHub release job should include the crates.io package URL"
     );
     assert!(
         release_script
@@ -301,27 +301,27 @@ fn release_workflow_publishes_synced_docker_hub_image_after_crate() {
             .matches("password: ${{ secrets.DOCKERHUB_TOKEN }}")
             .count(),
         2,
-        "auto and manual release jobs should authenticate to Docker Hub with DOCKERHUB_TOKEN"
+        "Docker build and manifest jobs should authenticate with DOCKERHUB_TOKEN"
     );
     assert_eq!(
         workflow.matches("username: konard").count(),
         2,
-        "auto and manual release jobs should publish as the konard Docker Hub user"
+        "Docker build and manifest jobs should publish as the konard Docker Hub user"
     );
     assert_eq!(
         workflow.matches("docker/login-action@v4").count(),
         4,
-        "auto and manual release jobs should log in to both GHCR and Docker Hub"
+        "Docker build and manifest jobs should log in to both GHCR and Docker Hub"
     );
     assert_eq!(
         workflow.matches("docker/metadata-action@v6").count(),
-        4,
-        "auto and manual release jobs should derive Docker metadata for the default and Claude CLI images"
+        1,
+        "the shared native matrix should preserve standard OCI image metadata"
     );
     assert_eq!(
         workflow.matches("docker/build-push-action@v7").count(),
-        4,
-        "auto and manual release jobs should push the default and Claude CLI images"
+        2,
+        "the native matrix should push the default and Claude CLI images"
     );
 
     let auto_publish = workflow
@@ -330,17 +330,15 @@ fn release_workflow_publishes_synced_docker_hub_image_after_crate() {
     let auto_wait = workflow
         .find("- name: Wait for Crate availability on Crates.io")
         .expect("auto release should wait for the crate to be visible");
-    let auto_docker = workflow
-        .find("- name: Publish Docker images to registries")
-        .expect("auto release should publish Docker images");
-    let auto_github_release = workflow
-        .find("- name: Create GitHub Release")
-        .expect("auto release should create a GitHub release");
-
-    assert!(
-        auto_publish < auto_wait && auto_wait < auto_docker && auto_docker < auto_github_release,
-        "auto release should publish crates.io first, then Docker images, then the GitHub release"
-    );
+    let docker_build = workflow
+        .find("publish-docker-images:")
+        .expect("shared native Docker build job should exist");
+    let docker_manifests = workflow
+        .find("publish-docker-manifests:")
+        .expect("shared Docker manifest job should exist");
+    let github_release = workflow
+        .find("create-github-release:")
+        .expect("shared GitHub release job should exist");
 
     let manual_release = workflow
         .find("manual-release:")
@@ -352,18 +350,14 @@ fn release_workflow_publishes_synced_docker_hub_image_after_crate() {
     let manual_wait = manual_section
         .find("- name: Wait for Crate availability on Crates.io")
         .expect("manual release should wait for the crate to be visible");
-    let manual_docker = manual_section
-        .find("- name: Publish Docker images to registries")
-        .expect("manual release should publish Docker images");
-    let manual_github_release = manual_section
-        .find("- name: Create GitHub Release")
-        .expect("manual release should create a GitHub release");
-
     assert!(
-        manual_publish < manual_wait
-            && manual_wait < manual_docker
-            && manual_docker < manual_github_release,
-        "manual release should publish crates.io first, then Docker images, then the GitHub release"
+        auto_publish < auto_wait
+            && auto_wait < docker_build
+            && manual_publish < manual_wait
+            && manual_release + manual_wait < docker_build
+            && docker_build < docker_manifests
+            && docker_manifests < github_release,
+        "both release paths should publish crates.io first, then native Docker images and manifests, then the GitHub release"
     );
 }
 
@@ -532,23 +526,25 @@ fn release_workflow_publishes_both_the_default_and_claude_cli_images() {
 
     assert_eq!(
         workflow.matches("target: runtime").count(),
-        2,
-        "auto and manual release jobs should pin the default image to the minimal `runtime` stage"
+        1,
+        "the shared native build matrix should pin the default image to the minimal `runtime` stage"
     );
     assert_eq!(
         workflow.matches("target: with-claude-cli").count(),
-        2,
-        "auto and manual release jobs should also build the Claude CLI variant"
+        1,
+        "the shared native build matrix should also build the Claude CLI variant"
     );
     assert_eq!(
-        workflow.matches("type=raw,value=with-claude-cli").count(),
-        2,
-        "the Claude CLI variant should get a floating `with-claude-cli` tag"
+        workflow.matches(":with-claude-cli\"").count(),
+        4,
+        "both registries should get and verify the floating `with-claude-cli` tag"
     );
     assert_eq!(
-        workflow.matches("-with-claude-cli\n").count(),
+        workflow
+            .matches("${RELEASE_VERSION}-with-claude-cli")
+            .count(),
         2,
-        "the Claude CLI variant should also get a version-pinned tag"
+        "both registries should get a version-pinned Claude CLI tag"
     );
 }
 
@@ -557,24 +553,49 @@ fn release_workflow_publishes_and_verifies_multi_platform_images() {
     let workflow = read_lf(".github/workflows/release.yml");
     let platform_check = read_lf("scripts/check-docker-platforms.rs");
 
+    assert!(
+        !workflow.contains("docker/setup-qemu-action"),
+        "release images must not use QEMU emulation"
+    );
+    for snippet in [
+        "platform: linux/amd64",
+        "runner: ubuntu-latest",
+        "platform: linux/arm64",
+        "runner: ubuntu-24.04-arm",
+        "runs-on: ${{ matrix.runner }}",
+        "platforms: ${{ matrix.platform }}",
+    ] {
+        assert!(
+            workflow.contains(snippet),
+            "native release matrix should contain `{snippet}`"
+        );
+    }
     assert_eq!(
-        workflow.matches("docker/setup-qemu-action@v4").count(),
+        workflow.matches("push-by-digest=true").count(),
         2,
-        "auto and manual release jobs should install emulation for cross-platform builds"
+        "both image variants should publish architecture-specific digests"
     );
     assert_eq!(
-        workflow
-            .matches("platforms: linux/amd64,linux/arm64")
-            .count(),
+        workflow.matches("cache-from: type=gha").count(),
+        2,
+        "both image variants should reuse GitHub Actions build cache"
+    );
+    assert_eq!(
+        workflow.matches("cache-to: type=gha,mode=max").count(),
+        2,
+        "both image variants should populate GitHub Actions build cache"
+    );
+    assert_eq!(
+        workflow.matches("docker buildx imagetools create").count(),
         4,
-        "both image variants in both release paths should publish amd64 and arm64 manifests"
+        "both registries and both variants should receive merged multi-platform manifests"
     );
     assert_eq!(
         workflow
             .matches("rust-script scripts/check-docker-platforms.rs")
             .count(),
-        2,
-        "auto and manual releases should verify the published manifests"
+        1,
+        "the shared manifest job should verify every published image"
     );
     assert!(
         workflow.contains("rust-script --test scripts/check-docker-platforms.rs"),


### PR DESCRIPTION
## Summary

- build `linux/amd64` and `linux/arm64` release images concurrently on native GitHub runners
- publish architecture images by digest, reuse architecture-specific GitHub Actions caches, and merge the digests into runtime and Claude CLI manifests on GHCR and Docker Hub
- share Docker publication between automatic and manual release paths while preserving OCI metadata, tags, manifest verification, and release ordering
- add regression coverage that rejects QEMU and requires both native runners, digest publication, caching, and manifest assembly

## Root cause and reproduction

Both release paths ran on `ubuntu-latest`, installed `docker/setup-qemu-action`, and asked each of the runtime and Claude CLI Buildx steps to compile `linux/amd64,linux/arm64`. ARM64 Rust and Node compilation therefore ran under emulation in the same serial release job.

Before the workflow change, the new regression test fails with:

```text
release images must not use QEMU emulation
```

The release run cited in #113 spent about 17 minutes in the emulated image publication step before cancellation, after the crate and tag were already published but before the GitHub release was created.

## Verification

- `cargo fmt --all -- --check`
- `cargo check --locked --all-targets --all-features`
- `cargo clippy --locked --all-targets --all-features`
- `cargo test --locked --all-features --verbose` (all unit and integration suites)
- `cargo test --locked --doc --verbose`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --no-deps --all-features`
- `cargo package --locked --list`
- `rust-script --test scripts/version-and-commit.rs`
- `rust-script --test scripts/check-docker-platforms.rs` (3 tests)
- `rust-script scripts/check-release-workflow.rs`
- `rust-script scripts/check-file-size.rs`
- `actionlint .github/workflows/release.yml`
- `docker build --target runtime .`

This is a CI/release change, so screenshots are not applicable.

Fixes #113
