### PR TITLE
fix(auth): persist Claude PKCE login

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-12T14:04:04.130Z for PR creation at branch issue-122-8744d24bb30e for issue https://github.com/link-assistant/router/issues/122

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-12T14:04:04.130Z for PR creation at branch issue-122-8744d24bb30e for issue https://github.com/link-assistant/router/issues/122

--- a/README.md
+++ b/README.md
@@ -325,8 +325,10 @@ vendor CLI; its PKCE loopback flow remains available as a CLI fallback.
 | `/api/login/{id}` | DELETE | (admin) Cancel a pending login and kill its process |
 | `/api/login/{id}/code` | POST | (admin) Submit the code the human copied from the browser |
 
-For a foreground local login, use `link-assistant-router auth claude`,
-`auth claude --code <code>`, or `auth codex`. `auth status` reports each
+For a foreground local login, use `link-assistant-router auth claude` or
+`auth codex`. Claude's `--flow code` stores its pending PKCE login for 15
+minutes, so the code can be redeemed from a later process with
+`auth claude --flow code --code <code>`. `auth status` reports each
 provider credential as `usable`, `expired`, or `absent`. `auth codex` defaults
 to device authorization; `--flow device` or `--flow loopback` makes the choice
 explicit. Unsupported forced flows fail instead of falling back.

--- a/changelog.d/20260812_150000_persist_claude_pkce.md
+++ b/changelog.d/20260812_150000_persist_claude_pkce.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+### Fixed
+
+- Persist and consume Claude PKCE login state so `auth claude --code` redeems the authorization it was issued for without starting a different login.

--- a/docs/use-cases/remote-login.md
+++ b/docs/use-cases/remote-login.md
@@ -155,13 +155,22 @@ For local or scripted authorization, use the foreground commands:
 
 ```bash
 link-assistant-router auth claude
-link-assistant-router auth claude --code "$CODE"
 link-assistant-router auth codex
 link-assistant-router auth status
 ```
 
-Claude supports `--flow code`; `--flow cli` forces the disposable bun fallback,
-while `auto` tries it only after native OAuth fails. Codex defaults to `--flow device`; use
+To split Claude authorization across processes or containers sharing the same
+`CLAUDE_CODE_HOME`, first run `auth claude --flow code` and open its URL. The
+pending PKCE state remains usable for 15 minutes if that process exits. Redeem
+the copied code without printing a different URL:
+
+```bash
+link-assistant-router auth claude --flow code --code "$CODE"
+```
+
+`--flow cli` forces the disposable bun fallback and cannot be combined with
+`--code`, while `auto` tries it only after native OAuth fails. Codex defaults
+to `--flow device`; use
 `--flow loopback` as an explicit fallback when device authorization is disabled
 for the account. Loopback binds port 1455 (or 1457 via `--port`) and validates
 OAuth state; the listener closes on success, denial, timeout and cancellation.

--- a/src/auth_cli.rs
+++ b/src/auth_cli.rs
@@ -24,12 +24,16 @@ async fn run_claude(config: &Config, code: Option<String>, flow: AuthFlow) -> Ex
     // Disabling HTTP login routes must not disable this local CLI command.
     login_config.enabled = true;
     if flow == AuthFlow::Cli {
+        if code.is_some() {
+            eprintln!("error: --code requires --flow code; the CLI fallback starts its own login");
+            return ExitCode::from(2);
+        }
         return run_claude_cli_fallback(config, login_config, code).await;
     }
