### PR TITLE
fix(storage): adopt associative token stores

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-13T15:11:14.501Z for PR creation at branch issue-148-3cd968519599 for issue https://github.com/link-assistant/router/issues/148

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-13T15:11:14.501Z for PR creation at branch issue-148-3cd968519599 for issue https://github.com/link-assistant/router/issues/148

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c880a97d28a3681c0267bd29cff89621202715b065127cd445fa0f0fe0aa2880"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,6 +243,12 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "bitflags"
@@ -600,6 +612,22 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "doublets"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fec36305f729ca75677ebe6be2f45020a52894c32cac4842e18d4ad320f7a31f"
+dependencies = [
+ "cfg-if",
+ "leak_slice",
+ "platform-data",
+ "platform-mem",
+ "platform-num",
+ "platform-trees",
+ "tap",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "downcast-rs"
@@ -1363,6 +1391,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "leak_slice"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecf3387da9fb41906394e1306ddd3cd26dd9b7177af11c19b45b364b743aed26"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1391,6 +1425,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "doublets",
  "futures-util",
  "getrandom 0.4.2",
  "hex",
@@ -1399,8 +1434,11 @@ dependencies = [
  "hyper",
  "hyper-util",
  "jsonwebtoken",
+ "links-notation",
  "lino-arguments",
+ "lino-objects-codec",
  "log-lazy",
+ "platform-mem",
  "portable-pty",
  "reqwest",
  "rust-embed",
@@ -1416,6 +1454,15 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "links-notation"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c952b42a8c6ff6f849d7cafe3b1e13f1063a51bbb144bc6c62026ab327814c"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -1437,6 +1484,16 @@ name = "lino-env"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f453c53827aabe91a3d3856d61d14ae3867ab1a4344db22f9fa5396664c8d0e"
+
+[[package]]
+name = "lino-objects-codec"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4db12a09a113afcfa4bd1ba32e76b5e4cb22a37b8d3f130b198f8c14dded0ad0"
+dependencies = [
+ "base64",
+ "links-notation",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1493,6 +1550,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1529,6 +1595,15 @@ dependencies = [
  "cfg-if",
  "cfg_aliases 0.1.1",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1674,6 +1749,47 @@ checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
+]
+
+[[package]]
+name = "platform-data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6782bc71345465116de96d250a36dcf49336010a2320d958d12a5d4390186c90"
+dependencies = [
+ "beef",
+ "platform-num",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "platform-mem"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27cff7c92440ac926c8c91ea3151db6e52a262f602d0c157f254e422fc15b12"
+dependencies = [
+ "allocator-api2",
+ "memmap2",
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "platform-num"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ca8e18138b1c90ad802aff931f946a0e6bd760c35af30f1ff2489489ab54a"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "platform-trees"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40e25a531617fa762c8505826c930f6c1cfcc226f63dea09882b56ae0b8ed078"
+dependencies = [
+ "platform-num",
 ]
 
 [[package]]
@@ -2478,6 +2594,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,9 @@ tower = { version = "0.5", features = ["util"] }
 tempfile = "3"
 
 [lints.rust]
-unsafe_code = "forbid"
+# The file-mapping compatibility adapter has a scoped exception; unsafe code
+# remains denied throughout the rest of the crate.
+unsafe_code = "deny"
 
 [lints.clippy]
 all = { level = "warn", priority = -1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,10 @@ futures-util = "0.3"
 http = "1.4"
 http-body-util = "0.1"
 lino-arguments = "0.3"
+lino-objects-codec = "0.2.1"
+links-notation = "0.13.0"
+doublets = "0.4.0"
+mem = { package = "platform-mem", version = "0.3.0" }
 clap = { version = "4", features = ["derive", "env"] }
 base64 = "0.22"
 async-trait = "0.1"

--- a/README.md
+++ b/README.md
@@ -669,6 +669,30 @@ The HTTP API accepts the same shape at `POST /api/providers`:
 | `--session-affinity-ttl-secs` / `SESSION_AFFINITY_TTL_SECS` | `3600` | Inactive seconds before a conversation can be assigned again; `0` disables affinity |
 | `--account-request-limits` / `ACCOUNT_REQUEST_LIMITS` | (unknown) | Comma-separated request caps, primary first then extras; must match pool size, and `0` means unknown/unlimited |
 
+#### Storage formats and ownership
+
+Router-owned token state uses the associative stack. `tokens.lino` is a
+portable Links Notation projection produced by `lino-objects-codec`, with each
+record represented as `Type → SubType → Value`. `tokens.bin` is the same
+semantic graph in a native `doublets` store backed by file-mapped
+`platform-mem`. The `text`, `binary`, and default `both` policies select those
+two projections; `memory` remains non-persistent. Hand-built `tokens.lino`
+files and `LARTOK01` JSON containers from earlier releases are loaded and
+atomically converted on first open.
+
+Other files keep the format of the boundary they serve:
+
+- Provider/client credentials and client settings such as
+  `.credentials.json`, `auth.json`, `settings.json`, and `config.toml` are
+  vendor-owned interoperability files. The router continues to read or update
+  the vendor's expected shape.
+- `requests.jsonl` and the optional audit JSONL are append-only operational
+  streams intended for log collectors and standard text tooling, rather than
+  mutable router domain state.
+- `providers.lenv` is the router's existing portable provider configuration
+  interchange. Moving additional router-owned state onto doublets can be done
+  independently of the token migration.
+
 ### Feature toggles
 
 | Flag / env | Default | Description |

--- a/changelog.d/20260813_150000_associative_token_storage.md
+++ b/changelog.d/20260813_150000_associative_token_storage.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+### Fixed
+
+- Persist token state as official Links Notation and a native file-mapped doublets graph, with automatic migration from the legacy hand-built text and `LARTOK01` JSON formats.

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,9 +1,7 @@
 //! Token persistence backends.
 //!
-//! Issue #7 requires that the router persist issued tokens with **two**
-//! formats by default — a Lino-style text encoding (so humans can audit
-//! the token database with a text editor) **and** a binary encoding that
-//! is compatible with the `link-cli` storage layer.
+//! Issued-token state can be persisted as real Links Notation text, a native
+//! file-mapped doublets graph, or both.
 //!
 //! This module provides:
 //!
@@ -11,15 +9,11 @@
 //!   listing, persisting, and revoking [`TokenRecord`]s.
 //! - [`MemoryTokenStore`] — an in-memory implementation, used in tests and
 //!   for [`StoragePolicy::Memory`].
-//! - [`TextTokenStore`] — persists records as a Lino-style text file at
-//!   `<data_dir>/tokens.lino`. This is the format recommended by
-//!   `lino-objects-codec`. We implement a minimal subset of the encoder
-//!   internally so we don't depend on the (currently unpublished) crate.
-//! - [`BinaryTokenStore`] — persists records as a length-prefixed
-//!   binary file at `<data_dir>/tokens.bin`. The format is intentionally
-//!   simple and round-trippable; it interoperates with `link-cli` when
-//!   the optional CLI backend adapter is wired up but does not require
-//!   `clink` to be installed.
+//! - [`TextTokenStore`] — persists records through `lino-objects-codec` at
+//!   `<data_dir>/tokens.lino`.
+//! - [`BinaryTokenStore`] — persists the same `Type → SubType → Value` graph
+//!   in a `doublets` store backed by `platform-mem` at
+//!   `<data_dir>/tokens.bin`.
 //! - [`DualTokenStore`] — fans writes out to two stores (typically text +
 //!   binary) and reads from the *first* store, falling back to the second
 //!   on miss. This is the default when [`StoragePolicy::Both`] is set.
@@ -37,13 +31,18 @@
 
 use std::collections::HashMap;
 use std::fs::{self, OpenOptions};
-use std::io::{self, Read, Write};
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 
 use serde::{Deserialize, Serialize};
 
 use crate::config::StoragePolicy;
+
+mod associative;
+#[allow(unsafe_code)]
+mod file_mapped;
+mod legacy;
 
 /// One persisted token record.
 ///
@@ -197,18 +196,10 @@ impl TokenStore for MemoryTokenStore {
     }
 }
 
-/// Lino-style text token store.
+/// Links Notation text token store.
 ///
-/// File layout (one record per line):
-///
-/// ```text
-/// (token <id> (label "<label>") (issued_at <iat>) (expires_at <exp>) (revoked <bool>) (account "<account>"))
-/// ```
-///
-/// We use a hand-rolled encoder so we don't depend on the unpublished
-/// `lino-objects-codec` crate. The shape mirrors Lino syntax (parens, atoms
-/// and quoted strings) and round-trips cleanly via the encoder/decoder
-/// helpers in this module.
+/// Existing hand-built files are read once and atomically migrated to the
+/// official `lino-objects-codec` representation.
 #[derive(Clone)]
 pub struct TextTokenStore {
     path: PathBuf,
@@ -221,23 +212,34 @@ impl TextTokenStore {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
-        let records = if path.exists() {
+        let (records, migrated) = if path.exists() {
             let contents = fs::read_to_string(&path)?;
-            decode_lino(&contents).map_err(StorageError::Codec)?
+            match associative::decode_text(&contents) {
+                Ok(records) => (records, false),
+                Err(_) => (
+                    legacy::decode_text(&contents).map_err(StorageError::Codec)?,
+                    true,
+                ),
+            }
         } else {
-            Vec::new()
+            (Vec::new(), false)
         };
         let map: HashMap<_, _> = records.into_iter().map(|r| (r.id.clone(), r)).collect();
-        Ok(Self {
+        let store = Self {
             path,
             inner: Arc::new(RwLock::new(map)),
-        })
+        };
+        if migrated {
+            let guard = store.inner.read().map_err(|_| StorageError::LockPoisoned)?;
+            store.flush(&guard)?;
+        }
+        Ok(store)
     }
 
     fn flush(&self, guard: &HashMap<String, TokenRecord>) -> Result<(), StorageError> {
         let mut sorted: Vec<&TokenRecord> = guard.values().collect();
         sorted.sort_by(|a, b| a.id.cmp(&b.id));
-        let body = encode_lino(sorted.iter().copied());
+        let body = associative::encode_text(sorted.iter().copied());
         atomic_write(&self.path, body.as_bytes())
     }
 }
@@ -278,28 +280,15 @@ impl TokenStore for TextTokenStore {
     }
 }
 
-/// Length-prefixed binary token store.
+/// Native file-mapped doublets token store.
 ///
-/// File layout:
-/// ```text
-/// magic = b"LARTOK01"  // 8 bytes
-/// repeat:
-///     u32 LE record_len
-///     <record_len> bytes of JSON-encoded TokenRecord
-/// ```
-///
-/// JSON-on-binary is intentional: it keeps the format trivially auditable
-/// and round-trippable while still being length-prefixed and
-/// non-text-editor-friendly enough that operators won't accidentally edit
-/// it. An optional CLI backend adapter can substitute a `clink`-driven
-/// implementation when configured.
+/// Existing `LARTOK01` length-prefixed JSON files are read once and
+/// atomically migrated to the doublets representation.
 #[derive(Clone)]
 pub struct BinaryTokenStore {
     path: PathBuf,
     inner: Arc<RwLock<HashMap<String, TokenRecord>>>,
 }
-
-const BIN_MAGIC: &[u8; 8] = b"LARTOK01";
 
 impl BinaryTokenStore {
     pub fn open(path: impl Into<PathBuf>) -> Result<Self, StorageError> {
@@ -307,31 +296,31 @@ impl BinaryTokenStore {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
-        let records = if path.exists() {
-            decode_binary(&path)?
+        let (records, migrated) = if path.exists() {
+            if legacy::is_binary(&path)? {
+                (legacy::decode_binary(&path)?, true)
+            } else {
+                (associative::read_binary(&path)?, false)
+            }
         } else {
-            Vec::new()
+            (Vec::new(), false)
         };
         let map: HashMap<_, _> = records.into_iter().map(|r| (r.id.clone(), r)).collect();
-        Ok(Self {
+        let store = Self {
             path,
             inner: Arc::new(RwLock::new(map)),
-        })
+        };
+        if migrated {
+            let guard = store.inner.read().map_err(|_| StorageError::LockPoisoned)?;
+            store.flush(&guard)?;
+        }
+        Ok(store)
     }
 
     fn flush(&self, guard: &HashMap<String, TokenRecord>) -> Result<(), StorageError> {
         let mut sorted: Vec<&TokenRecord> = guard.values().collect();
         sorted.sort_by(|a, b| a.id.cmp(&b.id));
-        let mut buf: Vec<u8> = Vec::with_capacity(8 + sorted.len() * 128);
-        buf.extend_from_slice(BIN_MAGIC);
-        for rec in sorted {
-            let json = serde_json::to_vec(rec).map_err(|e| StorageError::Codec(e.to_string()))?;
-            let len = u32::try_from(json.len())
-                .map_err(|_| StorageError::Codec("record too large".into()))?;
-            buf.extend_from_slice(&len.to_le_bytes());
-            buf.extend_from_slice(&json);
-        }
-        atomic_write(&self.path, &buf)
+        associative::write_binary(&self.path, sorted)
     }
 }
 
@@ -383,36 +372,6 @@ fn consume_request(record: Option<&mut TokenRecord>) -> bool {
     }
     record.used_requests = record.used_requests.saturating_add(1);
     true
-}
-
-fn decode_binary(path: &Path) -> Result<Vec<TokenRecord>, StorageError> {
-    let mut f = fs::File::open(path)?;
-    let mut magic = [0u8; 8];
-    if let Err(e) = f.read_exact(&mut magic) {
-        if e.kind() == io::ErrorKind::UnexpectedEof {
-            return Ok(Vec::new());
-        }
-        return Err(e.into());
-    }
-    if &magic != BIN_MAGIC {
-        return Err(StorageError::Codec("invalid binary magic header".into()));
-    }
-    let mut out = Vec::new();
-    loop {
-        let mut len_buf = [0u8; 4];
-        match f.read_exact(&mut len_buf) {
-            Ok(()) => {}
-            Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => break,
-            Err(e) => return Err(e.into()),
-        }
-        let len = u32::from_le_bytes(len_buf) as usize;
-        let mut data = vec![0u8; len];
-        f.read_exact(&mut data)?;
-        let rec: TokenRecord =
-            serde_json::from_slice(&data).map_err(|e| StorageError::Codec(e.to_string()))?;
-        out.push(rec);
-    }
-    Ok(out)
 }
 
 /// Dual-write store: every mutation goes to *both* primary and secondary;
@@ -487,281 +446,6 @@ pub fn build_token_store(
                 secondary: binary,
             }))
         }
-    }
-}
-
-// =====================================================================
-// Lino-style text codec
-// =====================================================================
-
-fn encode_lino<'a>(records: impl IntoIterator<Item = &'a TokenRecord>) -> String {
-    let mut out = String::new();
-    out.push_str("# Link.Assistant.Router token store\n");
-    out.push_str("# Format: (token <id> (label \"...\") ...)\n");
-    for rec in records {
-        out.push('(');
-        out.push_str("token ");
-        out.push_str(&rec.id);
-        out.push_str(" (label ");
-        write_quoted(&mut out, &rec.label);
-        out.push_str(") (issued_at ");
-        out.push_str(&rec.issued_at.to_string());
-        out.push_str(") (expires_at ");
-        out.push_str(&rec.expires_at.to_string());
-        out.push_str(") (revoked ");
-        out.push_str(if rec.revoked { "true" } else { "false" });
-        out.push(')');
-        if let Some(ref acc) = rec.account {
-            out.push_str(" (account ");
-            write_quoted(&mut out, acc);
-            out.push(')');
-        }
-        if let Some(max) = rec.max_requests {
-            out.push_str(" (max_requests ");
-            out.push_str(&max.to_string());
-            out.push(')');
-        }
-        if rec.used_requests > 0 {
-            out.push_str(" (used_requests ");
-            out.push_str(&rec.used_requests.to_string());
-            out.push(')');
-        }
-        if !rec.scope.is_empty() {
-            out.push_str(" (scope ");
-            write_quoted(&mut out, &rec.scope);
-            out.push(')');
-        }
-        out.push_str(")\n");
-    }
-    out
-}
-
-fn write_quoted(out: &mut String, s: &str) {
-    out.push('"');
-    for ch in s.chars() {
-        match ch {
-            '"' => out.push_str("\\\""),
-            '\\' => out.push_str("\\\\"),
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
-            c => out.push(c),
-        }
-    }
-    out.push('"');
-}
-
-fn decode_lino(input: &str) -> Result<Vec<TokenRecord>, String> {
-    let mut out = Vec::new();
-    for raw in input.lines() {
-        let line = raw.trim();
-        if line.is_empty() || line.starts_with('#') {
-            continue;
-        }
-        out.push(parse_record_line(line)?);
-    }
-    Ok(out)
-}
-
-fn parse_record_line(line: &str) -> Result<TokenRecord, String> {
-    // Expected outer shape: (token <id> <fields...>)
-    let inner = line
-        .strip_prefix('(')
-        .and_then(|s| s.strip_suffix(')'))
-        .ok_or_else(|| format!("expected parens around record: {line}"))?
-        .trim();
-    let mut tokens = LinoTokens::new(inner);
-    let kind = tokens
-        .next_atom()
-        .ok_or_else(|| "missing record kind".to_string())?;
-    if kind != "token" {
-        return Err(format!("unexpected record kind: {kind}"));
-    }
-    let id = tokens
-        .next_atom()
-        .ok_or_else(|| "missing token id".to_string())?
-        .to_string();
-    let mut label = String::new();
-    let mut issued_at = 0i64;
-    let mut expires_at = 0i64;
-    let mut revoked = false;
-    let mut account: Option<String> = None;
-    let mut max_requests: Option<u64> = None;
-    let mut used_requests: u64 = 0;
-    let mut scope = String::new();
-    while let Some(field) = tokens.next_paren_group() {
-        let mut inner = LinoTokens::new(field);
-        let key = inner
-            .next_atom()
-            .ok_or_else(|| "field missing key".to_string())?;
-        match key {
-            "label" => {
-                label = inner
-                    .next_string()
-                    .ok_or_else(|| "label missing value".to_string())?;
-            }
-            "issued_at" => {
-                let v = inner
-                    .next_atom()
-                    .ok_or_else(|| "issued_at missing value".to_string())?;
-                issued_at = v
-                    .parse()
-                    .map_err(|e: std::num::ParseIntError| e.to_string())?;
-            }
-            "expires_at" => {
-                let v = inner
-                    .next_atom()
-                    .ok_or_else(|| "expires_at missing value".to_string())?;
-                expires_at = v
-                    .parse()
-                    .map_err(|e: std::num::ParseIntError| e.to_string())?;
-            }
-            "revoked" => {
-                let v = inner
-                    .next_atom()
-                    .ok_or_else(|| "revoked missing value".to_string())?;
-                revoked = matches!(v, "true" | "1" | "yes");
-            }
-            "account" => {
-                account = inner.next_string();
-            }
-            "max_requests" => {
-                let v = inner
-                    .next_atom()
-                    .ok_or_else(|| "max_requests missing value".to_string())?;
-                max_requests = Some(
-                    v.parse()
-                        .map_err(|e: std::num::ParseIntError| e.to_string())?,
-                );
-            }
-            "used_requests" => {
-                let v = inner
-                    .next_atom()
-                    .ok_or_else(|| "used_requests missing value".to_string())?;
-                used_requests = v
-                    .parse()
-                    .map_err(|e: std::num::ParseIntError| e.to_string())?;
-            }
-            "scope" => {
-                scope = inner.next_string().unwrap_or_default();
-            }
-            other => return Err(format!("unknown field: {other}")),
-        }
-    }
-    Ok(TokenRecord {
-        id,
-        label,
-        issued_at,
-        expires_at,
-        revoked,
-        account,
-        max_requests,
-        used_requests,
-        scope,
-    })
-}
-
-struct LinoTokens<'a> {
-    rest: &'a str,
-}
-
-impl<'a> LinoTokens<'a> {
-    const fn new(input: &'a str) -> Self {
-        Self { rest: input }
-    }
-
-    fn skip_ws(&mut self) {
-        self.rest = self.rest.trim_start();
-    }
-
-    fn next_atom(&mut self) -> Option<&'a str> {
-        self.skip_ws();
-        if self.rest.is_empty() || self.rest.starts_with('(') || self.rest.starts_with('"') {
-            return None;
-        }
-        let end = self
-            .rest
-            .find(|c: char| c.is_whitespace() || c == '(' || c == ')')
-            .unwrap_or(self.rest.len());
-        let (atom, rest) = self.rest.split_at(end);
-        self.rest = rest;
-        Some(atom)
-    }
-
-    fn next_string(&mut self) -> Option<String> {
-        self.skip_ws();
-        let bytes = self.rest.as_bytes();
-        if bytes.first() != Some(&b'"') {
-            return None;
-        }
-        let mut out = String::new();
-        let mut i = 1usize;
-        while i < bytes.len() {
-            let c = bytes[i];
-            if c == b'\\' && i + 1 < bytes.len() {
-                let esc = bytes[i + 1];
-                match esc {
-                    b'"' => out.push('"'),
-                    b'\\' => out.push('\\'),
-                    b'n' => out.push('\n'),
-                    b'r' => out.push('\r'),
-                    b't' => out.push('\t'),
-                    other => out.push(other as char),
-                }
-                i += 2;
-            } else if c == b'"' {
-                self.rest = &self.rest[i + 1..];
-                return Some(out);
-            } else {
-                out.push(c as char);
-                i += 1;
-            }
-        }
-        None
-    }
-
-    fn next_paren_group(&mut self) -> Option<&'a str> {
-        self.skip_ws();
-        if !self.rest.starts_with('(') {
-            return None;
-        }
-        let bytes = self.rest.as_bytes();
-        let mut depth = 0i32;
-        let mut in_str = false;
-        let mut escape = false;
-        let mut end = 0usize;
-        for (idx, &b) in bytes.iter().enumerate() {
-            if escape {
-                escape = false;
-                continue;
-            }
-            if in_str {
-                match b {
-                    b'\\' => escape = true,
-                    b'"' => in_str = false,
-                    _ => {}
-                }
-                continue;
-            }
-            match b {
-                b'"' => in_str = true,
-                b'(' => depth += 1,
-                b')' => {
-                    depth -= 1;
-                    if depth == 0 {
-                        end = idx + 1;
-                        break;
-                    }
-                }
-                _ => {}
-            }
-        }
-        if end == 0 {
-            return None;
-        }
-        let group = &self.rest[1..end - 1];
-        self.rest = &self.rest[end..];
-        Some(group)
     }
 }
 
