### PR TITLE
fix(auth): reject unsupported provider flows

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-12T14:09:29.666Z for PR creation at branch issue-123-5ce8de8509b4 for issue https://github.com/link-assistant/router/issues/123

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-12T14:09:29.666Z for PR creation at branch issue-123-5ce8de8509b4 for issue https://github.com/link-assistant/router/issues/123

--- a/changelog.d/20260812_141500_auth_flow_validation.md
+++ b/changelog.d/20260812_141500_auth_flow_validation.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Fixed
+- Return a failing status for unsupported `auth --flow` values and document each provider's supported flows.

--- a/src/auth_cli.rs
+++ b/src/auth_cli.rs
@@ -15,10 +15,18 @@ pub async fn run(config: &Config, op: &AuthOp) -> ExitCode {
     }
 }
 
+const fn claude_supports_flow(flow: AuthFlow) -> bool {
+    matches!(flow, AuthFlow::Auto | AuthFlow::Code | AuthFlow::Cli)
+}
+
+const fn codex_supports_flow(flow: AuthFlow) -> bool {
+    matches!(flow, AuthFlow::Auto | AuthFlow::Device | AuthFlow::Loopback)
+}
+
 async fn run_claude(config: &Config, code: Option<String>, flow: AuthFlow) -> ExitCode {
-    if !matches!(flow, AuthFlow::Auto | AuthFlow::Code | AuthFlow::Cli) {
+    if !claude_supports_flow(flow) {
         eprintln!("error: Claude does not support {flow:?}; use --flow code or --flow cli");
-        return ExitCode::from(2);
+        return ExitCode::from(1);
     }
     let mut login_config = config.login.clone();
     // Disabling HTTP login routes must not disable this local CLI command.
@@ -109,13 +117,9 @@ async fn read_code() -> Result<String, String> {
 }
 
 async fn run_codex(config: &Config, flow: AuthFlow, port: u16) -> ExitCode {
-    if flow == AuthFlow::Cli {
-        eprintln!("error: Codex does not support CLI; use --flow device or --flow loopback");
-        return ExitCode::from(2);
-    }
-    if flow == AuthFlow::Code {
-        eprintln!("error: Codex does not support Code; use --flow device or --flow loopback");
-        return ExitCode::from(2);
+    if !codex_supports_flow(flow) {
+        eprintln!("error: Codex does not support {flow:?}; use --flow device or --flow loopback");
+        return ExitCode::from(1);
     }
     if matches!(flow, AuthFlow::Auto | AuthFlow::Device) {
         return run_codex_device(config, port).await;
@@ -207,4 +211,25 @@ fn status(config: &Config) -> ExitCode {
         );
     }
     ExitCode::SUCCESS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_flow_support_matrix_matches_the_oauth_implementations() {
+        let cases = [
+            (AuthFlow::Auto, true, true),
+            (AuthFlow::Device, false, true),
+            (AuthFlow::Code, true, false),
+            (AuthFlow::Loopback, false, true),
+            (AuthFlow::Cli, true, false),
+        ];
+
+        for (flow, claude_supported, codex_supported) in cases {
+            assert_eq!(claude_supports_flow(flow), claude_supported, "{flow:?}");
+            assert_eq!(codex_supports_flow(flow), codex_supported, "{flow:?}");
+        }
+    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -486,12 +486,16 @@ pub enum AuthOp {
         #[arg(long)]
         code: Option<String>,
         /// Force an OAuth flow instead of automatic selection.
+        ///
+        /// Supported flows: auto, code, cli.
         #[arg(long, value_enum, default_value_t)]
         flow: AuthFlow,
     },
     /// Authorize an `OpenAI` Codex / `ChatGPT` subscription.
     Codex {
         /// Force an OAuth flow instead of automatic selection.
+        ///
+        /// Supported flows: auto, device, loopback.
         #[arg(long, value_enum, default_value_t)]
         flow: AuthFlow,
         /// Local callback port registered for the Codex OAuth client.

--- a/tests/auth_cli_test.rs
+++ b/tests/auth_cli_test.rs
@@ -1,0 +1,49 @@
+//! Black-box coverage for provider-specific authorization flow validation.
+
+use std::process::{Command, Output};
+
+fn router(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_link-assistant-router"))
+        .args(args)
+        .env("TOKEN_SECRET", "auth-cli-test-secret")
+        .output()
+        .expect("router CLI should run")
+}
+
+#[test]
+fn unsupported_provider_flows_exit_with_authorization_error() {
+    for (provider, flow) in [
+        ("claude", "device"),
+        ("claude", "loopback"),
+        ("codex", "code"),
+        ("codex", "cli"),
+    ] {
+        let output = router(&["auth", provider, "--flow", flow]);
+        assert_eq!(
+            output.status.code(),
+            Some(1),
+            "auth {provider} --flow {flow} returned the wrong status"
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("does not support"),
+            "auth {provider} --flow {flow} did not explain the failure: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+#[test]
+fn provider_help_lists_supported_flows() {
+    for (provider, supported_flows) in [
+        ("claude", "Supported flows: auto, code, cli."),
+        ("codex", "Supported flows: auto, device, loopback."),
+    ] {
+        let output = router(&["auth", provider, "--help"]);
+        assert!(output.status.success());
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains(supported_flows),
+            "auth {provider} help did not contain {supported_flows:?}:\n{stdout}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- return exit status 1 when Claude or Codex receives an unsupported `--flow`
- document each provider's supported flows directly in its command help
- centralize and test the complete provider/flow support matrix
- add black-box coverage for every unsupported pair and both provider help screens
- add a patch changelog fragment

## Root cause and reproduction

The CLI's shared `AuthFlow` value enum makes Clap advertise all five flows for both providers, even though Claude supports only `auto`/`code`/`cli` and Codex supports only `auto`/`device`/`loopback`. The provider guards also used command-usage status 2 instead of the authorization-error status 1 used by other auth failures.

Before the fix, provider help contains no supported-flow guidance:

```
link-assistant-router auth claude --help
link-assistant-router auth codex --help
```

The black-box regression also invokes all unsupported combinations and requires status 1:

- Claude: `device`, `loopback`
- Codex: `code`, `cli`

## Verification

- `cargo fmt --all -- --check`
- `cargo check --locked --all-targets --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --locked --no-deps --all-features`
- `cargo test --locked --all-features --verbose`
- `cargo test --locked --doc --verbose`
- `cargo build --locked --release --verbose`
- `cargo package --locked --list`
- file-size and release-script checks
- `npm audit --audit-level=high` (0 vulnerabilities)

Fixes #123
