### PR TITLE
fix(auth): restore Claude OAuth login paths

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-12T12:26:03.983Z for PR creation at branch issue-120-2cbee18ae165 for issue https://github.com/link-assistant/router/issues/120

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-12T12:26:03.983Z for PR creation at branch issue-120-2cbee18ae165 for issue https://github.com/link-assistant/router/issues/120

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,6 +1392,7 @@ dependencies = [
  "chrono",
  "clap",
  "futures-util",
+ "getrandom 0.4.2",
  "hex",
  "http",
  "http-body-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ toml_edit = "0.23"
 jsonwebtoken = { version = "10.0", default-features = false, features = ["rust_crypto"] }
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.0", features = ["v4"] }
+getrandom = "0.4"
 tower = { version = "0.5", features = ["util"] }
 tower-http = { version = "0.7", features = ["trace", "cors"] }
 tracing = "0.1"

--- a/changelog.d/20260812_140000_fix_claude_oauth.md
+++ b/changelog.d/20260812_140000_fix_claude_oauth.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+### Fixed
+
+- Match Claude Code's native OAuth state entropy and current token endpoint, and make the disposable CLI fallback use its dedicated subscription login command without entering first-run TUI onboarding.

--- a/src/claude_auth.rs
+++ b/src/claude_auth.rs
@@ -65,7 +65,7 @@ impl ClaudeLogin {
     #[must_use]
     pub fn begin(config: ClaudeAuthConfig) -> Self {
         let state = random_urlsafe();
-        let code_verifier = format!("{}{}", random_urlsafe(), random_urlsafe());
+        let code_verifier = random_urlsafe();
         let challenge = base64::engine::general_purpose::URL_SAFE_NO_PAD
             .encode(Sha256::digest(code_verifier.as_bytes()));
         let mut url = reqwest::Url::parse(&config.authorize_url)
@@ -178,7 +178,9 @@ fn persist(home: &Path, token: TokenResponse) -> Result<PathBuf, String> {
 }
 
 fn random_urlsafe() -> String {
-    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(uuid::Uuid::new_v4().as_bytes())
+    let mut bytes = [0_u8; 32];
+    getrandom::fill(&mut bytes).expect("operating system randomness is available");
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
 }
 
 fn response_detail(body: &str) -> String {

--- a/src/on_demand_cli.rs
+++ b/src/on_demand_cli.rs
@@ -27,6 +27,9 @@ impl DisposableCli {
                 "x".into(),
                 "--bun".into(),
                 "@anthropic-ai/claude-code@latest".into(),
+                "auth".into(),
+                "login".into(),
+                "--claudeai".into(),
             ];
             config.package_cache = Some(root.join("bun-cache"));
         } else if command_exists("npx") {
@@ -36,6 +39,9 @@ impl DisposableCli {
                 "--cache".into(),
                 root.join("npm-cache").to_string_lossy().into_owned(),
                 "@anthropic-ai/claude-code@latest".into(),
+                "auth".into(),
+                "login".into(),
+                "--claudeai".into(),
             ];
             config.package_cache = Some(root.join("npm-cache"));
         } else {
@@ -112,5 +118,17 @@ mod tests {
         .read_token()
         .unwrap();
         assert_eq!(token.access_token, "sk-ant-oat-result");
+    }
+
+    #[test]
+    fn fallback_runs_the_dedicated_subscription_login_command() {
+        let (_guard, config) = DisposableCli::claude(&LoginConfig::default()).unwrap();
+
+        assert!(config.args.ends_with(&[
+            "@anthropic-ai/claude-code@latest".to_string(),
+            "auth".to_string(),
+            "login".to_string(),
+            "--claudeai".to_string(),
+        ]));
     }
 }

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -58,7 +58,7 @@ pub const GEMINI_CLIENT_SECRET_ENV: &str = "GEMINI_OAUTH_CLIENT_SECRET";
 pub const CLAUDE_CLIENT_ID: &str = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
 
 /// Anthropic's OAuth token endpoint.
-pub const CLAUDE_TOKEN_URL: &str = "https://console.anthropic.com/v1/oauth/token";
+pub const CLAUDE_TOKEN_URL: &str = "https://platform.claude.com/v1/oauth/token";
 
 /// Refresh parameters for a provider. Every subscription provider now has a
 /// public OAuth client, so this is total.

--- a/tests/claude_auth_test.rs
+++ b/tests/claude_auth_test.rs
@@ -1,7 +1,9 @@
 use std::sync::{Arc, Mutex};
 
 use axum::{Json, Router, extract::State, routing::post};
+use base64::Engine as _;
 use link_assistant_router::claude_auth::{CLAUDE_SCOPES, ClaudeAuthConfig, ClaudeLogin};
+use link_assistant_router::refresh::CLAUDE_TOKEN_URL;
 use serde_json::{Value, json};
 
 #[test]
@@ -23,9 +25,21 @@ fn native_login_builds_the_claude_pkce_authorization_url() {
     assert_eq!(query["redirect_uri"], "https://callback.test/code");
     assert_eq!(query["scope"], CLAUDE_SCOPES);
     assert_eq!(query["response_type"], "code");
+    assert_eq!(query["code"], "true");
     assert_eq!(query["code_challenge_method"], "S256");
     assert!(!query["code_challenge"].is_empty());
-    assert!(!query["state"].is_empty());
+    let state = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(query["state"].as_bytes())
+        .expect("state must be unpadded URL-safe base64");
+    assert_eq!(state.len(), 32, "state must match Claude Code's entropy");
+}
+
+#[test]
+fn native_login_uses_the_current_claude_code_token_endpoint() {
+    assert_eq!(
+        CLAUDE_TOKEN_URL,
+        "https://platform.claude.com/v1/oauth/token"
+    );
 }
 
 #[tokio::test]
@@ -64,7 +78,10 @@ async fn native_login_exchanges_code_and_persists_a_refreshable_credential() {
     assert_eq!(request["code"], "copied-code");
     assert_eq!(request["state"], state);
     assert_eq!(request["client_id"], "public-client");
-    assert!(request["code_verifier"].as_str().unwrap().len() >= 43);
+    let verifier = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(request["code_verifier"].as_str().unwrap())
+        .expect("verifier must be unpadded URL-safe base64");
+    assert_eq!(verifier.len(), 32, "verifier must carry 256 bits");
     let stored: Value = serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap();
     assert_eq!(stored["claudeAiOauth"]["accessToken"], "sk-ant-oat-test");
     assert_eq!(stored["claudeAiOauth"]["refreshToken"], "sk-ant-ort-test");


### PR DESCRIPTION
## Summary

- match Claude Code's native OAuth contract with 256-bit state/PKCE values and the current token endpoint
- run the disposable CLI fallback through `claude auth login --claudeai`, bypassing first-run TUI onboarding
- add regression coverage for both login paths and a patch changelog fragment

## Root cause and reproduction

The native flow generated a 16-byte state while Claude Code generates 32 bytes, and it exchanged codes against the retired console token endpoint. The fallback launched the bare CLI in a fresh home, so it stopped at theme/onboarding screens before reaching `/login`.

Before the fix, the new tests report the native state as 16 bytes instead of 32 and show the stale token endpoint; the fallback argument test also shows that no dedicated auth subcommand was supplied.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features --verbose`
- `cargo test --locked --doc --verbose`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --locked --no-deps --all-features`
- `cargo check --locked --all-targets --all-features`
- `cargo build --locked --release --verbose`
- `cargo package --locked --list`
- changelog, version-modification, file-size, and release-script checks
- `npm audit --audit-level=high` (0 vulnerabilities)
- live startup check with Claude Code 2.1.228: the patched fallback immediately emitted the authorization URL and code prompt without onboarding

The native token exchange is covered using a stub token server; completing a real account authorization was intentionally left to the reviewer because it requires interactive credentials.

Fixes #120
