### PR TITLE
fix(security): close unauthenticated state leaks

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-08-13T05:45:04.642Z for PR creation at branch issue-128-36dd99b62733 for issue https://github.com/link-assistant/router/issues/128
+# Updated: 2026-08-13T10:37:38.062Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-13T05:45:04.642Z for PR creation at branch issue-128-36dd99b62733 for issue https://github.com/link-assistant/router/issues/128
-# Updated: 2026-08-13T10:37:38.062Z

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ need:
 | Document | Scenario |
 | --- | --- |
 | [per-task-tokens.md](docs/use-cases/per-task-tokens.md) | One `la_sk_…` token per task — audit, monitoring, security, isolation |
-| [audit-and-monitoring.md](docs/use-cases/audit-and-monitoring.md) | Per-token counters in `/metrics` and `/v1/usage`, plus the JSONL audit log |
+| [audit-and-monitoring.md](docs/use-cases/audit-and-monitoring.md) | Aggregate `/metrics`, admin-only per-token `/v1/usage`, and the JSONL audit log |
 | [claude-max-in-codex.md](docs/use-cases/claude-max-in-codex.md) | A Claude MAX subscription inside Codex CLI and other OpenAI-dialect clients |
 | [chatgpt-in-claude-code.md](docs/use-cases/chatgpt-in-claude-code.md) | A ChatGPT/Qwen/Gemini/LiteLLM backend inside Claude Code and other Anthropic-dialect clients |
 | [cli-claude-code.md](docs/use-cases/cli-claude-code.md) | Claude Code configuration |
@@ -437,14 +437,15 @@ method-specific verifier is configured.
 
 | Endpoint | Method | Description |
 |---|---|---|
-| `/metrics` | GET | Prometheus text-exposition counters |
-| `/v1/usage` | GET | JSON snapshot of all counters |
-| `/v1/accounts` | GET | Multi-account health: cooldowns, last error, used count, configured limit, and remaining requests |
+| `/metrics` | GET | Public Prometheus text-exposition aggregate counters |
+| `/v1/usage` | GET | Admin-only JSON snapshot, including per-token and per-account counters |
+| `/v1/accounts` | GET | Admin-only multi-account health: cooldowns, last error, used count, configured limit, and remaining requests |
 
-`/metrics` and `/v1/usage` also attribute every authorised request to its
-router token — `link_assistant_token_requests_total{token,label}` and the
-`token_calls` JSON map. Set `--audit-log` for a durable JSONL trail of the same
-events. See [docs/use-cases/audit-and-monitoring.md](docs/use-cases/audit-and-monitoring.md).
+`/metrics` deliberately contains no token ids, labels, or account names because
+it is available without authentication. Administrators can inspect per-token
+usage in the `/v1/usage` `token_calls` JSON map. Set `--audit-log` for a durable
+JSONL trail of the same events. See
+[docs/use-cases/audit-and-monitoring.md](docs/use-cases/audit-and-monitoring.md).
 
 ### POST /api/tokens
 

--- a/changelog.d/20260813_110000_secure_public_endpoints.md
+++ b/changelog.d/20260813_110000_secure_public_endpoints.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+### Security
+
+- Remove token and account identities from public Prometheus metrics, authenticate requests before automatic model routing, and hide token parser details from client error responses.

--- a/docs/use-cases/README.md
+++ b/docs/use-cases/README.md
@@ -16,7 +16,7 @@ come first; the per-CLI documents follow.
 | [admin-ui.md](admin-ui.md) | The opt-in browser console on its own port: enabling it, the two-phase first-visitor claim, and the `localStorage` trade-off |
 | [chat-admin-bots.md](chat-admin-bots.md) | The optional Telegram and VK admin bots: private chats only, sharing one system-wide admin claim with the web UI |
 | [per-task-tokens.md](per-task-tokens.md) | One `la_sk_…` token per task, for audit, monitoring, security and isolation |
