### PR TITLE
fix(storage): prevent concurrent token corruption

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-13T11:21:56.907Z for PR creation at branch issue-135-ce7088043612 for issue https://github.com/link-assistant/router/issues/135

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-13T11:21:56.907Z for PR creation at branch issue-135-ce7088043612 for issue https://github.com/link-assistant/router/issues/135

--- a/changelog.d/20260813_130000_concurrent_token_storage.md
+++ b/changelog.d/20260813_130000_concurrent_token_storage.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Fixed
+- Prevent concurrent requests from corrupting dual token stores or losing usage counts, and report storage failures as server errors instead of rate limits.

--- a/src/crater.rs
+++ b/src/crater.rs
@@ -536,11 +536,7 @@ pub async fn forward_chat_completions(
         }
     };
     if let Err(e) = state.token_manager.enforce_request_budget(&claims.sub) {
-        return crate::proxy::error_response(
-            StatusCode::TOO_MANY_REQUESTS,
-            "rate_limit_error",
-            &format!("{e}"),
-        );
+        return crate::proxy::token_budget_error_response(&e);
     }
     crate::audit::record_authorised_request(
         state,

--- a/src/gemini.rs
+++ b/src/gemini.rs
@@ -253,13 +253,7 @@ async fn route_gemini_token(
     state
         .token_manager
         .enforce_request_budget(&claims.sub)
-        .map_err(|error| {
-            error_response(
-                StatusCode::TOO_MANY_REQUESTS,
-                "rate_limit_error",
-                &error.to_string(),
-            )
-        })?;
+        .map_err(|error| crate::proxy::token_budget_error_response(&error))?;
     crate::audit::record_authorised_request(state, &claims, surface, path, Some(body));
     let pinned_account = state
         .token_manager

--- a/src/gonka.rs
+++ b/src/gonka.rs
@@ -143,11 +143,7 @@ pub(crate) async fn forward_openai(
         }
     };
     if let Err(e) = state.token_manager.enforce_request_budget(&claims.sub) {
-        return crate::proxy::error_response(
-            StatusCode::TOO_MANY_REQUESTS,
-            "rate_limit_error",
-            &format!("{e}"),
-        );
+        return crate::proxy::token_budget_error_response(&e);
     }
     crate::audit::record_authorised_request(state, &claims, surface, path, Some(&body));
 

--- a/src/provider_proxy.rs
+++ b/src/provider_proxy.rs
@@ -160,11 +160,7 @@ pub async fn forward_openai_compatible(
     // subscription ones, so a task token cannot escape its cap by being
     // pointed at an OpenAI-compatible gateway.
     if let Err(e) = state.token_manager.enforce_request_budget(&claims.sub) {
-        return error_response(
-            StatusCode::TOO_MANY_REQUESTS,
-            "rate_limit_error",
-            &format!("{e}"),
-        );
+        return crate::proxy::token_budget_error_response(&e);
     }
     crate::audit::record_authorised_request(state, &claims, surface, path, Some(&body));
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -276,11 +276,7 @@ pub async fn proxy_handler(State(state): State<AppState>, req: Request) -> Respo
         state
             .logger
             .debug(|| format!("Token budget check failed: {e}"));
-        return error_response(
-            StatusCode::TOO_MANY_REQUESTS,
-            "rate_limit_error",
-            &format!("{e}"),
-        );
+        return token_budget_error_response(&e);
     }
 
     // Read the body before account selection so the router gets a copy of
@@ -766,11 +762,7 @@ async fn forward_openai(
         }
     };
     if let Err(e) = state.token_manager.enforce_request_budget(&claims.sub) {
-        return error_response(
-            StatusCode::TOO_MANY_REQUESTS,
-            "rate_limit_error",
-            &format!("{e}"),
-        );
+        return token_budget_error_response(&e);
     }
     crate::audit::record_authorised_request(state, &claims, surface, path, Some(routing_body));
 