@@ -973,7 +657,7 @@ mod tests {
         dual.put(sample_record("d")).unwrap();
         // both files updated
         let text_contents = std::fs::read_to_string(dir.path().join("tokens.lino")).unwrap();
-        assert!(text_contents.contains("(token d "));
+        assert_eq!(associative::decode_text(&text_contents).unwrap()[0].id, "d");
     }
 
     #[test]
@@ -989,8 +673,8 @@ mod tests {
             used_requests: 7,
             scope: crate::token::ADMIN_SCOPE.to_string(),
         };
-        let s = encode_lino(std::iter::once(&rec));
-        let parsed = decode_lino(&s).unwrap();
+        let s = associative::encode_text(std::iter::once(&rec));
+        let parsed = associative::decode_text(&s).unwrap();
         assert_eq!(parsed.len(), 1);
         assert_eq!(parsed[0], rec);
     }

--- a/src/storage/associative.rs
+++ b/src/storage/associative.rs
@@ -1,0 +1,665 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::fs::{self, OpenOptions};
+use std::path::{Path, PathBuf};
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD_NO_PAD;
+use doublets::{Doublets, DoubletsExt, Links, unit};
+use lino_objects_codec::LinoValue;
+
+use super::file_mapped::LoadedFileMapped;
+use super::{StorageError, TokenRecord};
+
+const TYPE: &str = "Type";
+const TOKEN_RECORD: &str = "TokenRecord";
+const SUBTYPE: &str = "SubType";
+const VALUE: &str = "Value";
+const STORAGE_FORMAT: &str = "StorageFormat";
+const FORMAT_VERSION: &str = "router-token-doublets-v1";
+const RECORD_PREFIX: &str = "Record/";
+
+const STRING_TAG: usize = 1;
+const EDGE_TAG: usize = 2;
+const EMPTY_SEQUENCE: usize = 3;
+const BYTE_NODE_START: usize = 4;
+const SCHEMA_NODE_COUNT: usize = 259;
+
+type FileStore = unit::Store<usize, LoadedFileMapped>;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct SemanticLink {
+    source: String,
+    target: String,
+}
+
+impl SemanticLink {
+    fn new(source: impl Into<String>, target: impl Into<String>) -> Self {
+        Self {
+            source: source.into(),
+            target: target.into(),
+        }
+    }
+}
+
+pub(super) fn encode_text<'a>(records: impl IntoIterator<Item = &'a TokenRecord>) -> String {
+    let records = records
+        .into_iter()
+        .map(record_to_lino_value)
+        .collect::<Vec<_>>();
+    lino_objects_codec::encode(&LinoValue::object([
+        ("type", LinoValue::String("RouterState".into())),
+        ("subtype", LinoValue::String("TokenStore".into())),
+        ("value", LinoValue::Array(records)),
+    ]))
+}
+
+pub(super) fn decode_text(input: &str) -> Result<Vec<TokenRecord>, String> {
+    let root = lino_objects_codec::decode(input).map_err(|error| error.to_string())?;
+    expect_string_field(&root, "type", "token store")?
+        .eq("RouterState")
+        .then_some(())
+        .ok_or_else(|| "token store type must be RouterState".to_string())?;
+    expect_string_field(&root, "subtype", "token store")?
+        .eq("TokenStore")
+        .then_some(())
+        .ok_or_else(|| "token store subtype must be TokenStore".to_string())?;
+    let records = object_field(&root, "value", "token store")?;
+    let LinoValue::Array(records) = records else {
+        return Err("token store value must be an array".into());
+    };
+    records.iter().map(record_from_lino_value).collect()
+}
+
+fn record_to_lino_value(record: &TokenRecord) -> LinoValue {
+    LinoValue::object([
+        ("type", LinoValue::String(TOKEN_RECORD.into())),
+        ("subtype", LinoValue::String(record.id.clone())),
+        (
+            "value",
+            LinoValue::object([
+                ("id", LinoValue::String(record.id.clone())),
+                ("label", LinoValue::String(record.label.clone())),
+                ("issued_at", LinoValue::Int(record.issued_at)),
+                ("expires_at", LinoValue::Int(record.expires_at)),
+                ("revoked", LinoValue::Bool(record.revoked)),
+                (
+                    "account",
+                    record
+                        .account
+                        .as_ref()
+                        .map_or(LinoValue::Null, |value| LinoValue::String(value.clone())),
+                ),
+                (
+                    "max_requests",
+                    record.max_requests.map_or(LinoValue::Null, |value| {
+                        LinoValue::String(value.to_string())
+                    }),
+                ),
+                (
+                    "used_requests",
+                    LinoValue::String(record.used_requests.to_string()),
+                ),
+                ("scope", LinoValue::String(record.scope.clone())),
+            ]),
+        ),
+    ])
+}
+
+fn record_from_lino_value(value: &LinoValue) -> Result<TokenRecord, String> {
+    if expect_string_field(value, "type", "record")? != TOKEN_RECORD {
+        return Err("record type must be TokenRecord".into());
+    }
+    let subtype = expect_string_field(value, "subtype", "record")?;
+    let fields = object_field(value, "value", "record")?;
+    let id = expect_string_field(fields, "id", "record value")?.to_string();
+    if subtype != id {
+        return Err("record subtype must match its id".into());
+    }
+    Ok(TokenRecord {
+        id,
+        label: expect_string_field(fields, "label", "record value")?.to_string(),
+        issued_at: expect_i64_field(fields, "issued_at", "record value")?,
+        expires_at: expect_i64_field(fields, "expires_at", "record value")?,
+        revoked: expect_bool_field(fields, "revoked", "record value")?,
+        account: optional_string_field(fields, "account", "record value")?,
+        max_requests: optional_u64_field(fields, "max_requests", "record value")?,
+        used_requests: expect_u64_field(fields, "used_requests", "record value")?,
+        scope: expect_string_field(fields, "scope", "record value")?.to_string(),
+    })
+}
+
+fn object_field<'a>(
+    value: &'a LinoValue,
+    key: &str,
+    context: &str,
+) -> Result<&'a LinoValue, String> {
+    let LinoValue::Object(fields) = value else {
+        return Err(format!("{context} must be an object"));
+    };
+    fields
+        .iter()
+        .find_map(|(field, value)| (field == key).then_some(value))
+        .ok_or_else(|| format!("{context} is missing {key}"))
+}
+
+fn expect_string_field<'a>(
+    value: &'a LinoValue,
+    key: &str,
+    context: &str,
+) -> Result<&'a str, String> {
+    match object_field(value, key, context)? {
+        LinoValue::String(value) => Ok(value),
+        _ => Err(format!("{context}.{key} must be a string")),
+    }
+}
+
+fn expect_i64_field(value: &LinoValue, key: &str, context: &str) -> Result<i64, String> {
+    match object_field(value, key, context)? {
+        LinoValue::Int(value) => Ok(*value),
+        _ => Err(format!("{context}.{key} must be an integer")),
+    }
+}
+
+fn expect_bool_field(value: &LinoValue, key: &str, context: &str) -> Result<bool, String> {
+    match object_field(value, key, context)? {
+        LinoValue::Bool(value) => Ok(*value),
+        _ => Err(format!("{context}.{key} must be a boolean")),
+    }
+}
+
+fn expect_u64_field(value: &LinoValue, key: &str, context: &str) -> Result<u64, String> {
+    expect_string_field(value, key, context)?
+        .parse()
+        .map_err(|error| format!("{context}.{key} is invalid: {error}"))
+}
+
+fn optional_string_field(
+    value: &LinoValue,
+    key: &str,
+    context: &str,
+) -> Result<Option<String>, String> {
+    match object_field(value, key, context)? {
+        LinoValue::Null => Ok(None),
+        LinoValue::String(value) => Ok(Some(value.clone())),
+        _ => Err(format!("{context}.{key} must be a string or null")),
+    }
+}
+
+fn optional_u64_field(value: &LinoValue, key: &str, context: &str) -> Result<Option<u64>, String> {
+    match object_field(value, key, context)? {
+        LinoValue::Null => Ok(None),
+        LinoValue::String(value) => value
+            .parse()
+            .map(Some)
+            .map_err(|error| format!("{context}.{key} is invalid: {error}")),
+        _ => Err(format!("{context}.{key} must be a string or null")),
+    }
+}
+
+pub(super) fn write_binary<'a>(
+    path: &Path,
+    records: impl IntoIterator<Item = &'a TokenRecord>,
+) -> Result<(), StorageError> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| std::io::Error::other("storage path has no parent directory"))?;
+    fs::create_dir_all(parent)?;
+    let tmp = temporary_path(path)?;
+    let result = (|| {
+        let mut options = OpenOptions::new();
+        options.read(true).write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let file = options.open(&tmp)?;
+        let mapped = LoadedFileMapped::new(file)?;
+        let mut store = unit::Store::<usize, _>::new(mapped)
+            .map_err(|error| codec_error("initialize doublets store", error))?;
+        write_semantic_links(&mut store, records)?;
+        drop(store);
+        OpenOptions::new().read(true).open(&tmp)?.sync_all()?;
+        if let Ok(metadata) = fs::metadata(path) {
+            fs::set_permissions(&tmp, metadata.permissions())?;
+        }
+        fs::rename(&tmp, path)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(tmp);
+    }
+    result
+}
+
+pub(super) fn read_binary(path: &Path) -> Result<Vec<TokenRecord>, StorageError> {
+    let file = OpenOptions::new().read(true).write(true).open(path)?;
+    let mapped = LoadedFileMapped::new(file)?;
+    let store = unit::Store::<usize, _>::new(mapped)
+        .map_err(|error| codec_error("open doublets store", error))?;
+    let links = read_semantic_links(&store)?;
+    links_to_records(&links).map_err(StorageError::Codec)
+}
+
+fn write_semantic_links<'a>(
+    store: &mut FileStore,
+    records: impl IntoIterator<Item = &'a TokenRecord>,
+) -> Result<(), StorageError> {
+    initialize_schema(store)?;
+    let mut links = BTreeSet::from([
+        SemanticLink::new(STORAGE_FORMAT, FORMAT_VERSION),
+        SemanticLink::new(TYPE, TOKEN_RECORD),
+        SemanticLink::new(TOKEN_RECORD, SUBTYPE),
+        SemanticLink::new(SUBTYPE, VALUE),
+    ]);
+    for record in records {
+        links.extend(record_to_links(record));
+    }
+    let mut string_nodes = HashMap::new();
+    for link in links {
+        let source = intern_string(store, &mut string_nodes, &link.source)?;
+        let target = intern_string(store, &mut string_nodes, &link.target)?;
+        let pair = store
+            .create_link(source, target)
+            .map_err(|error| codec_error("create semantic pair", error))?;
+        store
+            .create_link(EDGE_TAG, pair)
+            .map_err(|error| codec_error("mark semantic pair", error))?;
+    }
+    Ok(())
+}
+
+fn initialize_schema(store: &mut FileStore) -> Result<(), StorageError> {
+    for expected in 1..=SCHEMA_NODE_COUNT {
+        let actual = store
+            .create_point()
+            .map_err(|error| codec_error("create doublets schema point", error))?;
+        if actual != expected {
+            return Err(StorageError::Codec(format!(
+                "unexpected doublets schema point {actual}; expected {expected}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn intern_string(
+    store: &mut FileStore,
+    nodes: &mut HashMap<String, usize>,
+    value: &str,
+) -> Result<usize, StorageError> {
+    if let Some(node) = nodes.get(value) {
+        return Ok(*node);
+    }
+    let mut sequence = EMPTY_SEQUENCE;
+    for byte in value.as_bytes().iter().rev() {
+        sequence = store
+            .create_link(BYTE_NODE_START + usize::from(*byte), sequence)
+            .map_err(|error| codec_error("encode string byte", error))?;
+    }
+    let node = store
+        .create_link(STRING_TAG, sequence)
+        .map_err(|error| codec_error("encode string node", error))?;
+    nodes.insert(value.to_string(), node);
+    Ok(node)
+}
+
+fn read_semantic_links(store: &FileStore) -> Result<BTreeSet<SemanticLink>, StorageError> {
+    validate_schema(store)?;
+    let any = store.constants().any;
+    let mut strings = HashMap::new();
+    let mut links = BTreeSet::new();
+    for marker in store.each_iter([any, EDGE_TAG, any]) {
+        if marker.index == EDGE_TAG {
+            continue;
+        }
+        let pair = store
+            .get_link(marker.target)
+            .ok_or_else(|| StorageError::Codec("semantic edge points to a missing pair".into()))?;
+        let source = decode_string(store, pair.source, &mut strings)?;
+        let target = decode_string(store, pair.target, &mut strings)?;
+        links.insert(SemanticLink::new(source, target));
+    }
+    if !links.contains(&SemanticLink::new(STORAGE_FORMAT, FORMAT_VERSION)) {
+        return Err(StorageError::Codec(
+            "doublets store has an unsupported token schema".into(),
+        ));
+    }
+    Ok(links)
+}
+
+fn validate_schema(store: &FileStore) -> Result<(), StorageError> {
+    for expected in 1..=SCHEMA_NODE_COUNT {
+        let point = store.get_link(expected).ok_or_else(|| {
+            StorageError::Codec(format!("doublets schema is incomplete at point {expected}"))
+        })?;
+        if point.index != expected || point.source != expected || point.target != expected {
+            return Err(StorageError::Codec(
+                "doublets schema contains an invalid point".into(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn decode_string(
+    store: &FileStore,
+    node: usize,
+    cache: &mut HashMap<usize, String>,
+) -> Result<String, StorageError> {
+    if let Some(value) = cache.get(&node) {
+        return Ok(value.clone());
+    }
+    let string = store
+        .get_link(node)
+        .ok_or_else(|| StorageError::Codec("semantic edge points to a missing string".into()))?;
+    if string.source != STRING_TAG {
+        return Err(StorageError::Codec(
+            "semantic edge points to a non-string node".into(),
+        ));
+    }
+    let mut bytes = Vec::new();
+    let mut sequence = string.target;
+    let mut visited = HashSet::new();
+    while sequence != EMPTY_SEQUENCE {
+        if !visited.insert(sequence) {
+            return Err(StorageError::Codec("cyclic string sequence".into()));
+        }
+        let part = store
+            .get_link(sequence)
+            .ok_or_else(|| StorageError::Codec("string sequence is incomplete".into()))?;
+        let Some(byte) = part.source.checked_sub(BYTE_NODE_START) else {
+            return Err(StorageError::Codec(
+                "string sequence has an invalid byte".into(),
+            ));
+        };
+        bytes.push(
+            u8::try_from(byte)
+                .map_err(|_| StorageError::Codec("string sequence has an invalid byte".into()))?,
+        );
+        sequence = part.target;
+    }
+    let value = String::from_utf8(bytes)
+        .map_err(|error| StorageError::Codec(format!("string is not UTF-8: {error}")))?;
+    cache.insert(node, value.clone());
+    Ok(value)
+}
+
+fn record_to_links(record: &TokenRecord) -> BTreeSet<SemanticLink> {
+    let root = record_root(&record.id);
+    let subtype = format!("{root}/{SUBTYPE}");
+    let value = format!("{root}/{VALUE}");
+    let mut links = BTreeSet::from([
+        SemanticLink::new(&root, TYPE),
+        SemanticLink::new(&root, &subtype),
+        SemanticLink::new(&subtype, encoded_value_node(&subtype, &record.id)),
+        SemanticLink::new(&root, &value),
+    ]);
+    add_field(&mut links, &value, "id", &record.id);
+    add_field(&mut links, &value, "label", &record.label);
+    add_field(
+        &mut links,
+        &value,
+        "issued_at",
+        &record.issued_at.to_string(),
+    );
+    add_field(
+        &mut links,
+        &value,
+        "expires_at",
+        &record.expires_at.to_string(),
+    );
+    add_field(&mut links, &value, "revoked", &record.revoked.to_string());
+    if let Some(account) = &record.account {
+        add_field(&mut links, &value, "account", account);
+    }
+    if let Some(max_requests) = record.max_requests {
+        add_field(
+            &mut links,
+            &value,
+            "max_requests",
+            &max_requests.to_string(),
+        );
+    }
+    add_field(
+        &mut links,
+        &value,
+        "used_requests",
+        &record.used_requests.to_string(),
+    );
+    add_field(&mut links, &value, "scope", &record.scope);
+    links
+}
+
+fn add_field(links: &mut BTreeSet<SemanticLink>, value: &str, name: &str, raw: &str) {
+    let field = format!("{value}/Field/{name}");
+    links.insert(SemanticLink::new(value, &field));
+    links.insert(SemanticLink::new(&field, encoded_value_node(&field, raw)));
+}
+
+fn encoded_value_node(parent: &str, raw: &str) -> String {
+    format!("{parent}/Value/{}", STANDARD_NO_PAD.encode(raw))
+}
+
+fn decode_value_node(parent: &str, node: &str) -> Result<String, String> {
+    let prefix = format!("{parent}/Value/");
+    let encoded = node
+        .strip_prefix(&prefix)
+        .ok_or_else(|| format!("value node is not below {parent}"))?;
+    let bytes = STANDARD_NO_PAD
+        .decode(encoded)
+        .map_err(|error| format!("value node is invalid base64: {error}"))?;
+    String::from_utf8(bytes).map_err(|error| format!("value node is not UTF-8: {error}"))
+}
+
+fn record_root(id: &str) -> String {
+    format!("{RECORD_PREFIX}{}", STANDARD_NO_PAD.encode(id))
+}
+
+fn links_to_records(links: &BTreeSet<SemanticLink>) -> Result<Vec<TokenRecord>, String> {
+    for edge in [
+        SemanticLink::new(TYPE, TOKEN_RECORD),
+        SemanticLink::new(TOKEN_RECORD, SUBTYPE),
+        SemanticLink::new(SUBTYPE, VALUE),
+    ] {
+        if !links.contains(&edge) {
+            return Err("token doublets graph is missing Type -> SubType -> Value schema".into());
+        }
+    }
+    links
+        .iter()
+        .filter(|link| link.target == TYPE && link.source.starts_with(RECORD_PREFIX))
+        .map(|link| record_from_links(&link.source, links))
+        .collect()
+}
+
+fn record_from_links(root: &str, links: &BTreeSet<SemanticLink>) -> Result<TokenRecord, String> {
+    let subtype = format!("{root}/{SUBTYPE}");
+    if !links.contains(&SemanticLink::new(root, &subtype)) {
+        return Err(format!("record {root} is missing its SubType relation"));
+    }
+    let subtype_value = one_target(links, &subtype)?;
+    let subtype_id = decode_value_node(&subtype, subtype_value)?;
+    let value = format!("{root}/{VALUE}");
+    if !links.contains(&SemanticLink::new(root, &value)) {
+        return Err(format!("record {root} is missing its Value relation"));
+    }
+    let fields = field_values(links, &value)?;
+    let id = required_field(&fields, "id")?.to_string();
+    let encoded_id = root
+        .strip_prefix(RECORD_PREFIX)
+        .ok_or_else(|| format!("record root {root} has an invalid prefix"))?;
+    let root_id = String::from_utf8(
+        STANDARD_NO_PAD
+            .decode(encoded_id)
+            .map_err(|error| format!("record root {root} has an invalid id: {error}"))?,
+    )
+    .map_err(|error| format!("record root {root} id is not UTF-8: {error}"))?;
+    if id != subtype_id || id != root_id {
+        return Err(format!(
+            "record {root} identity relations do not match its id"
+        ));
+    }
+    Ok(TokenRecord {
+        id,
+        label: required_field(&fields, "label")?.to_string(),
+        issued_at: parse_field(&fields, "issued_at")?,
+        expires_at: parse_field(&fields, "expires_at")?,
+        revoked: parse_field(&fields, "revoked")?,
+        account: fields.get("account").cloned(),
+        max_requests: optional_parsed_field(&fields, "max_requests")?,
+        used_requests: parse_field(&fields, "used_requests")?,
+        scope: required_field(&fields, "scope")?.to_string(),
+    })
+}
+
+fn field_values(
+    links: &BTreeSet<SemanticLink>,
+    value: &str,
+) -> Result<BTreeMap<String, String>, String> {
+    let prefix = format!("{value}/Field/");
+    let mut fields = BTreeMap::new();
+    for link in links.iter().filter(|link| link.source == value) {
+        let Some(name) = link.target.strip_prefix(&prefix) else {
+            continue;
+        };
+        let raw = decode_value_node(&link.target, one_target(links, &link.target)?)?;
+        if fields.insert(name.to_string(), raw).is_some() {
+            return Err(format!("record has duplicate {name} field"));
+        }
+    }
+    Ok(fields)
+}
+
+fn one_target<'a>(links: &'a BTreeSet<SemanticLink>, source: &str) -> Result<&'a str, String> {
+    let mut targets = links
+        .iter()
+        .filter_map(|link| (link.source == source).then_some(link.target.as_str()));
+    let target = targets
+        .next()
+        .ok_or_else(|| format!("{source} has no value"))?;
+    if targets.next().is_some() {
+        return Err(format!("{source} has multiple values"));
+    }
+    Ok(target)
+}
+
+fn required_field<'a>(fields: &'a BTreeMap<String, String>, name: &str) -> Result<&'a str, String> {
+    fields
+        .get(name)
+        .map(String::as_str)
+        .ok_or_else(|| format!("record is missing {name}"))
+}
+
+fn parse_field<T>(fields: &BTreeMap<String, String>, name: &str) -> Result<T, String>
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+{
+    required_field(fields, name)?
+        .parse()
+        .map_err(|error| format!("record {name} is invalid: {error}"))
+}
+
+fn optional_parsed_field<T>(
+    fields: &BTreeMap<String, String>,
+    name: &str,
+) -> Result<Option<T>, String>
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+{
+    fields
+        .get(name)
+        .map(|value| {
+            value
+                .parse()
+                .map_err(|error| format!("record {name} is invalid: {error}"))
+        })
+        .transpose()
+}
+
+fn temporary_path(path: &Path) -> Result<PathBuf, StorageError> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| std::io::Error::other("storage path has no parent directory"))?;
+    let name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| std::io::Error::other("storage file name is not valid UTF-8"))?;
+    Ok(parent.join(format!(
+        ".{name}.{}.{}.tmp",
+        std::process::id(),
+        uuid::Uuid::new_v4()
+    )))
+}
+
+fn codec_error(context: &str, error: impl std::fmt::Debug) -> StorageError {
+    StorageError::Codec(format!("{context}: {error:?}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn sample_record() -> TokenRecord {
+        TokenRecord {
+            id: "id/with spaces".into(),
+            label: "label with \"quotes\" and a newline\n".into(),
+            issued_at: i64::MIN,
+            expires_at: i64::MAX,
+            revoked: true,
+            account: Some(String::new()),
+            max_requests: Some(u64::MAX),
+            used_requests: u64::MAX,
+            scope: "admin".into(),
+        }
+    }
+
+    #[test]
+    fn semantic_reduction_is_lossless() {
+        let record = sample_record();
+        let mut links = BTreeSet::from([
+            SemanticLink::new(STORAGE_FORMAT, FORMAT_VERSION),
+            SemanticLink::new(TYPE, TOKEN_RECORD),
+            SemanticLink::new(TOKEN_RECORD, SUBTYPE),
+            SemanticLink::new(SUBTYPE, VALUE),
+        ]);
+        links.extend(record_to_links(&record));
+
+        assert_eq!(links_to_records(&links).unwrap(), vec![record]);
+    }
+
+    #[test]
+    fn official_lino_codec_roundtrip_is_lossless() {
+        let record = sample_record();
+        let encoded = encode_text(std::iter::once(&record));
+
+        assert_eq!(decode_text(&encoded).unwrap(), vec![record]);
+    }
+
+    #[test]
+    fn native_doublets_graph_reopens_across_growth_boundary() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("tokens.bin");
+        let mut record = sample_record();
+        record.label = "large associative value".repeat(500);
+        write_binary(&path, std::iter::once(&record)).unwrap();
+
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&path)
+            .unwrap();
+        let memory = LoadedFileMapped::new(file).unwrap();
+        let graph = unit::Store::<usize, _>::new(memory).unwrap();
+        assert!(
+            graph.count() > 8 * 1024,
+            "fixture must cross the upstream bootstrap page boundary"
+        );
+        drop(graph);
+
+        assert_eq!(read_binary(&path).unwrap(), vec![record]);
+    }
+}

--- a/src/storage/associative.rs
+++ b/src/storage/associative.rs
@@ -219,7 +219,13 @@ pub(super) fn write_binary<'a>(
             .map_err(|error| codec_error("initialize doublets store", error))?;
         write_semantic_links(&mut store, records)?;
         drop(store);
-        OpenOptions::new().read(true).open(&tmp)?.sync_all()?;
+        // Windows requires a writable handle for FlushFileBuffers, which is
+        // what File::sync_all uses after the memory map has been dropped.
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&tmp)?
+            .sync_all()?;
         if let Ok(metadata) = fs::metadata(path) {
             fs::set_permissions(&tmp, metadata.permissions())?;
         }

--- a/src/storage/file_mapped.rs
+++ b/src/storage/file_mapped.rs
@@ -1,0 +1,91 @@
+//! Compatibility adapter for `doublets` 0.4 and `platform-mem` 0.3.
+//!
+//! `FileMapped` starts with a logical capacity of zero even when its file
+//! already contains data. `doublets::unit::Store::new` consequently treats a
+//! reopened file as empty. This adapter restores the mapped capacity and
+//! preserves it across the store's initial bootstrap resize.
+
+use std::fs::File;
+use std::io;
+use std::mem::{MaybeUninit, size_of};
+
+use doublets::parts::LinkPart;
+use mem::{FileMapped, RawMem};
+
+const DOUBLETS_BOOTSTRAP_ITEMS: usize = 8 * 1024;
+
+pub(super) struct LoadedFileMapped {
+    inner: FileMapped<LinkPart<usize>>,
+    preserve_bootstrap: bool,
+}
+
+impl LoadedFileMapped {
+    pub(super) fn new(file: File) -> io::Result<Self> {
+        let bytes = usize::try_from(file.metadata()?.len())
+            .map_err(|_| io::Error::other("mapped file is too large for this platform"))?;
+        if bytes % size_of::<LinkPart<usize>>() != 0 && bytes >= 4096 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "mapped file length is not aligned to a doublets link part",
+            ));
+        }
+        let mut inner = FileMapped::new(file)?;
+        let items = bytes.max(4096) / size_of::<LinkPart<usize>>();
+
+        // SAFETY: LinkPart<usize> is repr(C), consists solely of usize fields,
+        // and every bit pattern is valid. The mapped bytes came from the same
+        // native doublets store on this platform.
+        unsafe {
+            inner.grow_assumed(items).map_err(platform_mem_error)?;
+        }
+        Ok(Self {
+            inner,
+            preserve_bootstrap: items > DOUBLETS_BOOTSTRAP_ITEMS,
+        })
+    }
+}
+
+impl RawMem for LoadedFileMapped {
+    type Item = LinkPart<usize>;
+
+    fn allocated(&self) -> &[Self::Item] {
+        self.inner.allocated()
+    }
+
+    fn allocated_mut(&mut self) -> &mut [Self::Item] {
+        self.inner.allocated_mut()
+    }
+
+    unsafe fn grow(
+        &mut self,
+        addition: usize,
+        fill: impl FnOnce(usize, (&mut [Self::Item], &mut [MaybeUninit<Self::Item>])),
+    ) -> mem::Result<&mut [Self::Item]> {
+        // SAFETY: The caller supplies the initialization callback required by
+        // RawMem, and FileMapped enforces the same contract.
+        unsafe {
+            self.inner.grow(addition, fill)?;
+        }
+        // FileMapped 0.3 returns only the newly grown tail. doublets expects
+        // RawMem::grow to return the complete allocation when it refreshes
+        // its internal pointers.
+        Ok(self.inner.allocated_mut())
+    }
+
+    fn shrink(&mut self, count: usize) -> mem::Result<()> {
+        if self.preserve_bootstrap
+            && self.inner.allocated().len().saturating_sub(count) == DOUBLETS_BOOTSTRAP_ITEMS
+        {
+            self.preserve_bootstrap = false;
+            return Ok(());
+        }
+        self.inner.shrink(count)
+    }
+}
+
+fn platform_mem_error(error: mem::Error) -> io::Error {
+    match error {
+        mem::Error::System(error) => error,
+        other => io::Error::other(other),
+    }
+}