-    let manager = LoginManager::new(login_config.clone());
-    match complete_claude(config, &manager, code).await {
+    let has_code = code.is_some();
+    match complete_native_claude(config, code).await {
         Ok(()) => ExitCode::SUCCESS,
-        Err(error) if flow == AuthFlow::Auto => {
+        Err(error) if flow == AuthFlow::Auto && !has_code => {
             eprintln!("native Claude OAuth failed: {error}");
             eprintln!("Trying a disposable Claude Code CLI fallback…");
             run_claude_cli_fallback(config, login_config, None).await
@@ -41,7 +45,36 @@ async fn run_claude(config: &Config, code: Option<String>, flow: AuthFlow) -> Ex
     }
 }
 
-async fn complete_claude(
+async fn complete_native_claude(config: &Config, code: Option<String>) -> Result<(), String> {
+    let auth_config = link_assistant_router::claude_auth::ClaudeAuthConfig::production(
+        config.login.claude_code_home.clone(),
+    );
+    let submitted = if let Some(code) = code {
+        code
+    } else {
+        let login = link_assistant_router::claude_auth::ClaudeLogin::begin_persisted(
+            auth_config.clone(),
+            config.login.session_ttl,
+        )?;
+        println!("Open this URL:\n{}", login.authorization_url());
+        read_code().await?
+    };
+    if submitted.trim().is_empty() {
+        return Err(
+            "no authorization code was supplied; the pending login was kept for `router auth claude --flow code --code <CODE>`"
+                .to_string(),
+        );
+    }
+    let login = link_assistant_router::claude_auth::ClaudeLogin::resume(auth_config)?;
+    login.complete(submitted.trim()).await?;
+    println!(
+        "Claude authorization saved in {}",
+        config.login.claude_code_home.display()
+    );
+    Ok(())
+}
+
+async fn complete_claude_cli(
     config: &Config,
     manager: &LoginManager,
     code: Option<String>,
@@ -86,7 +119,7 @@ async fn run_claude_cli_fallback(
                 return ExitCode::from(1);
             }
         };
-    match complete_claude(config, &LoginManager::new(fallback_config), code).await {
+    match complete_claude_cli(config, &LoginManager::new(fallback_config), code).await {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {
             eprintln!("error: {error}");

--- a/src/claude_auth.rs
+++ b/src/claude_auth.rs
@@ -2,9 +2,10 @@
 
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use base64::Engine as _;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::refresh::{CLAUDE_CLIENT_ID, CLAUDE_TOKEN_URL};
@@ -16,6 +17,8 @@ pub const CLAUDE_AUTHORIZE_URL: &str = "https://claude.com/cai/oauth/authorize";
 pub const CLAUDE_REDIRECT_URI: &str = "https://platform.claude.com/oauth/code/callback";
 /// Scopes requested by the interactive Claude Code login.
 pub const CLAUDE_SCOPES: &str = "org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload";
+
+const PENDING_LOGIN_FILE: &str = ".link-assistant-router-claude-login.json";
 
 /// Testable settings for one native Claude authorization.
 #[derive(Clone, Debug)]
@@ -60,6 +63,13 @@ struct TokenResponse {
     rate_limit_tier: Option<String>,
 }
 
+#[derive(Debug, Deserialize, Serialize)]
+struct PendingLogin {
+    code_verifier: String,
+    state: String,
+    expires_at: i64,
+}
+
 impl ClaudeLogin {
     /// Construct a native login without spawning or locating a vendor CLI.
     #[must_use]
@@ -85,6 +95,42 @@ impl ClaudeLogin {
             code_verifier,
             state,
         }
+    }
+
+    /// Start a login whose PKCE state can be redeemed by a later CLI process.
+    pub fn begin_persisted(config: ClaudeAuthConfig, ttl: Duration) -> Result<Self, String> {
+        let login = Self::begin(config);
+        let ttl = i64::try_from(ttl.as_millis()).unwrap_or(i64::MAX);
+        let pending = PendingLogin {
+            code_verifier: login.code_verifier.clone(),
+            state: login.state.clone(),
+            expires_at: chrono::Utc::now().timestamp_millis().saturating_add(ttl),
+        };
+        write_pending(&login.config.claude_home, &pending)?;
+        Ok(login)
+    }
+
+    /// Atomically consume the PKCE state created by [`Self::begin_persisted`].
+    pub fn resume(config: ClaudeAuthConfig) -> Result<Self, String> {
+        let pending = take_pending(&config.claude_home)?;
+        if pending.expires_at <= chrono::Utc::now().timestamp_millis() {
+            return Err(
+                "pending Claude authorization expired; run `router auth claude --flow code` again"
+                    .to_string(),
+            );
+        }
+        if pending.code_verifier.is_empty() || pending.state.is_empty() {
+            return Err(
+                "pending Claude authorization is invalid; run `router auth claude --flow code` again"
+                    .to_string(),
+            );
+        }
+        Ok(Self {
+            config,
+            authorization_url: String::new(),
+            code_verifier: pending.code_verifier,
+            state: pending.state,
+        })
     }
 
     #[must_use]
@@ -134,6 +180,50 @@ impl ClaudeLogin {
         }
         persist(&self.config.claude_home, token)
     }
+}
+
+fn write_pending(home: &Path, pending: &PendingLogin) -> Result<(), String> {
+    std::fs::create_dir_all(home)
+        .map_err(|error| format!("could not create {}: {error}", home.display()))?;
+    let path = home.join(PENDING_LOGIN_FILE);
+    let temporary = home.join(format!("{PENDING_LOGIN_FILE}.{}.tmp", uuid::Uuid::new_v4()));
+    let bytes = serde_json::to_vec(pending)
+        .map_err(|error| format!("could not encode pending Claude authorization: {error}"))?;
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temporary)
+        .map_err(|error| format!("could not create {}: {error}", temporary.display()))?;
+    file.write_all(&bytes)
+        .and_then(|()| file.sync_all())
+        .map_err(|error| format!("could not write {}: {error}", temporary.display()))?;
+    restrict_permissions(&temporary)?;
+    std::fs::rename(&temporary, &path)
+        .map_err(|error| format!("could not install {}: {error}", path.display()))
+}
+
+fn take_pending(home: &Path) -> Result<PendingLogin, String> {
+    let path = home.join(PENDING_LOGIN_FILE);
+    let claimed = home.join(format!(
+        "{PENDING_LOGIN_FILE}.{}.claimed",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::rename(&path, &claimed).map_err(|error| {
+        if error.kind() == std::io::ErrorKind::NotFound {
+            "no pending Claude authorization; run `router auth claude --flow code` first and open the printed URL"
+                .to_string()
+        } else {
+            format!("could not consume {}: {error}", path.display())
+        }
+    })?;
+    let result = std::fs::read(&claimed)
+        .map_err(|error| format!("could not read {}: {error}", claimed.display()))
+        .and_then(|bytes| {
+            serde_json::from_slice(&bytes)
+                .map_err(|error| format!("invalid pending Claude authorization: {error}"))
+        });
+    let _ = std::fs::remove_file(&claimed);
+    result
 }
 
 fn persist(home: &Path, token: TokenResponse) -> Result<PathBuf, String> {

--- a/tests/auth_cli_test.rs
+++ b/tests/auth_cli_test.rs
@@ -1,0 +1,55 @@
+//! Black-box coverage for foreground provider authorization commands.
+
+use std::process::Command;
+
+#[test]
+fn claude_code_without_a_pending_login_does_not_start_a_new_login() {
+    let home = tempfile::tempdir().expect("temp home");
+    let output = Command::new(env!("CARGO_BIN_EXE_link-assistant-router"))
+        .args([
+            "auth",
+            "claude",
+            "--flow",
+            "code",
+            "--code",
+            "copied-code#previous-state",
+        ])
+        .env("HOME", home.path())
+        .env("CLAUDE_CODE_HOME", home.path().join(".claude"))
+        .env("TOKEN_SECRET", "auth-cli-test-secret")
+        .env("DATA_DIR", home.path().join("router-data"))
+        .env("STORAGE_POLICY", "text")
+        .output()
+        .expect("router CLI should run");
+
+    assert!(!output.status.success());
+    assert!(
+        !String::from_utf8_lossy(&output.stdout).contains("Open this URL:"),
+        "supplying a code must not create a different PKCE login: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("no pending Claude authorization"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("auth claude --flow code"), "{stderr}");
+}
+
+#[test]
+fn claude_code_is_rejected_for_the_cli_fallback_without_starting_it() {
+    let home = tempfile::tempdir().expect("temp home");
+    let output = Command::new(env!("CARGO_BIN_EXE_link-assistant-router"))
+        .args(["auth", "claude", "--flow", "cli", "--code", "copied-code"])
+        .env("HOME", home.path())
+        .env("CLAUDE_CODE_HOME", home.path().join(".claude"))
+        .env("TOKEN_SECRET", "auth-cli-test-secret")
+        .env("DATA_DIR", home.path().join("router-data"))
+        .env("STORAGE_POLICY", "text")
+        .output()
+        .expect("router CLI should run");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(!String::from_utf8_lossy(&output.stdout).contains("Open this URL:"));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("--code requires --flow code"));
+}

--- a/tests/claude_auth_test.rs
+++ b/tests/claude_auth_test.rs
@@ -1,4 +1,5 @@
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use axum::{Json, Router, extract::State, routing::post};
 use base64::Engine as _;
@@ -52,13 +53,14 @@ async fn native_login_exchanges_code_and_persists_a_refreshable_credential() {
     let address = listener.local_addr().unwrap();
     let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
     let home = tempfile::tempdir().unwrap();
-    let login = ClaudeLogin::begin(ClaudeAuthConfig {
+    let config = ClaudeAuthConfig {
         authorize_url: "https://claude.test/oauth/authorize".into(),
         token_url: format!("http://{address}/token"),
         client_id: "public-client".into(),
         redirect_uri: "https://callback.test/code".into(),
         claude_home: home.path().into(),
-    });
+    };
+    let login = ClaudeLogin::begin_persisted(config.clone(), Duration::from_secs(900)).unwrap();
     let state = reqwest::Url::parse(login.authorization_url())
         .unwrap()
         .query_pairs()
@@ -66,8 +68,10 @@ async fn native_login_exchanges_code_and_persists_a_refreshable_credential() {
         .unwrap()
         .1
         .into_owned();
+    drop(login);
 
-    let path = login
+    let path = ClaudeLogin::resume(config)
+        .unwrap()
         .complete(&format!("copied-code#{state}"))
         .await
         .unwrap();


### PR DESCRIPTION
## Summary

- persist the native Claude OAuth PKCE verifier and state in the Claude config directory for 15 minutes
- resume and atomically consume that transaction when `auth claude --flow code --code ...` runs in a later process or container
- reject incompatible `--flow cli --code` input without starting an unrelated login
- document the two-step remote/container workflow and add a patch changelog fragment

## Root cause

The native code flow always called `LoginManager::begin`, including invocations that already supplied `--code`. That generated a new state and PKCE verifier, so a code returned for the earlier authorization URL could never pass state validation in the later process.

## Reproduction and regression coverage

The updated Claude auth integration test begins a persisted login, drops the original login object to simulate process exit, resumes it, and verifies the token exchange uses the original state and verifier. New CLI black-box tests verify that a supplied code never prints a fresh authorization URL and that incompatible CLI fallback input is rejected.

## Verification

- `cargo fmt --all -- --check`
- `cargo check --locked --all-targets --all-features`
- strict Clippy with warnings denied
- rustdoc with warnings denied
- `RUSTFLAGS=-Dwarnings cargo test --locked --all-features --verbose`
- focused `auth_cli_test` and `claude_auth_test`
- release LTO build and package-content validation
- repository changelog, version, release-workflow, and file-size checks
- `cargo audit`
- `npm audit --audit-level=high`

No UI change; screenshots are not applicable.

Fixes #122