### PR TITLE
fix(proxy): enforce client dialect contracts

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-13T11:11:53.639Z for PR creation at branch issue-133-17788d217579 for issue https://github.com/link-assistant/router/issues/133

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-13T11:11:53.639Z for PR creation at branch issue-133-17788d217579 for issue https://github.com/link-assistant/router/issues/133

--- a/changelog.d/20260813_120000_dialect_contracts.md
+++ b/changelog.d/20260813_120000_dialect_contracts.md
@@ -1,0 +1,9 @@
+---
+bump: patch
+---
+
+### Fixed
+- Return JSON parse and Messages validation errors in the requesting API dialect.
+- Preserve terminal usage in translated streams and implement Chat Completions `include_usage` chunks.
+- Hide Codex subscription metadata and malformed upstream bodies while retaining safe quota headers.
+- Disclose when Codex cannot enforce the required Anthropic `max_tokens` field.

--- a/docs/use-cases/chatgpt-in-claude-code.md
+++ b/docs/use-cases/chatgpt-in-claude-code.md
@@ -145,7 +145,8 @@ Expect the Anthropic SSE vocabulary, in order: `message_start`,
 | `image` blocks | OpenAI image parts |
 | `tools` / `tool_choice` | OpenAI function tools |
 | `tool_use` / `tool_result` blocks | assistant `tool_calls` / `tool` messages |
-| `max_tokens`, `temperature`, `top_p`, `stop_sequences`, `stream` | direct equivalents |
+| `temperature`, `top_p`, `stop_sequences`, `stream` | direct equivalents |
+| `max_tokens` | forwarded when supported; see the Codex caveat below |
 | `stop_reason` | mapped from the OpenAI `finish_reason` |
 | `usage.input_tokens` / `output_tokens` | mapped from upstream usage when reported |
 
@@ -159,6 +160,12 @@ an approximation for budgeting, not as a billing figure.
   there is no OpenAI equivalent. Extended-thinking output will not appear.
 - **Prompt caching** (`cache_control`) has no counterpart upstream and is
   ignored.
+- **Codex cannot enforce `max_tokens`.** The field remains required by the
+  Anthropic Messages protocol, but the ChatGPT backend rejects its Responses
+  equivalent. Successful Codex-backed Messages responses therefore include
+  `x-link-assistant-output-limit: unsupported` and an HTTP `Warning` header;
+  callers that require a hard spend cap must select a provider that supports
+  one.
 - Anthropic-only beta features and vendor-specific fields are not emulated.
 - Token *estimates* replace exact `count_tokens` results (see above).
 - Cost and quota accounting are the upstream vendor's; the router only counts

--- a/src/anthropic_bridge.rs
+++ b/src/anthropic_bridge.rs
@@ -29,6 +29,9 @@ use crate::metrics::Surface;
 /// The Anthropic Messages API requires the field; `OpenAI` upstreams do not.
 pub(crate) const DEFAULT_MAX_TOKENS: u64 = 4096;
 
+/// Response header used when a required Messages limit cannot be enforced.
+pub const OUTPUT_LIMIT_HEADER: &str = "x-link-assistant-output-limit";
+
 /// Whether the Anthropic surface must be bridged for this upstream provider.
 ///
 /// `Anthropic` needs no translation, and `Gonka`/`Crater` keep the behaviour
@@ -570,6 +573,19 @@ pub async fn forward_anthropic_messages(
         }
         return anthropic_error(StatusCode::BAD_REQUEST, b"max_tokens is required");
     }
+    if anthropic_body
+        .get("messages")
+        .and_then(Value::as_array)
+        .is_none_or(Vec::is_empty)
+    {
+        if let Err(response) = count_tokens_claims(&state.token_manager, headers) {
+            return *response;
+        }
+        return anthropic_error(
+            StatusCode::BAD_REQUEST,
+            b"messages must contain at least one message",
+        );
+    }
     let requested_model = anthropic_body
         .get("model")
         .and_then(Value::as_str)
@@ -627,7 +643,20 @@ pub async fn forward_anthropic_messages(
         }
     };
 
-    translate_upstream_response(upstream, &requested_model, stream_requested).await
+    let mut response =
+        translate_upstream_response(upstream, &requested_model, stream_requested).await;
+    if state.upstream_provider == UpstreamProvider::Codex && response.status().is_success() {
+        response
+            .headers_mut()
+            .insert(OUTPUT_LIMIT_HEADER, HeaderValue::from_static("unsupported"));
+        response.headers_mut().insert(
+            "warning",
+            HeaderValue::from_static(
+                "299 link-assistant-router \"max_tokens is required by Messages but cannot be enforced by the Codex subscription backend\"",
+            ),
+        );
+    }
+    response
 }
 
 /// Convert the `OpenAI`-dialect response produced by a delegate forwarder into
@@ -644,7 +673,12 @@ async fn translate_upstream_response(
         let bytes = axum::body::to_bytes(body, 1024 * 1024)
             .await
             .unwrap_or_default();
-        return anthropic_error(status, &bytes);
+        let mut response = anthropic_error(status, &bytes);
+        *response.headers_mut() = parts.headers;
+        response
+            .headers_mut()
+            .insert("content-type", HeaderValue::from_static("application/json"));
+        return response;
     }
 
     if stream_requested {
@@ -661,13 +695,21 @@ async fn translate_upstream_response(
         }
     };
     let Ok(payload) = serde_json::from_slice::<Value>(&bytes) else {
-        return anthropic_error(StatusCode::BAD_GATEWAY, &bytes);
+        return anthropic_error(
+            StatusCode::BAD_GATEWAY,
+            b"Upstream returned a malformed response",
+        );
     };