--- a/src/storage/legacy.rs
+++ b/src/storage/legacy.rs
@@ -1,0 +1,241 @@
+use std::fs;
+use std::io::{self, Read};
+use std::path::Path;
+
+use super::{StorageError, TokenRecord};
+
+pub(super) const BIN_MAGIC: &[u8; 8] = b"LARTOK01";
+
+pub(super) fn is_binary(path: &Path) -> Result<bool, StorageError> {
+    if fs::metadata(path)?.len() < BIN_MAGIC.len() as u64 {
+        return Ok(true);
+    }
+    let mut file = fs::File::open(path)?;
+    let mut magic = [0u8; 8];
+    file.read_exact(&mut magic)?;
+    Ok(&magic == BIN_MAGIC)
+}
+
+pub(super) fn decode_binary(path: &Path) -> Result<Vec<TokenRecord>, StorageError> {
+    let mut file = fs::File::open(path)?;
+    let mut magic = [0u8; 8];
+    if let Err(error) = file.read_exact(&mut magic) {
+        if error.kind() == io::ErrorKind::UnexpectedEof {
+            return Ok(Vec::new());
+        }
+        return Err(error.into());
+    }
+    if &magic != BIN_MAGIC {
+        return Err(StorageError::Codec(
+            "invalid legacy binary magic header".into(),
+        ));
+    }
+    let mut records = Vec::new();
+    loop {
+        let mut len = [0u8; 4];
+        match file.read_exact(&mut len) {
+            Ok(()) => {}
+            Err(error) if error.kind() == io::ErrorKind::UnexpectedEof => break,
+            Err(error) => return Err(error.into()),
+        }
+        let mut data = vec![0u8; u32::from_le_bytes(len) as usize];
+        file.read_exact(&mut data)?;
+        records.push(
+            serde_json::from_slice(&data)
+                .map_err(|error| StorageError::Codec(error.to_string()))?,
+        );
+    }
+    Ok(records)
+}
+
+pub(super) fn decode_text(input: &str) -> Result<Vec<TokenRecord>, String> {
+    let mut records = Vec::new();
+    for raw in input.lines() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        records.push(parse_record_line(line)?);
+    }
+    Ok(records)
+}
+
+fn parse_record_line(line: &str) -> Result<TokenRecord, String> {
+    let inner = line
+        .strip_prefix('(')
+        .and_then(|value| value.strip_suffix(')'))
+        .ok_or_else(|| format!("expected parens around record: {line}"))?
+        .trim();
+    let mut tokens = LinoTokens::new(inner);
+    let kind = tokens
+        .next_atom()
+        .ok_or_else(|| "missing record kind".to_string())?;
+    if kind != "token" {
+        return Err(format!("unexpected record kind: {kind}"));
+    }
+    let id = tokens
+        .next_atom()
+        .ok_or_else(|| "missing token id".to_string())?
+        .to_string();
+    let mut record = TokenRecord {
+        id,
+        label: String::new(),
+        issued_at: 0,
+        expires_at: 0,
+        revoked: false,
+        account: None,
+        max_requests: None,
+        used_requests: 0,
+        scope: String::new(),
+    };
+    while let Some(field) = tokens.next_paren_group() {
+        parse_field(&mut record, field)?;
+    }
+    Ok(record)
+}
+
+fn parse_field(record: &mut TokenRecord, field: &str) -> Result<(), String> {
+    let mut tokens = LinoTokens::new(field);
+    let key = tokens
+        .next_atom()
+        .ok_or_else(|| "field missing key".to_string())?;
+    match key {
+        "label" => record.label = required_string(&mut tokens, key)?,
+        "issued_at" => record.issued_at = required_number(&mut tokens, key)?,
+        "expires_at" => record.expires_at = required_number(&mut tokens, key)?,
+        "revoked" => {
+            let value = required_atom(&mut tokens, key)?;
+            record.revoked = matches!(value, "true" | "1" | "yes");
+        }
+        "account" => record.account = tokens.next_string(),
+        "max_requests" => record.max_requests = Some(required_number(&mut tokens, key)?),
+        "used_requests" => record.used_requests = required_number(&mut tokens, key)?,
+        "scope" => record.scope = tokens.next_string().unwrap_or_default(),
+        other => return Err(format!("unknown field: {other}")),
+    }
+    Ok(())
+}
+
+fn required_atom<'a>(tokens: &mut LinoTokens<'a>, name: &str) -> Result<&'a str, String> {
+    tokens
+        .next_atom()
+        .ok_or_else(|| format!("{name} missing value"))
+}
+
+fn required_string(tokens: &mut LinoTokens<'_>, name: &str) -> Result<String, String> {
+    tokens
+        .next_string()
+        .ok_or_else(|| format!("{name} missing value"))
+}
+
+fn required_number<T>(tokens: &mut LinoTokens<'_>, name: &str) -> Result<T, String>
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+{
+    required_atom(tokens, name)?
+        .parse::<T>()
+        .map_err(|error| error.to_string())
+}
+
+struct LinoTokens<'a> {
+    rest: &'a str,
+}
+
+impl<'a> LinoTokens<'a> {
+    const fn new(input: &'a str) -> Self {
+        Self { rest: input }
+    }
+
+    fn skip_ws(&mut self) {
+        self.rest = self.rest.trim_start();
+    }
+
+    fn next_atom(&mut self) -> Option<&'a str> {
+        self.skip_ws();
+        if self.rest.is_empty() || self.rest.starts_with('(') || self.rest.starts_with('"') {
+            return None;
+        }
+        let end = self
+            .rest
+            .find(|character: char| character.is_whitespace() || matches!(character, '(' | ')'))
+            .unwrap_or(self.rest.len());
+        let (atom, rest) = self.rest.split_at(end);
+        self.rest = rest;
+        Some(atom)
+    }
+
+    fn next_string(&mut self) -> Option<String> {
+        self.skip_ws();
+        let bytes = self.rest.as_bytes();
+        if bytes.first() != Some(&b'"') {
+            return None;
+        }
+        let mut value = String::new();
+        let mut index = 1;
+        while index < bytes.len() {
+            let character = bytes[index];
+            if character == b'\\' && index + 1 < bytes.len() {
+                value.push(match bytes[index + 1] {
+                    b'"' => '"',
+                    b'\\' => '\\',
+                    b'n' => '\n',
+                    b'r' => '\r',
+                    b't' => '\t',
+                    other => char::from(other),
+                });
+                index += 2;
+            } else if character == b'"' {
+                self.rest = &self.rest[index + 1..];
+                return Some(value);
+            } else {
+                value.push(char::from(character));
+                index += 1;
+            }
+        }
+        None
+    }
+
+    fn next_paren_group(&mut self) -> Option<&'a str> {
+        self.skip_ws();
+        if !self.rest.starts_with('(') {
+            return None;
+        }
+        let mut depth = 0i32;
+        let mut in_string = false;
+        let mut escape = false;
+        let mut end = 0;
+        for (index, &byte) in self.rest.as_bytes().iter().enumerate() {
+            if escape {
+                escape = false;
+                continue;
+            }
+            if in_string {
+                match byte {
+                    b'\\' => escape = true,
+                    b'"' => in_string = false,
+                    _ => {}
+                }
+                continue;
+            }
+            match byte {
+                b'"' => in_string = true,
+                b'(' => depth += 1,
+                b')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        end = index + 1;
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        if end == 0 {
+            return None;
+        }
+        let group = &self.rest[1..end - 1];
+        self.rest = &self.rest[end..];
+        Some(group)
+    }
+}