-| [audit-and-monitoring.md](audit-and-monitoring.md) | Where per-token usage shows up: `/metrics`, `/v1/usage`, and the JSONL audit log |
+| [audit-and-monitoring.md](audit-and-monitoring.md) | Public aggregate metrics, admin-only per-token usage, and the JSONL audit log |
 | [claude-max-in-codex.md](claude-max-in-codex.md) | Use a **Claude MAX** subscription from **Codex CLI** (and any other OpenAI-dialect client) |
 | [chatgpt-in-claude-code.md](chatgpt-in-claude-code.md) | Use a **ChatGPT/Codex** subscription from **Claude Code** (and any other Anthropic-dialect client) |
 

--- a/docs/use-cases/audit-and-monitoring.md
+++ b/docs/use-cases/audit-and-monitoring.md
@@ -12,30 +12,20 @@ when it authorises a request.
 
 | View | Endpoint / file | Retention | Best for |
 | --- | --- | --- | --- |
-| Prometheus counters | `GET /metrics` | in-memory, resets on restart | dashboards, alerts |
-| JSON snapshot | `GET /v1/usage` | in-memory, resets on restart | ad-hoc inspection, scripts |
+| Prometheus counters | `GET /metrics` (public, aggregate only) | in-memory, resets on restart | dashboards, alerts |
+| JSON snapshot | `GET /v1/usage` (admin only) | in-memory, resets on restart | per-token inspection, scripts |
 | Audit trail | `--audit-log <file>` (JSONL) | durable, append-only | forensics, compliance |
 | Persisted budgets | `tokens list` | durable token store | quota enforcement |
 
 ## Live per-token counters
 
 Every authorised request is attributed to its token id (the JWT `sub`) and the
-label the token was issued with:
+label the token was issued with. The detailed counters are available only from
+the admin-gated `/v1/usage` endpoint:
 
 ```bash
-curl -s http://127.0.0.1:8080/metrics | grep token_requests_total
-```
-
-```
-# TYPE link_assistant_token_requests_total counter
-link_assistant_token_requests_total{token="550e8400-…",label="issue-45-solver"} 42
-link_assistant_token_requests_total{token="9f1c2b7a-…",label="ci-nightly"} 7
-```
-
-The same numbers appear as JSON under `token_calls` in `/v1/usage`:
-
-```bash
-curl -s http://127.0.0.1:8080/v1/usage | jq .token_calls
+curl -s http://127.0.0.1:8080/v1/usage \
+  -H "Authorization: Bearer $ROUTER_ADMIN_TOKEN" | jq .token_calls
 ```
 
 ```json
@@ -44,14 +34,11 @@ curl -s http://127.0.0.1:8080/v1/usage | jq .token_calls
 }
 ```
 
-The counter increments once per *authorised* request — the same unit
+The count increments once per *authorised* request — the same unit
 `--max-requests` budgets — so `requests` here and `used/max` in `tokens list`