@@ -956,6 +948,26 @@ async fn forward_openai(
         .headers_mut()
         .insert("content-type", HeaderValue::from_static("application/json"));
     response
+}
+
+pub(crate) fn token_budget_error_response(error: &crate::token::TokenError) -> Response {
+    match error {
+        crate::token::TokenError::LimitExceeded => error_response(
+            StatusCode::TOO_MANY_REQUESTS,
+            "rate_limit_error",
+            &error.to_string(),
+        ),
+        crate::token::TokenError::Storage(_) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "storage_error",
+            &error.to_string(),
+        ),
+        _ => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "api_error",
+            &error.to_string(),
+        ),
+    }
 }
 
 pub(crate) fn maybe_mpp_challenge(

--- a/src/proxy_tests.rs
+++ b/src/proxy_tests.rs
@@ -1,9 +1,10 @@
-use axum::http::{HeaderMap, HeaderValue};
+use axum::http::{HeaderMap, HeaderValue, StatusCode};
+use http_body_util::BodyExt;
 use log_lazy::{LogLazy, levels};
 
 use crate::proxy::{
     OAUTH_BETA_FLAG, build_upstream_headers, extract_client_token, merge_oauth_beta,
-    request_routing_context, retry_after_duration,
+    request_routing_context, retry_after_duration, token_budget_error_response,
 };
 
 #[test]
@@ -145,4 +146,24 @@ fn retry_after_http_date_is_used_for_account_cooldown() {
     let parsed = retry_after_duration(&headers).unwrap();
     assert!(parsed >= std::time::Duration::from_secs(118));
     assert!(parsed <= std::time::Duration::from_secs(120));
+}
+
+#[tokio::test]
+async fn budget_errors_distinguish_limits_from_storage_failures() {
+    let limited = token_budget_error_response(&crate::token::TokenError::LimitExceeded);
+    assert_eq!(limited.status(), StatusCode::TOO_MANY_REQUESTS);
+    let body = limited.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&body).unwrap()["error"]["type"],
+        "rate_limit_error"
+    );
+
+    let failed =
+        token_budget_error_response(&crate::token::TokenError::Storage("disk full".into()));
+    assert_eq!(failed.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let body = failed.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&body).unwrap()["error"]["type"],
+        "storage_error"
+    );
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -36,7 +36,7 @@
 #![allow(clippy::significant_drop_tightening)]
 
 use std::collections::HashMap;
-use std::fs;
+use std::fs::{self, OpenOptions};
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
@@ -190,6 +190,11 @@ impl TokenStore for MemoryTokenStore {
         let mut guard = self.inner.write().map_err(|_| StorageError::LockPoisoned)?;
         Ok(guard.remove(id).is_some())
     }
+
+    fn try_consume_request(&self, id: &str) -> Result<bool, StorageError> {
+        let mut guard = self.inner.write().map_err(|_| StorageError::LockPoisoned)?;
+        Ok(consume_request(guard.get_mut(id)))
+    }
 }
 
 /// Lino-style text token store.
@@ -261,6 +266,15 @@ impl TokenStore for TextTokenStore {
             self.flush(&guard)?;
         }
         Ok(removed)
+    }
+
+    fn try_consume_request(&self, id: &str) -> Result<bool, StorageError> {
+        let mut guard = self.inner.write().map_err(|_| StorageError::LockPoisoned)?;
+        let permitted = consume_request(guard.get_mut(id));
+        if permitted && guard.contains_key(id) {
+            self.flush(&guard)?;
+        }
+        Ok(permitted)
     }
 }
 
@@ -346,6 +360,29 @@ impl TokenStore for BinaryTokenStore {
         }
         Ok(removed)
     }
+
+    fn try_consume_request(&self, id: &str) -> Result<bool, StorageError> {
+        let mut guard = self.inner.write().map_err(|_| StorageError::LockPoisoned)?;
+        let permitted = consume_request(guard.get_mut(id));
+        if permitted && guard.contains_key(id) {
+            self.flush(&guard)?;
+        }
+        Ok(permitted)
+    }
+}
+
+fn consume_request(record: Option<&mut TokenRecord>) -> bool {
+    let Some(record) = record else {
+        return true;
+    };
+    if record
+        .max_requests
+        .is_some_and(|max| record.used_requests >= max)
+    {
+        return false;
+    }
+    record.used_requests = record.used_requests.saturating_add(1);
+    true
 }
 
 fn decode_binary(path: &Path) -> Result<Vec<TokenRecord>, StorageError> {
@@ -417,6 +454,13 @@ impl TokenStore for DualTokenStore {
         let a = self.primary.delete(id)?;
         let b = self.secondary.delete(id)?;
         Ok(a || b)
+    }
+
+    fn try_consume_request(&self, id: &str) -> Result<bool, StorageError> {
+        if !self.primary.try_consume_request(id)? {
+            return Ok(false);
+        }
+        self.secondary.try_consume_request(id)
     }
 }
 
@@ -722,22 +766,49 @@ impl<'a> LinoTokens<'a> {
 }
 
 fn atomic_write(path: &Path, contents: &[u8]) -> Result<(), StorageError> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