--- a/tests/associative_storage_test.rs
+++ b/tests/associative_storage_test.rs
@@ -1,0 +1,29 @@
+use link_assistant_router::storage::{TextTokenStore, TokenRecord, TokenStore};
+
+use tempfile::tempdir;
+
+fn sample_record() -> TokenRecord {
+    TokenRecord {
+        id: "6fdf2800-72c6-47dc-9050-67bc66fa72fc".into(),
+        label: "official codec compatibility".into(),
+        issued_at: 1_700_000_000,
+        expires_at: 1_700_001_000,
+        revoked: false,
+        account: Some("primary".into()),
+        max_requests: Some(100),
+        used_requests: 7,
+        scope: "admin".into(),
+    }
+}
+
+#[test]
+fn text_store_is_decodable_by_the_official_lino_codec() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("tokens.lino");
+    let store = TextTokenStore::open(&path).unwrap();
+    store.put(sample_record()).unwrap();
+
+    let encoded = std::fs::read_to_string(path).unwrap();
+    lino_objects_codec::decode(&encoded)
+        .expect("tokens.lino must be real Links Notation understood by the official codec");
+}

--- a/tests/associative_storage_test.rs
+++ b/tests/associative_storage_test.rs
@@ -1,4 +1,6 @@
-use link_assistant_router::storage::{TextTokenStore, TokenRecord, TokenStore};
+use std::fs;
+
+use link_assistant_router::storage::{BinaryTokenStore, TextTokenStore, TokenRecord, TokenStore};
 
 use tempfile::tempdir;
 