-    (
+    let mut response = (
         StatusCode::OK,
         axum::Json(openai_json_to_anthropic_message(&payload, requested_model)),
     )
-        .into_response()
+        .into_response();
+    *response.headers_mut() = parts.headers;
+    response
+        .headers_mut()
+        .insert("content-type", HeaderValue::from_static("application/json"));
+    response
 }
 
 /// Wrap the upstream stream in an incremental Anthropic SSE translator.
@@ -706,6 +748,7 @@ fn anthropic_sse_response(body: Body, requested_model: &str, upstream: &HeaderMa
 
     let mut response = Response::new(Body::from_stream(stream));
     *response.status_mut() = StatusCode::OK;
+    *response.headers_mut() = crate::proxy::relay_response_headers(upstream);
     response.headers_mut().insert(
         "content-type",
         HeaderValue::from_static("text/event-stream"),
@@ -713,14 +756,6 @@ fn anthropic_sse_response(body: Body, requested_model: &str, upstream: &HeaderMa
     response
         .headers_mut()
         .insert("cache-control", HeaderValue::from_static("no-cache"));
-    // Relay rate-limit hints so clients keep seeing upstream back-pressure.
-    for name in ["retry-after", "x-ratelimit-remaining", "x-ratelimit-reset"] {
-        if let Some(value) = upstream.get(name) {
-            if let Ok(header) = axum::http::HeaderName::try_from(name) {
-                response.headers_mut().insert(header, value.clone());
-            }
-        }
-    }
     response
 }
 

--- a/src/anthropic_stream.rs
+++ b/src/anthropic_stream.rs
@@ -362,7 +362,10 @@ impl AnthropicStreamTranslator {
             &json!({
                 "type": "message_delta",
                 "delta": {"stop_reason": stop_reason, "stop_sequence": Value::Null},
-                "usage": {"output_tokens": self.output_tokens},
+                "usage": {
+                    "input_tokens": self.input_tokens,
+                    "output_tokens": self.output_tokens
+                },
             }),
         ));
         frames.push(anthropic_frame(

--- a/src/api_error.rs
+++ b/src/api_error.rs
@@ -1,0 +1,22 @@
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+
+/// Build the shared JSON error envelope used by all client API dialects.
+pub fn error_response(status: StatusCode, error_type: &str, message: &str) -> Response {
+    (
+        status,
+        axum::Json(serde_json::json!({
+            "type": "error",
+            "error": {"type": error_type, "message": message}
+        })),
+    )
+        .into_response()
+}
+
+pub fn malformed_json_response(error: &str) -> Response {
+    error_response(
+        StatusCode::BAD_REQUEST,
+        "invalid_request_error",
+        &format!("Failed to parse request body as JSON: {error}"),
+    )
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod admin_config;
 pub mod admin_ui;
 pub mod anthropic_bridge;
 pub mod anthropic_stream;
+mod api_error;
 pub mod app_state;
 pub mod audit;
 pub mod auth;

--- a/src/model_routing.rs
+++ b/src/model_routing.rs
@@ -248,7 +248,13 @@ pub async fn route_anthropic_request(
                 &format!("Failed to read request body: {error}"),
             )
         })?;
-    let routing_body = serde_json::from_slice(&body_bytes).unwrap_or(Value::Null);
+    let routing_body = serde_json::from_slice(&body_bytes).map_err(|error| {
+        crate::proxy::error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_request_error",
+            &format!("Failed to parse request body as JSON: {error}"),
+        )
+    })?;
     let routed = if path.ends_with("/messages") || path.ends_with("/messages/count_tokens") {
         route_state(state, &routing_body)
             .await
@@ -582,10 +588,10 @@ mod tests {
                 State(state),
                 Query(std::collections::BTreeMap::default()),
                 HeaderMap::new(),
-                axum::Json(json!({
+                Ok(axum::Json(json!({
                     "model": "totally-made-up-model-xyz",
                     "messages": [{"role": "user", "content": "hello"}]
-                })),
+                }))),
             )
             .await;
 

--- a/src/openai.rs
+++ b/src/openai.rs
@@ -273,6 +273,9 @@ pub struct OpenAIStreamTranslator {
     sent_chat_role: bool,
     sent_response_created: bool,
     sent_final: bool,
+    usage_requested: Option<()>,
+    input_tokens: u64,
+    output_tokens: u64,
     response_output_text: String,
 }
 
@@ -293,8 +296,18 @@ impl OpenAIStreamTranslator {
             sent_chat_role: false,
             sent_response_created: false,
             sent_final: false,
+            usage_requested: None,
+            input_tokens: 0,
+            output_tokens: 0,
             response_output_text: String::new(),
         }
+    }
+
+    /// Request a final Chat Completions usage chunk with empty choices.
+    #[must_use]
+    pub const fn with_include_usage(mut self, include_usage: bool) -> Self {
+        self.usage_requested = if include_usage { Some(()) } else { None };
+        self
     }
 
     /// Push raw upstream bytes and return zero or more `OpenAI` SSE frames.
@@ -331,6 +344,7 @@ impl OpenAIStreamTranslator {
         match event.get("type").and_then(Value::as_str) {
             Some("message_start") => {
                 self.capture_upstream_identity(event);
+                self.capture_anthropic_usage(event.pointer("/message/usage"));
                 if let Some(id) = event
                     .get("message")
                     .and_then(|m| m.get("id"))
@@ -393,19 +407,25 @@ impl OpenAIStreamTranslator {
                     _ => Vec::new(),
                 }
             }
-            Some("message_delta") => event
-                .get("delta")
-                .and_then(|d| d.get("stop_reason"))
-                .and_then(Value::as_str)
-                .map_or_else(Vec::new, |reason| {
-                    self.sent_final = true;
-                    vec![self.chat_frame(&json!({}), Some(map_finish_reason(reason)))]
-                }),
+            Some("message_delta") => {
+                self.capture_anthropic_usage(event.get("usage"));
+                event
+                    .get("delta")
+                    .and_then(|d| d.get("stop_reason"))
+                    .and_then(Value::as_str)
+                    .map_or_else(Vec::new, |reason| {
+                        self.sent_final = true;
+                        vec![self.chat_frame(&json!({}), Some(map_finish_reason(reason)))]
+                    })
+            }
             Some("message_stop") => {
                 let mut frames = Vec::new();
                 if !self.sent_final {
                     frames.push(self.chat_frame(&json!({}), Some("stop")));
                     self.sent_final = true;
+                }
+                if self.usage_requested.is_some() {
+                    frames.push(self.chat_usage_frame());
                 }
                 frames.push(done_frame());
                 frames
@@ -513,6 +533,35 @@ impl OpenAIStreamTranslator {
                 "finish_reason": finish_reason
             }]
         }))
