### PR TITLE
fix(auth): back off failed token refreshes

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-13T05:45:04.642Z for PR creation at branch issue-128-36dd99b62733 for issue https://github.com/link-assistant/router/issues/128
-# Updated: 2026-08-13T10:20:46.113Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-08-13T05:45:04.642Z for PR creation at branch issue-128-36dd99b62733 for issue https://github.com/link-assistant/router/issues/128
+# Updated: 2026-08-13T10:20:46.113Z

--- a/changelog.d/20260813_110000_refresh_backoff.md
+++ b/changelog.d/20260813_110000_refresh_backoff.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Cache terminal OAuth refresh failures per subscription, serialize concurrent refreshes, and exponentially back off transient failures so rejected credentials cannot storm vendor token endpoints.

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -22,6 +22,10 @@ use std::sync::Mutex;
 
 use serde::Deserialize;
 
+#[path = "refresh_state.rs"]
+mod refresh_state;
+use refresh_state::RefreshAttempts;
+
 use crate::subscription::{SubscriptionProvider, SubscriptionToken};
 
 /// How a provider's token endpoint expects the refresh request body encoded.
@@ -326,6 +330,9 @@ async fn refresh_at(
 #[derive(Debug, Default)]
 pub struct TokenCache {
     inner: Mutex<HashMap<(SubscriptionProvider, String), SubscriptionToken>>,
+    /// Per-subscription refresh state. Each async mutex is held across the
+    /// exchange so concurrent requests share one attempt.
+    attempts: RefreshAttempts,
     /// Latest observed verdict per provider from real upstream calls.
     evidence: Mutex<HashMap<SubscriptionProvider, CredentialEvidence>>,
     /// Latest refresh failure per provider, cleared by a successful refresh.
@@ -369,15 +376,56 @@ impl TokenCache {
         disk_token: SubscriptionToken,
         now_ms: i64,
     ) -> SubscriptionToken {
+        self.get_fresh_for_at(
+            client,
+            refresh_config(provider).token_url,
+            provider,
+            account,
+            disk_token,
+            now_ms,
+        )
+        .await
+    }
+
+    async fn get_fresh_for_at(
+        &self,
+        client: &reqwest::Client,
+        token_url: &str,
+        provider: SubscriptionProvider,
+        account: &str,
+        disk_token: SubscriptionToken,
+        now_ms: i64,
+    ) -> SubscriptionToken {
+        let key = (provider, account.to_string());
+        let attempt = self
+            .attempts
+            .for_subscription(provider, account, &disk_token);
+        let mut attempt = attempt.lock().await;
+
+        // Re-authentication replaces at least one credential field. Forget
+        // both negative and positive state derived from the previous file.
+        if attempt.reset_if_changed(&disk_token) {
+            if let Ok(mut guard) = self.inner.lock() {
+                guard.remove(&key);
+            }
+            if let Ok(mut guard) = self.evidence.lock() {
+                guard.remove(&provider);
+            }
+        }
         if !disk_token.is_expired(now_ms) {
             return disk_token;
         }
         if let Some(cached) = self.cached_valid_for(provider, account, now_ms) {
             return cached;
         }
-        match refresh(client, provider, &disk_token, now_ms).await {
+        if attempt.suppresses_attempt(now_ms) {
+            return disk_token;
+        }
+        match refresh_at(client, token_url, provider, &disk_token, now_ms).await {
             Ok(fresh) => {
                 self.store_for(provider, account, fresh.clone());
+                attempt.record_success();
+                self.record_credential_working(provider);
                 if let Ok(mut guard) = self.refresh_errors.lock() {
                     guard.remove(&provider);
                 }
@@ -386,6 +434,12 @@ impl TokenCache {
             Err(e) => {
                 tracing::warn!("subscription token refresh for {provider} failed: {e}");
                 self.record_refresh_error(provider, &e.to_string());
+                if e.is_invalid_grant() {
+                    attempt.record_terminal_failure();
+                    self.record_credential_rejected(provider);
+                } else {
+                    attempt.record_transient_failure(now_ms);
+                }
                 // The stamped-expired token is returned unchanged on purpose:
                 // it may still be honoured by the inference endpoint.
                 disk_token
@@ -633,6 +687,91 @@ mod tests {
             .await;
         assert_eq!(reused.access_token, "cached-once");
         server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn terminal_refresh_failure_is_attempted_only_once_for_same_credential() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}/token", listener.local_addr().unwrap());
+        let calls = Arc::new(AtomicUsize::new(0));
+        let server_calls = Arc::clone(&calls);
+        let server = tokio::spawn(async move {
+            loop {
+                let Ok(Ok((mut socket, _))) =
+                    tokio::time::timeout(std::time::Duration::from_millis(200), listener.accept())
+                        .await
+                else {
+                    break;
+                };
+                server_calls.fetch_add(1, Ordering::SeqCst);
+                let mut request = [0; 2048];
+                let _ = socket.read(&mut request).await.unwrap();
+                let body = r#"{"error":"invalid_grant","error_description":"revoked"}"#;
+                socket
+                    .write_all(
+                        format!(
+                            "HTTP/1.1 400 Bad Request\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                            body.len()
+                        )
+                        .as_bytes(),
+                    )
+                    .await
+                    .unwrap();
+            }
+        });
+
+        let cache = TokenCache::new();
+        let client = reqwest::Client::new();
+        let expired = token(Some("revoked-refresh"), Some(1));
+        let requests = (0..8).map(|_| {
+            cache.get_fresh_for_at(
+                &client,
+                &url,
+                SubscriptionProvider::Claude,
+                "primary",
+                expired.clone(),
+                10_000,
+            )
+        });
+        futures_util::future::join_all(requests).await;
+        server.await.unwrap();
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            cache.evidence(SubscriptionProvider::Claude),
+            Some(CredentialEvidence::Rejected)
+        );
+    }
+
+    #[tokio::test]
+    async fn changed_valid_credential_clears_terminal_rejection() {
+        let cache = TokenCache::new();
+        let expired = token(Some("revoked"), Some(1));
+        let attempt =
+            cache
+                .attempts
+                .for_subscription(SubscriptionProvider::Claude, "primary", &expired);
+        attempt.lock().await.record_terminal_failure();
+        cache.record_credential_rejected(SubscriptionProvider::Claude);
+
+        let replacement = token(Some("new-login"), Some(20_000));
+        let result = cache
+            .get_fresh_for_at(
+                &reqwest::Client::new(),
+                "http://unused.invalid",
+                SubscriptionProvider::Claude,
+                "primary",
+                replacement.clone(),
+                10_000,
+            )
+            .await;
+
+        assert_eq!(result, replacement);
+        assert!(cache.evidence(SubscriptionProvider::Claude).is_none());
     }
 
     #[tokio::test]

--- a/src/refresh_state.rs
+++ b/src/refresh_state.rs
@@ -1,0 +1,178 @@
+//! Per-subscription refresh suppression, backoff, and single-flight state.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use sha2::{Digest, Sha256};
+
+use crate::subscription::{SubscriptionProvider, SubscriptionToken};
+
+const INITIAL_BACKOFF_MS: i64 = 1_000;
+const MAX_BACKOFF_MS: i64 = 5 * 60 * 1_000;
+type SubscriptionKey = (SubscriptionProvider, String);
+type AttemptLock = Arc<tokio::sync::Mutex<RefreshAttempt>>;
+
+#[derive(Debug, Default)]
+pub(super) struct RefreshAttempts {
+    inner: Mutex<HashMap<SubscriptionKey, AttemptLock>>,
+}
+
+#[derive(Debug)]
+pub(super) struct RefreshAttempt {
+    credential: [u8; 32],
+    failure: Option<CachedFailure>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum CachedFailure {
+    Terminal,
+    Transient { failures: u32, retry_at_ms: i64 },
+}
+
+impl RefreshAttempts {
+    pub(super) fn for_subscription(
+        &self,
+        provider: SubscriptionProvider,
+        account: &str,
+        credential: &SubscriptionToken,
+    ) -> AttemptLock {
+        let fingerprint = credential_fingerprint(credential);
+        let mut guard = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        Arc::clone(
+            guard
+                .entry((provider, account.to_string()))
+                .or_insert_with(|| {
+                    Arc::new(tokio::sync::Mutex::new(RefreshAttempt {
+                        credential: fingerprint,
+                        failure: None,
+                    }))
+                }),
+        )
+    }
+}
+
+impl RefreshAttempt {
+    /// Reset state when any credential-file field changes.
+    pub(super) fn reset_if_changed(&mut self, credential: &SubscriptionToken) -> bool {
+        let fingerprint = credential_fingerprint(credential);
+        if self.credential == fingerprint {
+            return false;
+        }
+        self.credential = fingerprint;
+        self.failure = None;
+        true
+    }
+
+    pub(super) const fn suppresses_attempt(&self, now_ms: i64) -> bool {
+        match self.failure {
+            Some(CachedFailure::Terminal) => true,
+            Some(CachedFailure::Transient { retry_at_ms, .. }) => now_ms < retry_at_ms,
+            None => false,
+        }
+    }
+
+    pub(super) const fn record_success(&mut self) {
+        self.failure = None;
+    }
+
+    pub(super) const fn record_terminal_failure(&mut self) {
+        self.failure = Some(CachedFailure::Terminal);
+    }
+
+    pub(super) fn record_transient_failure(&mut self, now_ms: i64) {
+        let failures = match self.failure {
+            Some(CachedFailure::Transient { failures, .. }) => failures.saturating_add(1),
+            _ => 1,
+        };
+        let shift = failures.saturating_sub(1).min(18);
+        let delay = INITIAL_BACKOFF_MS
+            .saturating_mul(1_i64 << shift)
+            .min(MAX_BACKOFF_MS);
+        self.failure = Some(CachedFailure::Transient {
+            failures,
+            retry_at_ms: now_ms.saturating_add(delay),
+        });
+    }
+}
+
+/// Identify every credential-file change without retaining another plaintext
+/// copy of its secrets in failure state.
+fn credential_fingerprint(token: &SubscriptionToken) -> [u8; 32] {
+    fn hash_field(hasher: &mut Sha256, value: Option<&str>) {
+        match value {
+            Some(value) => {
+                hasher.update([1]);
+                hasher.update(value.len().to_le_bytes());
+                hasher.update(value.as_bytes());
+            }
+            None => hasher.update([0]),
+        }
+    }
+
+    let mut hasher = Sha256::new();
+    hash_field(&mut hasher, Some(&token.access_token));
+    hash_field(&mut hasher, token.refresh_token.as_deref());
+    match token.expires_at_ms {
+        Some(expiry) => {
+            hasher.update([1]);
+            hasher.update(expiry.to_le_bytes());
+        }
+        None => hasher.update([0]),
+    }
+    hash_field(&mut hasher, token.account_id.as_deref());
+    hash_field(&mut hasher, token.resource_url.as_deref());
+    hasher.finalize().into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn token(refresh: &str) -> SubscriptionToken {
+        SubscriptionToken {
+            access_token: "expired".into(),
+            refresh_token: Some(refresh.into()),
+            expires_at_ms: Some(1),
+            account_id: None,
+            resource_url: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn terminal_failure_is_rearmed_only_by_changed_credentials() {
+        let attempts = RefreshAttempts::default();
+        let original = token("revoked");
+        let attempt = attempts.for_subscription(SubscriptionProvider::Claude, "primary", &original);
+        let mut state = attempt.lock().await;
+        state.record_terminal_failure();
+        assert!(state.suppresses_attempt(10_000));
+        assert!(!state.reset_if_changed(&original));
+        assert!(state.suppresses_attempt(20_000));
+        assert!(state.reset_if_changed(&token("new-login")));
+        assert!(!state.suppresses_attempt(20_000));
+        drop(state);
+    }
+
+    #[tokio::test]
+    async fn transient_failures_back_off_exponentially_with_a_ceiling() {
+        let attempts = RefreshAttempts::default();
+        let attempt =
+            attempts.for_subscription(SubscriptionProvider::Claude, "primary", &token("transient"));
+        let mut state = attempt.lock().await;
+        state.record_transient_failure(10_000);
+        assert!(state.suppresses_attempt(10_999));
+        assert!(!state.suppresses_attempt(11_000));
+        state.record_transient_failure(11_000);
+        assert!(state.suppresses_attempt(12_999));
+        assert!(!state.suppresses_attempt(13_000));
+        for _ in 0..30 {
+            state.record_transient_failure(20_000);
+        }
+        assert!(state.suppresses_attempt(319_999));
+        assert!(!state.suppresses_attempt(320_000));
+        drop(state);
+    }
+}


### PR DESCRIPTION
## Summary

- cache terminal `invalid_grant` outcomes per provider/account and credential fingerprint
- serialize concurrent refreshes so requests share one token-endpoint exchange
- exponentially back off transient refresh failures from 1 second to a 5-minute ceiling
- clear cached failures and rejection evidence when credential contents change

## Root cause

The refresh cache retained only successful, non-expired tokens. An expired credential whose refresh token was rejected therefore missed the cache on every inbound request and immediately contacted the vendor token endpoint again. Refresh attempts also had no per-subscription synchronization or transient failure schedule.

## Reproduction and regression coverage

Before the fix, the loopback regression sent three requests with one rejected credential and observed three identical token-endpoint calls.

After the fix, `terminal_refresh_failure_is_attempted_only_once_for_same_credential` launches eight concurrent requests and asserts exactly one upstream exchange. Additional tests verify:

- terminal failure remains suppressed for unchanged credentials;
- replacing credential contents re-arms refresh and clears rejected health evidence;
- transient failures back off 1s, 2s, and exponentially up to a 5-minute ceiling;
- successful refreshed tokens remain account-isolated and reusable.

## Verification

- `cargo fmt --all -- --check`
- `cargo check --locked --all-targets --all-features`
- `RUSTFLAGS=-Dwarnings cargo clippy --locked --all-targets --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps --all-features`
- `RUSTFLAGS=-Dwarnings cargo test --locked --all-features --verbose`
- release automation script test suites
- changelog-fragment and file-size checks
- `npm audit --audit-level=high`

No UI change; screenshots are not applicable.

Fixes #130