@@ -24,6 +26,71 @@ fn text_store_is_decodable_by_the_official_lino_codec() {
     store.put(sample_record()).unwrap();
 
     let encoded = std::fs::read_to_string(path).unwrap();
+    links_notation::parse_lino(&encoded)
+        .expect("tokens.lino must parse as upstream Links Notation");
     lino_objects_codec::decode(&encoded)
         .expect("tokens.lino must be real Links Notation understood by the official codec");
+}
+
+#[test]
+fn binary_store_is_a_reopenable_native_doublets_graph() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("tokens.bin");
+    let store = BinaryTokenStore::open(&path).unwrap();
+    let mut record = sample_record();
+    record.label = "large associative value".repeat(500);
+    store.put(record.clone()).unwrap();
+
+    let bytes = fs::read(&path).unwrap();
+    assert!(!bytes.starts_with(b"LARTOK01"));
+
+    assert_eq!(
+        BinaryTokenStore::open(path)
+            .unwrap()
+            .get(&record.id)
+            .unwrap(),
+        Some(record)
+    );
+}
+
+#[test]
+fn legacy_text_store_is_loaded_and_migrated() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("tokens.lino");
+    fs::write(
+        &path,
+        concat!(
+            "# Link.Assistant.Router token store\n",
+            "(token legacy (label \"old format\") (issued_at 1) ",
+            "(expires_at 2) (revoked false) (account \"primary\") ",
+            "(max_requests 10) (used_requests 3) (scope \"admin\"))\n",
+        ),
+    )
+    .unwrap();
+
+    let store = TextTokenStore::open(&path).unwrap();
+    let record = store.get("legacy").unwrap().unwrap();
+    assert_eq!(record.label, "old format");
+    assert_eq!(record.max_requests, Some(10));
+    assert_eq!(record.used_requests, 3);
+
+    let migrated = fs::read_to_string(path).unwrap();
+    assert!(!migrated.contains("(token legacy"));
+    lino_objects_codec::decode(&migrated).expect("legacy text must migrate to official Lino");
+}
+
+#[test]
+fn legacy_binary_store_is_loaded_and_migrated() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("tokens.bin");
+    let record = sample_record();
+    let json = serde_json::to_vec(&record).unwrap();
+    let mut legacy = b"LARTOK01".to_vec();
+    legacy.extend_from_slice(&u32::try_from(json.len()).unwrap().to_le_bytes());
+    legacy.extend_from_slice(&json);
+    fs::write(&path, legacy).unwrap();
+
+    let store = BinaryTokenStore::open(&path).unwrap();
+    assert_eq!(store.get(&record.id).unwrap(), Some(record));
+    assert!(!fs::read(path).unwrap().starts_with(b"LARTOK01"));
 }