-count the same events. Tokens with no traffic yet emit no series at all, so the
-label set stays bounded by tokens actually in use.
-
-Label values are escaped (`\`, `"`, newline) before being written, so a token
-labelled with quotes or a newline still produces exactly one valid Prometheus
-sample.
+count the same events. `/metrics` remains unauthenticated for standard
+Prometheus scrapers, so it exposes aggregate totals and status codes only; it
+never emits token ids, token labels, or account names.
 
 ## Durable audit trail
 
@@ -109,8 +96,8 @@ link-assistant-router tokens list
 ```
 
 ```promql
-# Prometheus: request rate per task over 5 minutes
-rate(link_assistant_token_requests_total[5m])
+# Prometheus: aggregate request rate over 5 minutes
+rate(link_assistant_requests_total[5m])
 ```
 
 ## Related
@@ -118,5 +105,5 @@ rate(link_assistant_token_requests_total[5m])
 - [per-task-tokens.md](per-task-tokens.md) — issuing and scoping the tokens
   these views attribute traffic to.
 - The router also exports overall counters (`link_assistant_requests_total`,
-  `…_errors_total`, per-status and per-account series) — see the main
+  `…_errors_total`, and per-status series) — see the main
   [`README.md`](../../README.md).

--- a/docs/use-cases/per-task-tokens.md
+++ b/docs/use-cases/per-task-tokens.md
@@ -15,7 +15,7 @@ This is the first requirement of
 | Property | What a per-task token gives you |
 | --- | --- |
 | **Audit** | Every request carries a token id, so the JSONL audit log answers "which task did this?" after the fact |
-| **Monitoring** | `/metrics` exports `link_assistant_token_requests_total{token,label}`, so per-task usage is a Prometheus series |
+| **Monitoring** | Admin-only `/v1/usage` exposes per-token request counts while public `/metrics` stays aggregate-only |
 | **Security** | A leaked task token exposes one task's budget, not the subscription — the vendor OAuth credential never leaves the router |
 | **Isolation** | `--max-requests` bounds the blast radius of a runaway agent; `--account` pins a task to one subscription in a pool |
 
@@ -47,7 +47,7 @@ curl -s -X POST http://127.0.0.1:8080/api/tokens \
 ```
 
 Both return a token of the form `la_sk_eyJ…`. The `label` is the human name the
-audit log and the Prometheus series will carry, so use something you can grep
+audit log and the admin usage snapshot will carry, so use something you can grep
 for later — an issue id, a job id, a person, a service.
 
 Issuing is **universal**: one endpoint issues every token. What makes a token
@@ -57,7 +57,7 @@ Issuing is **universal**: one endpoint issues every token. What makes a token
 
 | Flag / field | Effect |
 | --- | --- |
-| `--label` / `label` | Name shown in `tokens list`, `/v1/usage`, `/metrics` and the audit log |
+| `--label` / `label` | Name shown in `tokens list`, admin-only `/v1/usage`, and the audit log |
 | `--ttl-hours` / `ttl_hours` | Token stops working after this many hours; short TTLs make revocation mostly unnecessary |
 | `--max-requests` / `max_requests` | Hard cap on forwarded requests; `429 rate_limit_error` after that. Omit for unlimited |
 | `--account` / `account` | Strict pin to one account in a multi-subscription pool. Pinned requests fail rather than silently changing identity |

--- a/src/anthropic_bridge.rs
+++ b/src/anthropic_bridge.rs
@@ -543,7 +543,7 @@ pub(crate) fn count_tokens_claims(
             crate::token::TokenError::Revoked => StatusCode::FORBIDDEN,
             _ => StatusCode::UNAUTHORIZED,
         };
-        Box::new(anthropic_error(status, e.to_string().as_bytes()))
+        Box::new(anthropic_error(status, e.client_message().as_bytes()))
     })
 }
 

--- a/src/crater.rs
+++ b/src/crater.rs
@@ -518,22 +518,9 @@ pub async fn forward_chat_completions(
         return resp;
     }
 