+    let parent = path
+        .parent()
+        .ok_or_else(|| io::Error::other("storage path has no parent directory"))?;
+    fs::create_dir_all(parent)?;
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| io::Error::other("storage file name is not valid UTF-8"))?;
+    let tmp = parent.join(format!(
+        ".{file_name}.{}.{}.tmp",
+        std::process::id(),
+        uuid::Uuid::new_v4()
+    ));
+
+    let result = (|| -> Result<(), StorageError> {
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut file = options.open(&tmp)?;
+        file.write_all(contents)?;
+        file.sync_all()?;
+        if let Ok(metadata) = fs::metadata(path) {
+            fs::set_permissions(&tmp, metadata.permissions())?;
+        }
+        fs::rename(&tmp, path)?;
+        Ok(())
+    })();
+
+    if result.is_err() {
+        let _ = fs::remove_file(&tmp);
     }
-    let tmp = path.with_extension("tmp");
-    {
-        let mut f = fs::File::create(&tmp)?;
-        f.write_all(contents)?;
-        f.sync_all()?;
-    }
-    fs::rename(&tmp, path)?;
-    Ok(())
+    result
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Barrier;
+    use std::thread;
     use tempfile::tempdir;
 
     fn sample_record(id: &str) -> TokenRecord {
@@ -833,6 +904,42 @@ mod tests {
         dual.put(sample_record("a")).unwrap();
         assert_eq!(text.list().unwrap().len(), 1);
         assert_eq!(bin.list().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn dual_store_concurrent_consumption_is_atomic_and_preserves_formats() {
+        const REQUESTS: usize = 32;
+
+        let dir = tempdir().unwrap();
+        let store = build_token_store(StoragePolicy::Both, dir.path()).unwrap();
+        store.put(sample_record("shared")).unwrap();
+
+        let barrier = Arc::new(Barrier::new(REQUESTS));
+        let handles: Vec<_> = (0..REQUESTS)
+            .map(|_| {
+                let store = Arc::clone(&store);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    store.try_consume_request("shared")
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            assert!(handle.join().unwrap().unwrap());
+        }
+
+        let text = TextTokenStore::open(dir.path().join("tokens.lino")).unwrap();
+        let binary = BinaryTokenStore::open(dir.path().join("tokens.bin")).unwrap();
+        assert_eq!(
+            text.get("shared").unwrap().unwrap().used_requests,
+            REQUESTS as u64
+        );
+        assert_eq!(
+            binary.get("shared").unwrap().unwrap().used_requests,
+            REQUESTS as u64
+        );
     }
 
     #[test]

--- a/src/subscription_proxy.rs
+++ b/src/subscription_proxy.rs
@@ -108,11 +108,7 @@ async fn forward_subscription_openai_inner(
         }
     };
     if let Err(e) = state.token_manager.enforce_request_budget(&claims.sub) {
-        return error_response(
-            StatusCode::TOO_MANY_REQUESTS,
-            "rate_limit_error",
-            &format!("{e}"),
-        );
+        return crate::proxy::token_budget_error_response(&e);
     }
     crate::audit::record_authorised_request(state, &claims, surface, path, Some(routing_body));
 


### PR DESCRIPTION
## Summary

- make token-store temporary files unique per write so text and binary writers cannot collide
- make built-in request accounting atomic and keep both default stores synchronized
- return storage failures as `500 storage_error` while preserving genuine quota exhaustion as `429 rate_limit_error`
- add a patch changelog fragment

## Root cause and reproduction

With `StoragePolicy::Both`, `tokens.lino` and `tokens.bin` both derived the same `tokens.tmp` path. Concurrent writes could truncate or rename one another, leaving malformed data or an `ENOENT` storage error. The default `try_consume_request` implementation also performed separate get and put operations, allowing concurrent increments to be lost.

The new 32-thread regression test failed before the fix at the consume call with an `ENOENT` storage error. It now verifies that every request succeeds, both persisted formats reopen successfully, and both counters equal 32.

## Automated coverage

- `dual_store_concurrent_consumption_is_atomic_and_preserves_formats`
- `budget_errors_distinguish_limits_from_storage_failures`

## Verification

- `cargo fmt --all -- --check`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps`
- `cargo test --all-features --verbose`
- `cargo test --doc --all-features`
- repository file-size, changelog, version, release-workflow, Docker-platform, and packaging checks
- concurrent regression repeated 10 times
- `npm audit` in `ui` (0 vulnerabilities)

No UI behavior changed, so screenshots are not applicable.

Fixes #135