--- a/tests/ghcr_visibility_test.rs
+++ b/tests/ghcr_visibility_test.rs
@@ -4,6 +4,9 @@ use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static SANDBOX_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 fn script() -> String {
     format!(
@@ -17,8 +20,9 @@ fn sandbox(status: &str, body: &str) -> PathBuf {
         .duration_since(std::time::UNIX_EPOCH)
         .expect("clock must be after the Unix epoch")
         .as_nanos();
+    let sequence = SANDBOX_SEQUENCE.fetch_add(1, Ordering::Relaxed);
     let dir = std::env::temp_dir().join(format!(
-        "router-ghcr-visibility-{}-{nonce}",
+        "router-ghcr-visibility-{}-{nonce}-{sequence}",
         std::process::id()
     ));
     fs::create_dir_all(&dir).expect("sandbox must be created");


### PR DESCRIPTION
## Summary

- encode `tokens.lino` with the official `lino-objects-codec` / `links-notation` stack
- persist `tokens.bin` as a native `doublets` graph backed by file-mapped `platform-mem`
- reduce each token through explicit `Type -> SubType -> Value` relations and validate the graph schema on read
- migrate legacy hand-built Lino and `LARTOK01` JSON containers atomically on first open
- document which files are router-owned associative state versus vendor interoperability or operational stream formats

## Root cause and reproduction

The previous text backend assembled a Lino-looking string manually, but the official codec could not decode it. The binary backend was a custom length-prefixed JSON container and did not contain doublets at all.

`tests/associative_storage_test.rs` reproduces the text incompatibility by decoding `tokens.lino` with the upstream parser and codec. It also verifies legacy migration and binary reopen behavior. A unit regression opens the physical store through `doublets` and crosses its bootstrap growth boundary.

## Implementation notes

`platform-mem` 0.3 starts an existing file mapping with zero logical capacity and returns only the grown tail from `RawMem::grow`, while `doublets` refreshes pointers from the returned allocation. A small scoped adapter restores existing capacity and returns the complete allocation. Unsafe code remains denied everywhere else in the crate.

Full-width `u64` counters are represented as strings in portable Lino so values above `i64::MAX` round-trip without loss. The binary format is intentionally native to the platform; Lino remains the portable projection.

Windows requires write access when `File::sync_all` reaches `FlushFileBuffers`, so the post-mapping durability handle is opened read/write. Cross-platform CI also exposed a pre-existing parallel-test collision in the newly merged GHCR visibility tests; their per-process sandbox names now include an atomic sequence number.

Vendor credential/config files keep their required JSON/TOML shapes, and request/audit JSONL streams remain operational logs rather than mutable domain storage.

## Verification

- `cargo fmt --all -- --check`
- `cargo check --locked --all-targets --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps --all-features`
- `cargo test --locked --all-features --verbose`
- `cargo test --locked --doc --verbose`
- `cargo package --locked`
- all Rust files remain within the 1,000-line limit

Fixes #148