-    let Some(token) = crate::proxy::extract_client_token(headers) else {
-        return crate::proxy::error_response(
-            StatusCode::UNAUTHORIZED,
-            "authentication_error",
-            "Missing Authorization Bearer token or x-api-key",
-        );
-    };
-    let claims = match state.token_manager.validate_token(token) {
+    let claims = match crate::proxy::authenticate_client(state, headers) {
         Ok(claims) => claims,
-        Err(e) => {
-            let status = match &e {
-                crate::token::TokenError::Revoked => StatusCode::FORBIDDEN,
-                _ => StatusCode::UNAUTHORIZED,
-            };
-            return crate::proxy::error_response(status, "authentication_error", &format!("{e}"));
-        }
+        Err(response) => return *response,
     };
     if let Err(e) = state.token_manager.enforce_request_budget(&claims.sub) {
         return crate::proxy::error_response(

--- a/src/gemini.rs
+++ b/src/gemini.rs
@@ -22,8 +22,7 @@ use serde_json::{Value, json};
 
 use crate::metrics::Surface;
 use crate::proxy::{
-    AppState, error_response, extract_client_token, maybe_mpp_challenge, request_routing_context,
-    retry_after_duration,
+    AppState, error_response, maybe_mpp_challenge, request_routing_context, retry_after_duration,
 };
 
 /// Environment variable carrying the Google Cloud project id for Code Assist.
@@ -235,21 +234,7 @@ async fn route_gemini_token(
     surface: Surface,
     path: &str,
 ) -> Result<RoutedGeminiToken, Response> {
-    let Some(token) = extract_client_token(headers) else {
-        return Err(error_response(
-            StatusCode::UNAUTHORIZED,
-            "authentication_error",
-            "Missing Authorization Bearer token or x-api-key",
-        ));
-    };
-    let claims = state.token_manager.validate_token(token).map_err(|error| {
-        let status = if matches!(error, crate::token::TokenError::Revoked) {
-            StatusCode::FORBIDDEN
-        } else {
-            StatusCode::UNAUTHORIZED
-        };
-        error_response(status, "authentication_error", &error.to_string())
-    })?;
+    let claims = crate::proxy::authenticate_client(state, headers).map_err(|response| *response)?;
     state
         .token_manager
         .enforce_request_budget(&claims.sub)

--- a/src/gonka.rs
+++ b/src/gonka.rs
@@ -125,22 +125,9 @@ pub(crate) async fn forward_openai(
         );
     };
 
-    let Some(token) = crate::proxy::extract_client_token(headers) else {
-        return crate::proxy::error_response(
-            StatusCode::UNAUTHORIZED,
-            "authentication_error",
-            "Missing Authorization Bearer token or x-api-key",
-        );
-    };
-    let claims = match state.token_manager.validate_token(token) {
+    let claims = match crate::proxy::authenticate_client(state, headers) {
         Ok(claims) => claims,
-        Err(e) => {
-            let status = match &e {
-                crate::token::TokenError::Revoked => StatusCode::FORBIDDEN,
-                _ => StatusCode::UNAUTHORIZED,
-            };
-            return crate::proxy::error_response(status, "authentication_error", &format!("{e}"));
-        }
+        Err(response) => return *response,
     };
     if let Err(e) = state.token_manager.enforce_request_budget(&claims.sub) {
         return crate::proxy::error_response(

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -205,35 +205,7 @@ pub fn render_prometheus(m: &Metrics) -> String {
             "link_assistant_status_total{{code=\"{status}\"}} {count}"
         );
     }
-    out.push_str("# TYPE link_assistant_token_requests_total counter\n");
-    let mut sorted_tokens: Vec<_> = snap.token_calls.iter().collect();
-    sorted_tokens.sort_by(|a, b| a.0.cmp(b.0));
-    for (token, usage) in sorted_tokens {
-        let label = escape_label(&usage.label);
-        let _ = writeln!(
-            out,
-            "link_assistant_token_requests_total{{token=\"{token}\",label=\"{label}\"}} {}",
-            usage.requests
-        );
-    }
-    out.push_str("# TYPE link_assistant_account_calls_total counter\n");
-    let mut sorted_accounts: Vec<_> = snap.account_calls.iter().collect();
-    sorted_accounts.sort_by(|a, b| a.0.cmp(b.0));
-    for (acct, count) in sorted_accounts {
-        let _ = writeln!(
-            out,
-            "link_assistant_account_calls_total{{account=\"{acct}\"}} {count}"
-        );
-    }
     out
-}
-
-/// Escape a value for use inside a Prometheus label.
-fn escape_label(value: &str) -> String {
-    value
-        .replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('\n', "\\n")
 }
 
 #[cfg(test)]
@@ -254,25 +226,33 @@ mod tests {
 
         let out = render_prometheus(&m);
         assert!(
-            out.contains("link_assistant_token_requests_total{token=\"tok-a\",label=\"task-a\"} 2")
+            !out.contains("tok-a"),
+            "public metrics leaked a token id: {out}"
         );
         assert!(
-            out.contains("link_assistant_token_requests_total{token=\"tok-b\",label=\"task-b\"} 1")
+            !out.contains("task-a"),
+            "public metrics leaked a token label: {out}"
         );
     }
 
     #[test]
-    fn token_labels_are_escaped_for_prometheus() {
+    fn public_metrics_omit_token_labels_and_account_names() {
         let m = Metrics::default();
         m.record_token_request("tok-a", "task \"one\"\nline");
+        m.record_request(Surface::Anthropic, 200, Some("primary-account"));
         let out = render_prometheus(&m);
-        assert!(out.contains(r#"label="task \"one\"\nline""#), "{out}");
-        // Every emitted line must still be a single Prometheus sample.
-        let token_lines = out
-            .lines()
-            .filter(|l| l.starts_with("link_assistant_token_requests_total"))
-            .count();
-        assert_eq!(token_lines, 1);
+        assert!(
+            !out.contains("tok-a"),
+            "public metrics leaked a token id: {out}"
+        );
+        assert!(
+            !out.contains("task"),
+            "public metrics leaked a token label: {out}"
+        );
+        assert!(
+            !out.contains("primary-account"),
+            "public metrics leaked an account name: {out}"
+        );
     }
 
     #[test]
@@ -300,7 +280,7 @@ mod tests {
         assert!(out.contains("link_assistant_tokens_issued_total 1"));
         assert!(out.contains("code=\"200\""));
         assert!(out.contains("code=\"500\""));
-        assert!(out.contains("account=\"primary\""));
+        assert!(!out.contains("account=\"primary\""));
     }
 
     #[test]

--- a/src/model_routing.rs
+++ b/src/model_routing.rs
@@ -185,20 +185,8 @@ pub async fn pinned_model_catalog(state: &AppState, provider: SubscriptionProvid
 
 /// `GET /v1/models` across automatic or explicitly pinned providers.
 pub async fn models(State(state): State<AppState>, headers: HeaderMap) -> Response {
-    let Some(token) = crate::proxy::extract_client_token(&headers) else {
-        return crate::proxy::error_response(
-            StatusCode::UNAUTHORIZED,
-            "authentication_error",
-            "Missing Authorization Bearer token or x-api-key",
-        );
-    };
-    if let Err(error) = state.token_manager.validate_token(token) {
-        let status = if matches!(error, crate::token::TokenError::Revoked) {
-            StatusCode::FORBIDDEN
-        } else {
-            StatusCode::UNAUTHORIZED
-        };
-        return crate::proxy::error_response(status, "authentication_error", &error.to_string());
+    if let Err(response) = crate::proxy::authenticate_client(&state, &headers) {
+        return *response;
     }
 
     let models = match state.upstream_provider {
@@ -519,6 +507,74 @@ mod tests {
                 "{path} rejected a valid token"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn automatic_messages_authenticate_before_model_routing() {
+        let data = tempdir().unwrap();
+        let state = auto_state(Vec::new(), data.path());
+        let app = axum::Router::new()
+            .route(
+                "/v1/messages",
+                axum::routing::post(crate::proxy::proxy_handler),
+            )
+            .with_state(state);
+        let bodies = [
+            json!({"model": "claude-opus-4-7", "max_tokens": 1, "messages": []}),
+            json!({"model": "totally-made-up-xyz", "max_tokens": 1, "messages": []}),
+            json!({"max_tokens": 1}),
+        ];
+
+        for authorization in [None, Some("Bearer la_sk_invalid-before-routing")] {
+            let mut responses = Vec::new();
+            for body in &bodies {
+                let mut request = Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header("content-type", "application/json");
+                if let Some(value) = authorization {
+                    request = request.header("authorization", value);
+                }
+                let response = app
+                    .clone()
+                    .oneshot(request.body(Body::from(body.to_string())).unwrap())
+                    .await
+                    .unwrap();
+                assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+                responses.push(response.into_body().collect().await.unwrap().to_bytes());
+            }
+            assert!(responses.windows(2).all(|pair| pair[0] == pair[1]));
+        }
+    }
+
+    #[tokio::test]
+    async fn malformed_client_tokens_return_a_fixed_message() {
+        let data = tempdir().unwrap();
+        let state = auto_state(Vec::new(), data.path());
+        let app = axum::Router::new()
+            .route("/v1/models", get(models))
+            .with_state(state);
+        let malformed = ["wrong-prefix", "la_sk_zzzzQQQrandom.stuff.here"];
+        let mut responses = Vec::new();
+
+        for token in malformed {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .uri("/v1/models")
+                        .header("authorization", format!("Bearer {token}"))
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+            responses.push(response.into_body().collect().await.unwrap().to_bytes());
+        }
+        assert!(responses.windows(2).all(|pair| pair[0] == pair[1]));
+        let payload: Value = serde_json::from_slice(&responses[0]).unwrap();
+        assert_eq!(payload["error"]["message"], "invalid token");
     }
 
     #[test]

--- a/src/provider_proxy.rs
+++ b/src/provider_proxy.rs
@@ -10,9 +10,7 @@ use futures_util::StreamExt;
 
 use crate::metrics::Surface;
 use crate::providers::{ProviderError, ProviderUpsert, ResolvedProvider};
-use crate::proxy::{
-    AppState, error_response, extract_client_token, is_admin_authorised, maybe_mpp_challenge,
-};
+use crate::proxy::{AppState, error_response, is_admin_authorised, maybe_mpp_challenge};
 
 /// List configured upstream providers with secrets redacted.
 #[allow(clippy::needless_pass_by_value)]
@@ -139,22 +137,9 @@ pub async fn forward_openai_compatible(
         return resp;
     }
 
-    let Some(token) = extract_client_token(headers) else {
-        return error_response(
-            StatusCode::UNAUTHORIZED,
-            "authentication_error",
-            "Missing Authorization Bearer token or x-api-key",
-        );
-    };
-    let claims = match state.token_manager.validate_token(token) {
+    let claims = match crate::proxy::authenticate_client(state, headers) {
         Ok(claims) => claims,
-        Err(e) => {
-            let status = match &e {
-                crate::token::TokenError::Revoked => StatusCode::FORBIDDEN,
-                _ => StatusCode::UNAUTHORIZED,
-            };
-            return error_response(status, "authentication_error", &format!("{e}"));
-        }
+        Err(response) => return *response,
     };
     // Per-token request budgets apply to every upstream, not just the
     // subscription ones, so a task token cannot escape its cap by being

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -164,6 +164,36 @@ pub(crate) fn extract_client_token(headers: &HeaderMap) -> Option<&str> {
     })
 }
 
+/// Validate the caller credential without exposing token parser internals.
+pub(crate) fn authenticate_client(
+    state: &AppState,
+    headers: &HeaderMap,
+) -> Result<crate::token::TokenClaims, Box<Response>> {
+    let Some(token) = extract_client_token(headers) else {
+        state.logger.debug(|| "Missing Authorization header");
+        return Err(Box::new(error_response(
+            StatusCode::UNAUTHORIZED,
+            "authentication_error",
+            "Missing Authorization Bearer token or x-api-key",
+        )));
+    };
+    state.token_manager.validate_token(token).map_err(|error| {
+        let status = if matches!(error, crate::token::TokenError::Revoked) {
+            StatusCode::FORBIDDEN
+        } else {
+            StatusCode::UNAUTHORIZED
+        };
+        state
+            .logger
+            .debug(|| format!("Token validation failed: {error}"));
+        Box::new(error_response(
+            status,
+            "authentication_error",
+            error.client_message(),
+        ))
+    })
+}
+
 /// Proxy handler for upstream API forwarding.
 ///
 /// Catches all requests, validates the custom token, swaps it for OAuth
@@ -180,6 +210,9 @@ pub async fn proxy_handler(State(state): State<AppState>, req: Request) -> Respo
     let incoming_headers = req.headers().clone();
 
     if state.upstream_provider == UpstreamProvider::Auto {
+        if let Err(response) = authenticate_client(&state, &incoming_headers) {
+            return *response;
+        }
         let (routed, request) =
             match crate::model_routing::route_anthropic_request(&state, req).await {
                 Ok(routed) => routed,
@@ -217,17 +250,6 @@ pub async fn proxy_handler(State(state): State<AppState>, req: Request) -> Respo
             .verbose(|| format!("Session: {}", session_id.to_str().unwrap_or("<invalid>")));
     }
 
-    // Extract and validate the bearer token from the Authorization header
-    let Some(token) = extract_client_token(&incoming_headers) else {
-        state.logger.debug(|| "Missing Authorization header");
-        return error_response(
-            StatusCode::UNAUTHORIZED,
-            "authentication_error",
-            "Missing Authorization Bearer token or x-api-key",
-        );
-    };
-    let custom_token = token.to_string();
-
     // Anthropic-dialect requests aimed at a non-Anthropic upstream are handed
     // to the bridge, which translates both directions and delegates to the
     // provider's own forwarder (that forwarder owns token validation, budget
@@ -254,19 +276,9 @@ pub async fn proxy_handler(State(state): State<AppState>, req: Request) -> Respo
         .await;
     }
 
-    // Validate custom token
-    let claims = match state.token_manager.validate_token(&custom_token) {
+    let claims = match authenticate_client(&state, &incoming_headers) {
         Ok(claims) => claims,
-        Err(e) => {
-            let status = match &e {
-                crate::token::TokenError::Revoked => StatusCode::FORBIDDEN,
-                _ => StatusCode::UNAUTHORIZED,
-            };
-            state
-                .logger
-                .debug(|| format!("Token validation failed: {e}"));
-            return error_response(status, "authentication_error", &format!("{e}"));
-        }
+        Err(response) => return *response,
     };
 
     // Enforce the per-token request budget (max_requests). This is what lets
@@ -748,22 +760,9 @@ async fn forward_openai(
     }
 
     // Validate caller token.
-    let Some(token) = extract_client_token(headers) else {
-        return error_response(
-            StatusCode::UNAUTHORIZED,
-            "authentication_error",
-            "Missing Authorization Bearer token or x-api-key",
-        );
-    };
-    let claims = match state.token_manager.validate_token(token) {
+    let claims = match authenticate_client(state, headers) {
         Ok(claims) => claims,
-        Err(e) => {
-            let status = match &e {
-                crate::token::TokenError::Revoked => StatusCode::FORBIDDEN,
-                _ => StatusCode::UNAUTHORIZED,
-            };
-            return error_response(status, "authentication_error", &format!("{e}"));
-        }
+        Err(response) => return *response,
     };
     if let Err(e) = state.token_manager.enforce_request_budget(&claims.sub) {
         return error_response(

--- a/src/subscription_proxy.rs
+++ b/src/subscription_proxy.rs
@@ -21,8 +21,8 @@ use std::collections::BTreeMap;
 
 use crate::metrics::Surface;
 use crate::proxy::{
-    AppState, error_response, extract_client_token, maybe_mpp_challenge, relay_response_headers,
-    request_routing_context, retry_after_duration,
+    AppState, error_response, maybe_mpp_challenge, relay_response_headers, request_routing_context,
+    retry_after_duration,
 };
 use crate::subscription::{SubscriptionProvider, SubscriptionToken};
 
@@ -90,22 +90,9 @@ async fn forward_subscription_openai_inner(
         return resp;
     }
 
-    let Some(token) = extract_client_token(headers) else {
-        return error_response(
-            StatusCode::UNAUTHORIZED,
-            "authentication_error",
-            "Missing Authorization Bearer token or x-api-key",
-        );
-    };
-    let claims = match state.token_manager.validate_token(token) {
+    let claims = match crate::proxy::authenticate_client(state, headers) {
         Ok(claims) => claims,
-        Err(e) => {
-            let status = match &e {
-                crate::token::TokenError::Revoked => StatusCode::FORBIDDEN,
-                _ => StatusCode::UNAUTHORIZED,
-            };
-            return error_response(status, "authentication_error", &format!("{e}"));
-        }
+        Err(response) => return *response,
     };
     if let Err(e) = state.token_manager.enforce_request_budget(&claims.sub) {
         return error_response(

--- a/src/token.rs
+++ b/src/token.rs
@@ -392,6 +392,24 @@ impl std::fmt::Display for TokenError {
     }
 }
 
+impl TokenError {
+    /// Stable message safe to return across the unauthenticated client boundary.
+    ///
+    /// Decoder and storage details remain available through [`std::fmt::Display`]
+    /// for server-side logs, but must not disclose parser internals to callers.
+    #[must_use]
+    pub const fn client_message(&self) -> &'static str {
+        match self {
+            Self::InvalidPrefix | Self::Invalid(_) => "invalid token",
+            Self::Expired => "Token has expired",
+            Self::Revoked => "Token has been revoked",
+            Self::InsufficientScope => "insufficient token scope",
+            Self::LimitExceeded => "Token has reached its request limit",
+            Self::Storage(_) => "token validation failed",
+        }
+    }
+}
+
 impl std::error::Error for TokenError {}
 
 #[cfg(test)]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -525,7 +525,7 @@ mod metrics_rendering_tests {
     use link_assistant_router::metrics::{Metrics, Surface, render_prometheus, usage_snapshot};
 
     #[test]
-    fn prometheus_output_contains_all_required_counters() {
+    fn prometheus_output_contains_only_aggregate_required_counters() {
         let m = Metrics::default();
         m.record_request(Surface::Anthropic, 200, Some("primary"));
         m.record_request(Surface::OpenAIChat, 429, Some("account-1"));
@@ -537,10 +537,11 @@ mod metrics_rendering_tests {
         assert!(out.contains("link_assistant_anthropic_messages_total"));
         assert!(out.contains("link_assistant_openai_chat_completions_total"));
         assert!(out.contains("link_assistant_tokens_issued_total"));
-        // Per-status + per-account labelled counters.
+        // Status codes are aggregate; account identities stay admin-only.
         assert!(out.contains("link_assistant_status_total{code=\"200\"}"));
         assert!(out.contains("link_assistant_status_total{code=\"429\"}"));
-        assert!(out.contains("link_assistant_account_calls_total{account=\"primary\"}"));
+        assert!(!out.contains("primary"));
+        assert!(!out.contains("account-1"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- keep `/metrics` unauthenticated while exposing aggregate counters only; token IDs, labels, and account names remain available through the admin-gated `/v1/usage` endpoint
- authenticate automatic-provider requests before parsing or routing their model body
- centralize client authentication and return stable client-safe token errors without exposing decoder or storage internals
- update observability documentation and add a patch security changelog fragment

## Reproduction and regression coverage

Before this change:

- public Prometheus output included token UUIDs, token labels, and upstream account names
- unauthenticated automatic-provider requests received distinguishable routing responses for known, unknown, and missing models
- differently malformed tokens exposed distinct decoder errors

The new regression tests verify that public metrics omit those identities while the admin usage snapshot retains its detail, automatic-provider requests authenticate before routing, and malformed client tokens receive the same sanitized response.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features`
- `cargo test --locked --all-features --verbose`
- `cargo test --locked --doc --verbose`
- `rust-script scripts/check-file-size.rs`
- `rust-script --test scripts/version-and-commit.rs`
- changelog-fragment and version-modification CI scripts
- `git diff --check origin/main...HEAD`

Fixes #131