+    }
+
+    fn chat_usage_frame(&self) -> String {
+        sse_frame(&json!({
+            "id": self.id,
+            "object": "chat.completion.chunk",
+            "created": self.created,
+            "model": self.served_model,
+            "choices": [],
+            "usage": {
+                "prompt_tokens": self.input_tokens,
+                "completion_tokens": self.output_tokens,
+                "total_tokens": self.input_tokens + self.output_tokens,
+            }
+        }))
+    }
+
+    fn capture_anthropic_usage(&mut self, usage: Option<&Value>) {
+        let Some(usage) = usage else {
+            return;
+        };
+        self.input_tokens = usage
+            .get("input_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(self.input_tokens);
+        self.output_tokens = usage
+            .get("output_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(self.output_tokens);
     }
 
     fn response_object(&self, status: &str, include_output: bool) -> Value {
@@ -853,58 +902,6 @@ mod tests {
                 .contains("rust")
         );
         assert_eq!(out["choices"][0]["finish_reason"], "tool_calls");
-    }
-
-    #[test]
-    fn translates_anthropic_text_stream_to_openai_chat_chunks() {
-        let mut translator =
-            OpenAIStreamTranslator::new(OpenAIStreamShape::ChatCompletion, "gpt-4o");
-        let frames = translator.push(
-            br#"event: message_start
-data: {"type":"message_start","message":{"id":"msg_1","model":"claude-sonnet-4-5-20250929"}}
-
-event: content_block_delta
-data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello"}}
-
-event: message_delta
-data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}
-
-event: message_stop
-data: {"type":"message_stop"}
-
-"#,
-        );
-        let joined = frames.join("");
-        assert!(joined.contains("\"object\":\"chat.completion.chunk\""));
-        assert!(joined.contains("\"role\":\"assistant\""));
-        assert!(joined.contains("\"content\":\"hello\""));
-        assert!(joined.contains("\"finish_reason\":\"stop\""));
-        assert!(joined.contains("\"model\":\"claude-sonnet-4-5-20250929\""));
-        assert!(joined.contains("data: [DONE]"));
-    }
-
-    #[test]
-    fn translates_anthropic_text_stream_to_openai_response_events() {
-        let mut translator = OpenAIStreamTranslator::new(OpenAIStreamShape::Response, "gpt-4o");
-        let frames = translator.push(
-            br#"event: message_start
-data: {"type":"message_start","message":{"id":"msg_1","model":"claude-sonnet-4-5-20250929"}}
-
-event: content_block_delta
-data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello"}}
-
-event: message_stop
-data: {"type":"message_stop"}
-
-"#,
-        );
-        let joined = frames.join("");
-        assert!(joined.contains("\"type\":\"response.created\""));
-        assert!(joined.contains("\"type\":\"response.output_text.delta\""));
-        assert!(joined.contains("\"delta\":\"hello\""));
-        assert!(joined.contains("\"type\":\"response.completed\""));
-        assert!(joined.contains("\"model\":\"claude-sonnet-4-5-20250929\""));
-        assert!(joined.contains("data: [DONE]"));
     }
 
     #[test]

--- a/src/openai_request_tests.rs
+++ b/src/openai_request_tests.rs
@@ -1,6 +1,82 @@
 use super::*;
 
 #[test]
+fn translates_anthropic_text_stream_to_openai_chat_chunks() {
+    let mut translator = OpenAIStreamTranslator::new(OpenAIStreamShape::ChatCompletion, "gpt-4o");
+    let frames = translator.push(
+        br#"event: message_start
+data: {"type":"message_start","message":{"id":"msg_1","model":"claude-sonnet-4-5-20250929"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello"}}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+"#,
+    );
+    let joined = frames.join("");
+    assert!(joined.contains("\"object\":\"chat.completion.chunk\""));
+    assert!(joined.contains("\"content\":\"hello\""));
+    assert!(joined.contains("\"finish_reason\":\"stop\""));
+    assert!(joined.contains("\"model\":\"claude-sonnet-4-5-20250929\""));
+    assert!(joined.contains("data: [DONE]"));
+}
+
+#[test]
+fn chat_stream_emits_usage_only_when_requested() {
+    let mut translator = OpenAIStreamTranslator::new(OpenAIStreamShape::ChatCompletion, "gpt-4o")
+        .with_include_usage(true);
+    let frames = translator.push(
+        br#"event: message_start
+data: {"type":"message_start","message":{"usage":{"input_tokens":7,"output_tokens":0}}}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":3}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+"#,
+    );
+    let usage = frames
+        .iter()
+        .filter_map(|frame| frame.strip_prefix("data: "))
+        .filter_map(|data| serde_json::from_str::<Value>(data.trim()).ok())
+        .find(|chunk| chunk["choices"].as_array().is_some_and(Vec::is_empty))
+        .expect("usage chunk");
+    assert_eq!(usage["usage"]["prompt_tokens"], 7);
+    assert_eq!(usage["usage"]["completion_tokens"], 3);
+    assert_eq!(usage["usage"]["total_tokens"], 10);
+}
+
+#[test]
+fn translates_anthropic_text_stream_to_openai_response_events() {
+    let mut translator = OpenAIStreamTranslator::new(OpenAIStreamShape::Response, "gpt-4o");
+    let frames = translator.push(
+        br#"event: message_start
+data: {"type":"message_start","message":{"id":"msg_1","model":"claude-sonnet-4-5-20250929"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello"}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+"#,
+    );
+    let joined = frames.join("");
+    assert!(joined.contains("\"type\":\"response.created\""));
+    assert!(joined.contains("\"type\":\"response.output_text.delta\""));
+    assert!(joined.contains("\"type\":\"response.completed\""));
+    assert!(joined.contains("\"model\":\"claude-sonnet-4-5-20250929\""));
+    assert!(joined.contains("data: [DONE]"));
+}
+
+#[test]
 fn translates_basic_chat_completion() {
     let req = OpenAIChatCompletionRequest {
         model: "gpt-4o".into(),

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -14,6 +14,7 @@
 #![allow(clippy::unused_async)]
 
 use axum::body::Body;
+use axum::extract::rejection::JsonRejection;
 use axum::extract::{Query, Request, State};
 use axum::http::{HeaderMap, HeaderValue, StatusCode};
 use axum::response::{IntoResponse, Response};
@@ -22,6 +23,8 @@ use log_lazy::LogLazy;
 use std::collections::{BTreeMap, HashSet};
 
 use crate::accounts::RoutingContext;
+pub(crate) use crate::api_error::error_response;
+use crate::api_error::malformed_json_response;
 pub use crate::app_state::AppState;
 use crate::config::UpstreamProvider;
 pub use crate::model_routing::models as openai_models;
@@ -107,6 +110,7 @@ pub(crate) fn relay_response_headers(headers: &HeaderMap) -> HeaderMap {
         let name_lower = name.as_str();
         if HOP_BY_HOP_HEADERS.contains(&name_lower)
             || RESPONSE_CREDENTIAL_HEADERS.contains(&name_lower)
+            || name_lower.starts_with("x-codex-")
             || name_lower == "content-length"
             || connection_headers.contains(name_lower)
         {
@@ -244,7 +248,10 @@ pub async fn proxy_handler(State(state): State<AppState>, req: Request) -> Respo
                 );
             }
         };
-        let body = serde_json::from_slice(&body_bytes).unwrap_or(serde_json::Value::Null);
+        let body = match serde_json::from_slice(&body_bytes) {
+            Ok(body) => body,
+            Err(error) => return malformed_json_response(&error.to_string()),
+        };
         return crate::anthropic_bridge::handle_anthropic_surface(
             &state,
             &incoming_headers,
@@ -295,7 +302,10 @@ pub async fn proxy_handler(State(state): State<AppState>, req: Request) -> Respo
             );
         }
     };
-    let routing_body = serde_json::from_slice(&body_bytes).unwrap_or(serde_json::Value::Null);
+    let routing_body = match serde_json::from_slice(&body_bytes) {
+        Ok(body) => body,
+        Err(error) => return malformed_json_response(&error.to_string()),
+    };
     crate::audit::record_authorised_request(
         &state,
         &claims,
@@ -553,8 +563,16 @@ pub async fn openai_chat_completions(
     State(state): State<AppState>,
     Query(query): Query<BTreeMap<String, String>>,
     headers: HeaderMap,
-    axum::Json(mut body): axum::Json<serde_json::Value>,
+    body: Result<axum::Json<serde_json::Value>, JsonRejection>,
 ) -> Response {
+    let mut body = match body {
+        Ok(axum::Json(body)) => body,
+        Err(error) => return malformed_json_response(&error.body_text()),
+    };
+    let include_usage = body
+        .pointer("/stream_options/include_usage")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
     let stream_from_query = openai::query_stream_requested(&query);
     if stream_from_query {
         body["stream"] = serde_json::json!(true);
@@ -641,8 +659,7 @@ pub async fn openai_chat_completions(
         body,
         &routing_body,
         crate::metrics::Surface::OpenAIChat,
-        stream_requested,
-        OpenAIShape::Chat,
+        (stream_requested, OpenAIShape::Chat, include_usage),
     )
     .await
 }
@@ -651,8 +668,12 @@ pub async fn openai_chat_completions(
 pub async fn openai_responses(
     State(state): State<AppState>,
     headers: HeaderMap,
-    axum::Json(body): axum::Json<serde_json::Value>,
+    body: Result<axum::Json<serde_json::Value>, JsonRejection>,
 ) -> Response {
+    let body = match body {
+        Ok(axum::Json(body)) => body,
+        Err(error) => return malformed_json_response(&error.body_text()),
+    };
     let state = match crate::model_routing::route_state(&state, &body).await {
         Ok(state) => state,
         Err(error) => return crate::model_routing::model_route_error_response(&error),
@@ -717,8 +738,7 @@ pub async fn openai_responses(
         body,
         &routing_body,
         crate::metrics::Surface::OpenAIResponses,
-        stream_requested,
-        OpenAIShape::Response,
+        (stream_requested, OpenAIShape::Response, false),
     )
     .await
 }
@@ -735,9 +755,9 @@ async fn forward_openai(
     body: serde_json::Value,
     routing_body: &serde_json::Value,
     surface: crate::metrics::Surface,
-    stream_requested: bool,
-    shape: OpenAIShape,
+    stream_options: (bool, OpenAIShape, bool),
 ) -> Response {
+    let (stream_requested, shape, include_usage) = stream_options;
     let served_model = body["model"].as_str().unwrap_or_default().to_string();
     let path = match shape {
         OpenAIShape::Chat => "/v1/chat/completions",
@@ -862,7 +882,8 @@ async fn forward_openai(
             OpenAIShape::Chat => openai::OpenAIStreamShape::ChatCompletion,
             OpenAIShape::Response => openai::OpenAIStreamShape::Response,
         };
-        let mut translator = openai::OpenAIStreamTranslator::new(stream_shape, &served_model);
+        let mut translator = openai::OpenAIStreamTranslator::new(stream_shape, &served_model)
+            .with_include_usage(include_usage);
         let response_log = std::sync::Arc::clone(&state.request_log);
         let stream = upstream_resp.bytes_stream().map(move |chunk| match chunk {
             Ok(bytes) => {
@@ -970,19 +991,4 @@ pub(crate) fn maybe_mpp_challenge(
         return Some(crate::mpp::unsupported_payment_verification());
     }
     Some(crate::mpp::payment_required(&state.mpp, path))
-}
-
-/// Build an Anthropic-format error response.
-pub(crate) fn error_response(status: StatusCode, error_type: &str, message: &str) -> Response {
-    (
-        status,
-        axum::Json(serde_json::json!({
-            "type": "error",
-            "error": {
-                "type": error_type,
-                "message": message
-            }
-        })),
-    )
-        .into_response()
 }

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -396,6 +396,10 @@ pub struct ResponsesChatStreamTranslator {
     buffer: String,
     sent_role: bool,
     sent_final: bool,
+    include_usage: bool,
+    input_tokens: u64,
+    output_tokens: u64,
+    total_tokens: u64,
     tool_indices: std::collections::BTreeSet<u64>,
 }
 
@@ -410,8 +414,19 @@ impl ResponsesChatStreamTranslator {
             buffer: String::new(),
             sent_role: false,
             sent_final: false,
+            include_usage: false,
+            input_tokens: 0,
+            output_tokens: 0,
+            total_tokens: 0,
             tool_indices: std::collections::BTreeSet::new(),
         }
+    }
+
+    /// Request the protocol's final empty-choices usage chunk.
+    #[must_use]
+    pub const fn with_include_usage(mut self, include_usage: bool) -> Self {
+        self.include_usage = include_usage;
+        self
     }
 
     /// Push raw upstream bytes and return complete Chat Completions SSE frames.
@@ -450,6 +465,7 @@ impl ResponsesChatStreamTranslator {
             Some("response.created") => {
                 if let Some(response) = event.get("response") {
                     self.capture_identity(response);
+                    self.capture_usage(response);
                 }
                 self.role_frame()
             }
@@ -488,6 +504,7 @@ impl ResponsesChatStreamTranslator {
                 }
                 if let Some(response) = event.get("response") {
                     self.capture_identity(response);
+                    self.capture_usage(response);
                 }
                 let finish_reason = if !self.tool_indices.is_empty() {
                     "tool_calls"
@@ -497,10 +514,12 @@ impl ResponsesChatStreamTranslator {
                     "stop"
                 };
                 self.sent_final = true;
-                vec![
-                    self.chat_frame(&json!({}), Some(finish_reason)),
-                    done_frame(),
-                ]
+                let mut frames = vec![self.chat_frame(&json!({}), Some(finish_reason))];
+                if self.include_usage {
+                    frames.push(self.usage_frame());
+                }
+                frames.push(done_frame());
+                frames
             }
             _ => Vec::new(),
         }
@@ -546,6 +565,24 @@ impl ResponsesChatStreamTranslator {
         }
     }
 
+    fn capture_usage(&mut self, response: &Value) {
+        let Some(usage) = response.get("usage") else {
+            return;
+        };
+        self.input_tokens = usage
+            .get("input_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(self.input_tokens);
+        self.output_tokens = usage
+            .get("output_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(self.output_tokens);
+        self.total_tokens = usage
+            .get("total_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(self.input_tokens + self.output_tokens);
+    }
+
     fn role_frame(&mut self) -> Vec<String> {
         if self.sent_role {
             Vec::new()
@@ -568,6 +605,24 @@ impl ResponsesChatStreamTranslator {
                     "delta": delta,
                     "finish_reason": finish_reason,
                 }]
+            })
+        )
+    }
+
+    fn usage_frame(&self) -> String {
+        format!(
+            "data: {}\n\n",
+            json!({
+                "id": self.id,
+                "object": "chat.completion.chunk",
+                "created": self.created,
+                "model": self.model,
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": self.input_tokens,
+                    "completion_tokens": self.output_tokens,
+                    "total_tokens": self.total_tokens,
+                }
             })
         )
     }
@@ -635,6 +690,10 @@ pub fn anthropic_to_response(anthropic: &Value, resolved_model: &str) -> Value {
         "usage": anthropic.get("usage").cloned().unwrap_or(Value::Null),
     })
 }
+
+#[cfg(test)]
+#[path = "responses_stream_tests.rs"]
+mod stream_tests;
 
 #[cfg(test)]
 mod tests {
@@ -863,38 +922,6 @@ mod tests {
         assert_eq!(out["usage"]["total_tokens"], 11);
         assert!(out.get("output").is_none());
         assert!(out.get("instructions").is_none());
-    }
-
-    #[test]
-    fn codex_response_stream_converts_to_chat_chunks() {
-        let mut translator = ResponsesChatStreamTranslator::new("gpt-5.6-sol");
-        let first = translator.push(
-            br#"event: response.created
-data: {"type":"response.created","response":{"id":"resp_1","created_at":1786448400,"model":"gpt-5.6-sol","status":"in_progress"}}
-
-event: response.output_text.delta
-data: {"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"content_index":0,"delta":"1"}
-
-"#,
-        );
-        let second = translator.push(
-            br#"event: response.output_text.delta
-data: {"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"content_index":0,"delta":"3"}
-
-event: response.completed
-data: {"type":"response.completed","response":{"id":"resp_1","created_at":1786448400,"model":"gpt-5.6-sol","status":"completed","output":[]}}
-
-"#,
-        );
-        let joined = first.into_iter().chain(second).collect::<String>();
-
-        assert!(joined.contains("\"object\":\"chat.completion.chunk\""));
-        assert!(joined.contains("\"role\":\"assistant\""));
-        assert!(joined.contains("\"content\":\"1\""));
-        assert!(joined.contains("\"content\":\"3\""));
-        assert!(joined.contains("\"finish_reason\":\"stop\""));
-        assert!(joined.ends_with("data: [DONE]\n\n"));
-        assert!(!joined.contains("response.output_text.delta"));
     }
 
     #[test]

--- a/src/responses_stream_tests.rs
+++ b/src/responses_stream_tests.rs
@@ -1,0 +1,53 @@
+use super::*;
+
+#[test]
+fn codex_response_stream_converts_to_chat_chunks() {
+    let mut translator = ResponsesChatStreamTranslator::new("gpt-5.6-sol");
+    let first = translator.push(
+        br#"event: response.created
+data: {"type":"response.created","response":{"id":"resp_1","created_at":1786448400,"model":"gpt-5.6-sol","status":"in_progress"}}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"content_index":0,"delta":"1"}
+
+"#,
+    );
+    let second = translator.push(
+        br#"event: response.output_text.delta
+data: {"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"content_index":0,"delta":"3"}
+
+event: response.completed
+data: {"type":"response.completed","response":{"id":"resp_1","created_at":1786448400,"model":"gpt-5.6-sol","status":"completed","output":[]}}
+
+"#,
+    );
+    let joined = first.into_iter().chain(second).collect::<String>();
+
+    assert!(joined.contains("\"object\":\"chat.completion.chunk\""));
+    assert!(joined.contains("\"role\":\"assistant\""));
+    assert!(joined.contains("\"content\":\"1\""));
+    assert!(joined.contains("\"content\":\"3\""));
+    assert!(joined.contains("\"finish_reason\":\"stop\""));
+    assert!(joined.ends_with("data: [DONE]\n\n"));
+    assert!(!joined.contains("response.output_text.delta"));
+}
+
+#[test]
+fn codex_chat_stream_emits_requested_usage_chunk() {
+    let mut translator = ResponsesChatStreamTranslator::new("gpt-5.6-sol").with_include_usage(true);
+    let frames = translator.push(
+        br#"event: response.completed
+data: {"type":"response.completed","response":{"id":"resp_1","model":"gpt-5.6-sol","usage":{"input_tokens":9,"output_tokens":2,"total_tokens":11}}}
+
+"#,
+    );
+    let usage = frames
+        .iter()
+        .filter_map(|frame| frame.strip_prefix("data: "))
+        .filter_map(|data| serde_json::from_str::<Value>(data.trim()).ok())
+        .find(|chunk| chunk["choices"].as_array().is_some_and(Vec::is_empty))
+        .expect("usage chunk");
+    assert_eq!(usage["usage"]["prompt_tokens"], 9);
+    assert_eq!(usage["usage"]["completion_tokens"], 2);
+    assert_eq!(usage["usage"]["total_tokens"], 11);
+}

--- a/src/subscription_proxy.rs
+++ b/src/subscription_proxy.rs
@@ -287,7 +287,12 @@ async fn forward_subscription_openai_inner(
             .get("model")
             .and_then(serde_json::Value::as_str)
             .unwrap_or_default();
-        let mut translator = crate::responses::ResponsesChatStreamTranslator::new(requested_model);
+        let include_usage = routing_body
+            .pointer("/stream_options/include_usage")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false);
+        let mut translator = crate::responses::ResponsesChatStreamTranslator::new(requested_model)
+            .with_include_usage(include_usage);
         let response_log = std::sync::Arc::clone(&state.request_log);
         let stream = upstream_resp.bytes_stream().map(move |chunk| {
             chunk.map_or_else(
@@ -952,7 +957,6 @@ mod tests {
         for relayed in [
             "retry-after",
             "x-ratelimit-remaining-requests",
-            "x-codex-active-limit",
             "x-oai-request-id",
             "content-type",
         ] {
@@ -965,6 +969,7 @@ mod tests {
             "connection",
             "x-remove-me",
             "content-length",
+            "x-codex-active-limit",
         ] {
             assert!(!selected.contains_key(excluded), "relayed {excluded}");
         }

--- a/tests/router_e2e_test.rs
+++ b/tests/router_e2e_test.rs
@@ -35,6 +35,7 @@ enum StubDialect {
 struct StubState {
     dialect: StubDialect,
     requests: Arc<Mutex<Vec<Value>>>,
+    invalid_body: bool,
 }
 
 struct TestRouter {
@@ -49,6 +50,10 @@ struct TestRouter {
 
 impl TestRouter {
     async fn start(provider: UpstreamProvider) -> Self {
+        Self::start_with_invalid_body(provider, false).await
+    }
+
+    async fn start_with_invalid_body(provider: UpstreamProvider, invalid_body: bool) -> Self {
         let data = tempfile::tempdir().expect("temporary test data");
         let dialect = if provider == UpstreamProvider::Codex {
             StubDialect::Codex
@@ -59,6 +64,7 @@ impl TestRouter {
         let stub_state = StubState {
             dialect,
             requests: Arc::clone(&requests),
+            invalid_body,
         };
         let stub = Router::new().fallback(stub_vendor).with_state(stub_state);
         let (stub_url, stub_task) = spawn(stub).await;
@@ -219,6 +225,12 @@ async fn stub_vendor(State(state): State<StubState>, request: Request) -> Respon
         .lock()
         .expect("stub request lock")
         .push(body.clone());
+
+    if state.invalid_body {
+        return Response::new(Body::from(
+            "internal safety_identifier and prompt_cache_key must stay private",
+        ));
+    }
 
     let stream = body.get("stream").and_then(Value::as_bool) == Some(true);
     let mut response = match state.dialect {
@@ -479,7 +491,8 @@ async fn codex_upstream_is_translated_and_relays_vendor_headers() {
         .await
         .expect("chat completion response");
     assert_eq!(response.status(), StatusCode::OK);
-    assert_eq!(response.headers()["x-codex-active-limit"], "primary");
+    assert!(response.headers().get("x-codex-active-limit").is_none());
+    assert_eq!(response.headers()["x-ratelimit-remaining-requests"], "41");
     assert_eq!(response.headers()["x-oai-request-id"], "req_stub_123");
     let chat: Value = response.json().await.expect("chat completion JSON");
     assert_eq!(chat["object"], "chat.completion");
@@ -494,6 +507,8 @@ async fn codex_upstream_is_translated_and_relays_vendor_headers() {
         .await
         .expect("Responses response");
     assert_eq!(response.status(), StatusCode::OK);
+    assert!(response.headers().get("x-codex-active-limit").is_none());
+    assert_eq!(response.headers()["x-ratelimit-remaining-requests"], "41");
     let responses: Value = response.json().await.expect("Responses JSON");
     assert_eq!(responses["object"], "response");
     assert!(responses["output"].is_array());
@@ -649,6 +664,22 @@ async fn codex_output_limit_policy_distinguishes_client_surfaces() {
         .await
         .expect("capped Codex Messages response");
     assert_eq!(messages.status(), StatusCode::OK);
+    assert!(messages.headers().get("x-codex-active-limit").is_none());
+    assert_eq!(messages.headers()["x-ratelimit-remaining-requests"], "41");
+    assert!(
+        messages
+            .headers()
+            .get("warning")
+            .and_then(|value| value.to_str().ok())
+            .is_some_and(|value| value.contains("max_tokens"))
+    );
+    assert_eq!(
+        messages
+            .headers()
+            .get("x-link-assistant-output-limit")
+            .and_then(|value| value.to_str().ok()),
+        Some("unsupported")
+    );
     let payload: Value = messages.json().await.expect("Messages JSON response");
     assert!(payload["content"].is_array());
 
@@ -723,4 +754,165 @@ async fn codex_output_limit_policy_distinguishes_client_surfaces() {
         1,
         "rejected requests must not reach the Codex subscription"
     );
+}
+
+#[tokio::test]
+async fn malformed_json_uses_each_http_surfaces_json_error_envelope() {
+    let router = TestRouter::start(UpstreamProvider::Codex).await;
+
+    for path in ["/v1/messages", "/v1/chat/completions", "/v1/responses"] {
+        let response = router
+            .client
+            .post(format!("{}{path}", router.url))
+            .bearer_auth(&router.token)
+            .header("content-type", "application/json")
+            .body(r#"{"model":"gpt-5",broken"#)
+            .send()
+            .await
+            .expect("malformed JSON response");
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{path}");
+        assert_eq!(
+            response
+                .headers()
+                .get("content-type")
+                .and_then(|value| value.to_str().ok()),
+            Some("application/json"),
+            "{path}"
+        );
+        let payload: Value = response.json().await.expect("JSON error envelope");
+        assert_eq!(payload["error"]["type"], "invalid_request_error", "{path}");
+        assert!(
+            payload["error"]["message"]
+                .as_str()
+                .is_some_and(|message| message.to_ascii_lowercase().contains("json")),
+            "{path}: {payload}"
+        );
+    }
+    assert!(router.requests.lock().expect("stub requests").is_empty());
+
+    let auto = TestRouter::start(UpstreamProvider::Auto).await;
+    let response = auto
+        .client
+        .post(format!("{}/v1/messages", auto.url))
+        .bearer_auth(&auto.token)
+        .header("content-type", "application/json")
+        .body(r#"{"model":"gpt-5",broken"#)
+        .send()
+        .await
+        .expect("automatic-routing malformed JSON response");
+    let payload: Value = response.json().await.expect("JSON error envelope");
+    assert_eq!(payload["error"]["type"], "invalid_request_error");
+    assert!(
+        payload["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.to_ascii_lowercase().contains("json"))
+    );
+}
+
+#[tokio::test]
+async fn empty_messages_is_reported_in_the_anthropic_dialect() {
+    let router = TestRouter::start(UpstreamProvider::Codex).await;
+
+    for body in [
+        json!({"model":"gpt-5","max_tokens":16,"messages":[]}),
+        json!({"model":"gpt-5","max_tokens":16}),
+    ] {
+        let response = router
+            .post("/v1/messages", &body)
+            .send()
+            .await
+            .expect("invalid Messages response");
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let payload: Value = response.json().await.expect("Anthropic error envelope");
+        assert_eq!(payload["error"]["type"], "invalid_request_error");
+        let message = payload["error"]["message"].as_str().expect("error message");
+        assert!(message.contains("messages"), "{message}");
+        for leaked in ["input", "previous_response_id", "prompt", "conversation"] {
+            assert!(!message.contains(leaked), "leaked {leaked}: {message}");
+        }
+    }
+    assert!(router.requests.lock().expect("stub requests").is_empty());
+}
+
+#[tokio::test]
+async fn translated_streams_preserve_usage_in_the_client_dialect() {
+    let router = TestRouter::start(UpstreamProvider::Codex).await;
+
+    let anthropic = router
+        .post(
+            "/v1/messages",
+            &json!({
+                "model":"gpt-5",
+                "max_tokens":16,
+                "messages":[{"role":"user","content":"hi"}],
+                "stream":true
+            }),
+        )
+        .send()
+        .await
+        .expect("Anthropic stream")
+        .text()
+        .await
+        .expect("Anthropic SSE body");
+    let message_delta = anthropic
+        .split("\n\n")
+        .filter_map(|block| block.lines().find_map(|line| line.strip_prefix("data: ")))
+        .filter_map(|data| serde_json::from_str::<Value>(data).ok())
+        .find(|event| event["type"] == "message_delta")
+        .expect("message_delta event");
+    assert_eq!(message_delta["usage"]["input_tokens"], 3);
+    assert_eq!(message_delta["usage"]["output_tokens"], 2);
+
+    let chat = router
+        .post(
+            "/v1/chat/completions",
+            &json!({
+                "model":"gpt-5",
+                "messages":[{"role":"user","content":"hi"}],
+                "stream":true,
+                "stream_options":{"include_usage":true}
+            }),
+        )
+        .send()
+        .await
+        .expect("Chat Completions stream")
+        .text()
+        .await
+        .expect("Chat SSE body");
+    let usage = chat
+        .split("\n\n")
+        .filter_map(|block| block.lines().find_map(|line| line.strip_prefix("data: ")))
+        .filter(|data| *data != "[DONE]")
+        .filter_map(|data| serde_json::from_str::<Value>(data).ok())
+        .find(|chunk| chunk["choices"].as_array().is_some_and(Vec::is_empty))
+        .expect("final usage chunk");
+    assert_eq!(usage["usage"]["prompt_tokens"], 3);
+    assert_eq!(usage["usage"]["completion_tokens"], 2);
+    assert_eq!(usage["usage"]["total_tokens"], 5);
+}
+
+#[tokio::test]
+async fn invalid_upstream_body_is_not_disclosed_to_anthropic_clients() {
+    let router = TestRouter::start_with_invalid_body(UpstreamProvider::Codex, true).await;
+    let response = router
+        .post(
+            "/v1/messages",
+            &json!({
+                "model":"gpt-5",
+                "max_tokens":16,
+                "messages":[{"role":"user","content":"hi"}]
+            }),
+        )
+        .send()
+        .await
+        .expect("invalid upstream response");
+    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+    let payload: Value = response.json().await.expect("Anthropic error envelope");
+    assert_eq!(
+        payload["error"]["message"],
+        "Upstream returned a malformed response"
+    );
+    let rendered = payload.to_string();
+    assert!(!rendered.contains("safety_identifier"));
+    assert!(!rendered.contains("prompt_cache_key"));
 }


### PR DESCRIPTION
## Summary

- return malformed JSON and Messages validation failures in the requesting API dialect
- preserve terminal usage in translated Anthropic and Chat Completions streams
- filter operator-only `x-codex-*` metadata on every client surface while retaining safe rate-limit headers
- replace malformed upstream payload disclosure with a fixed 502 error
- disclose the Codex `max_tokens` limitation through documented response headers

## Reproduction and regression coverage

The new E2E cases reproduce the v0.59.0 behavior with a Codex-compatible stub: empty or missing `messages`, malformed JSON on all three surfaces (including automatic routing), missing stream usage, leaked plan headers, silently ignored `max_tokens`, and raw malformed upstream bodies. Each case now asserts the client-facing contract and that invalid requests do not reach the upstream.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS=-Dwarnings cargo clippy --locked --all-targets --all-features`
- `cargo test --locked --all-features --verbose`
- `cargo test --locked --doc --verbose`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --locked --no-deps --all-features`
- `cargo build --locked --release --verbose`
- `cargo package --locked --list`
- file-size, changelog, version, and release-automation script checks
- `npm --prefix ui audit --audit-level=high`

Closes #133
