### PR TITLE
fix(proxy): relay headers through translations

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-12T14:15:13.268Z for PR creation at branch issue-124-eb9ceb3cb53f for issue https://github.com/link-assistant/router/issues/124

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-12T14:15:13.268Z for PR creation at branch issue-124-eb9ceb3cb53f for issue https://github.com/link-assistant/router/issues/124

--- a/changelog.d/20260812_150000_relay_translated_headers.md
+++ b/changelog.d/20260812_150000_relay_translated_headers.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Fixed
+- Relay upstream vendor quota and request-ID headers through translated Responses and Chat Completions endpoints.

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -853,6 +853,7 @@ async fn forward_openai(
     };
     let upstream_status = upstream_resp.status();
     let retry_after = retry_after_duration(upstream_resp.headers());
+    let response_headers = relay_response_headers(upstream_resp.headers());
     if stream_requested && upstream_status.is_success() {
         state
             .metrics
@@ -874,6 +875,7 @@ async fn forward_openai(
         });
         let mut response = Response::new(Body::from_stream(stream));
         *response.status_mut() = StatusCode::OK;
+        *response.headers_mut() = response_headers;
         response.headers_mut().insert(
             "content-type",
             HeaderValue::from_static("text/event-stream; charset=utf-8"),
@@ -919,6 +921,7 @@ async fn forward_openai(
             axum::Json(parsed),
         )
             .into_response();
+        *resp.headers_mut() = response_headers;
         resp.headers_mut()
             .insert("content-type", HeaderValue::from_static("application/json"));
         return resp;
@@ -947,7 +950,12 @@ async fn forward_openai(
         .metrics
         .record_request(surface, 200, selected_account.as_deref());
 
-    (StatusCode::OK, axum::Json(translated)).into_response()
+    let mut response = (StatusCode::OK, axum::Json(translated)).into_response();
+    *response.headers_mut() = response_headers;
+    response
+        .headers_mut()
+        .insert("content-type", HeaderValue::from_static("application/json"));
+    response
 }
 
 pub(crate) fn maybe_mpp_challenge(

--- a/tests/router_e2e_test.rs
+++ b/tests/router_e2e_test.rs
@@ -239,6 +239,14 @@ async fn stub_vendor(State(state): State<StubState>, request: Request) -> Respon
         "x-ratelimit-remaining-requests",
         HeaderValue::from_static("41"),
     );
+    response.headers_mut().insert(
+        "anthropic-ratelimit-unified-reset",
+        HeaderValue::from_static("1786546200"),
+    );
+    response.headers_mut().insert(
+        "request-id",
+        HeaderValue::from_static("req_anthropic_stub_123"),
+    );
     response
         .headers_mut()
         .insert("x-codex-active-limit", HeaderValue::from_static("primary"));
@@ -365,6 +373,50 @@ async fn anthropic_upstream_returns_each_client_dialect_and_pinned_alias() {
         assert!(
             payload[envelope].is_array(),
             "{path} must return {envelope}[]"
+        );
+    }
+}
+
+#[tokio::test]
+async fn anthropic_upstream_relays_vendor_headers_across_client_dialects() {
+    let router = TestRouter::start(UpstreamProvider::Anthropic).await;
+    let cases = [
+        (
+            "/v1/messages",
+            json!({"model":"claude-sonnet-4-5","max_tokens":64,"messages":[{"role":"user","content":"hi"}]}),
+        ),
+        (
+            "/v1/responses",
+            json!({"model":"claude-sonnet-4-5","input":"hi"}),
+        ),
+        (
+            "/v1/chat/completions",
+            json!({"model":"claude-sonnet-4-5","messages":[{"role":"user","content":"hi"}]}),
+        ),
+    ];
+
+    for (path, body) in cases {
+        let response = router
+            .post(path, &body)
+            .send()
+            .await
+            .expect("router response");
+        assert_eq!(response.status(), StatusCode::OK, "{path}");
+        assert_eq!(
+            response
+                .headers()
+                .get("anthropic-ratelimit-unified-reset")
+                .and_then(|value| value.to_str().ok()),
+            Some("1786546200"),
+            "{path} must relay Anthropic quota headers"
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get("request-id")
+                .and_then(|value| value.to_str().ok()),
+            Some("req_anthropic_stub_123"),
+            "{path} must relay the vendor request ID"
         );
     }
 }


### PR DESCRIPTION
## Summary

- preserve safe upstream response headers when Anthropic responses are translated to Responses or Chat Completions
- relay vendor quota fields and `request-id` for JSON, SSE, and upstream-error responses
- retain the existing filtering of credentials, hop-by-hop fields, and stale content lengths
- add a patch-release changelog fragment

## Root cause and reproduction

The shared response-header relay was applied to native Anthropic and subscription-provider paths, but the Anthropic-to-OpenAI translation path rebuilt each response after consuming the upstream body without copying the selected headers. Consequently, the same Anthropic response retained quota and request-identification fields on `/v1/messages` but lost them on `/v1/responses` and `/v1/chat/completions`.

Before the fix, the new client-boundary regression passes for `/v1/messages` and then fails on `/v1/responses` because `anthropic-ratelimit-unified-reset` is absent. The translator now captures the safe upstream header map before consuming the body and attaches it to every reconstructed response branch.

## Automated coverage

`anthropic_upstream_relays_vendor_headers_across_client_dialects` sends equivalent requests through `/v1/messages`, `/v1/responses`, and `/v1/chat/completions`, then verifies that the Anthropic quota header and vendor `request-id` are identical on all three responses.

## Verification

- `cargo fmt --all -- --check`
- `cargo check --locked --all-targets --all-features`
- `cargo clippy --locked --all-targets --all-features`
- `cargo test --locked --all-features --verbose`
- `cargo test --locked --doc --verbose`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --no-deps --all-features`
- `cargo build --locked --release --verbose`
- `cargo package --locked --list`
- file-size, changelog, version-modification, release-workflow, and release-script checks
- `npm audit --audit-level=high` (0 vulnerabilities)

This is backend response handling; screenshots are not applicable.

Fixes #124
