### PR TITLE
fix(ci): require public GHCR package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -499,7 +499,9 @@ jobs:
             ghcr.io/${{ github.repository }}
             ${{ env.DOCKERHUB_IMAGE }}
           tags: type=raw,value=${{ env.RELEASE_VERSION }}
-          labels: org.opencontainers.image.version=${{ env.RELEASE_VERSION }}
+          labels: |
+            org.opencontainers.image.version=${{ env.RELEASE_VERSION }}
+            org.opencontainers.image.source=https://github.com/link-assistant/router
 
       - name: Build and push image by digest
         id: build-image
@@ -591,6 +593,11 @@ jobs:
             -t "${{ env.DOCKERHUB_IMAGE }}:latest" \
             -t "${{ env.DOCKERHUB_IMAGE }}:${RELEASE_VERSION}" \
             "${dockerhub_runtime[@]}"
+
+      - name: Verify GHCR package is publicly pullable
+        env:
+          GHCR_IMAGE: ghcr.io/link-assistant/router
+        run: bash scripts/verify-ghcr-visibility.sh
 
       - name: Verify multi-platform Docker manifests
         run: |

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-13T15:28:59.510Z for PR creation at branch issue-144-561edd8d8533 for issue https://github.com/link-assistant/router/issues/144

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-13T15:28:59.510Z for PR creation at branch issue-144-561edd8d8533 for issue https://github.com/link-assistant/router/issues/144

--- a/README.md
+++ b/README.md
@@ -813,6 +813,13 @@ If native OAuth fails, `auth claude` downloads the current Claude Code package
 through bun into a temporary cache, completes the compatibility flow, and
 removes that cache. Force this path with `auth claude --flow cli`.
 
+The release pipeline verifies that `ghcr.io/link-assistant/router` is publicly
+pullable without credentials. On the first package publication, the publishing
+job fails closed if GitHub created the package as private. An organization owner
+must open the package settings, change its visibility to **Public**, and rerun
+the failed job. GitHub does not currently provide a package-visibility API, so
+this one-time bootstrap cannot be automated safely.
+
 ### Docker Compose example
 
 ```yaml

--- a/changelog.d/20260813_160000_public_ghcr_releases.md
+++ b/changelog.d/20260813_160000_public_ghcr_releases.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fail Docker releases unless GHCR grants an anonymous pull token, ensuring the published router package is public.

--- a/scripts/check-release-workflow.rs
+++ b/scripts/check-release-workflow.rs
@@ -31,6 +31,9 @@ fn main() {
         "cache-to: type=gha,mode=max",
         "docker buildx imagetools create",
         "rust-script scripts/check-docker-platforms.rs",
+        "bash scripts/verify-ghcr-visibility.sh",
+        "GHCR_IMAGE: ghcr.io/link-assistant/router",
+        "org.opencontainers.image.source=https://github.com/link-assistant/router",
         "username: konard",
         "password: ${{ secrets.DOCKERHUB_TOKEN }}",
         "ghcr.io/${{ github.repository }}",
@@ -92,6 +95,12 @@ fn main() {
         );
     }
 
+    if count_occurrences(&workflow, "bash scripts/verify-ghcr-visibility.sh") != 1 {
+        failures.push(
+            "the shared manifest job must verify anonymous GHCR visibility once".to_string(),
+        );
+    }
+
     if workflow.contains("docker-build:")
         || workflow.contains("needs: [lint, test, build, docker-build]")
     {
@@ -138,7 +147,7 @@ fn main() {
     }
 
     if failures.is_empty() {
-        println!("release workflow builds native images and publishes verified multi-platform manifests");
+        println!("release workflow builds native images and publishes public, verified multi-platform manifests");
     } else {
         for failure in failures {
             eprintln!("Error: {failure}");

--- a/scripts/verify-ghcr-visibility.sh
+++ b/scripts/verify-ghcr-visibility.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Verify that GHCR grants an anonymous pull token for the package just published.
+# Deliberately do not add authentication here: credentials would make a private
+# package look public and defeat this release gate.
+set -euo pipefail
+
+GHCR_IMAGE="${GHCR_IMAGE:-}"
+GHCR_TOKEN_ENDPOINT="${GHCR_TOKEN_ENDPOINT:-https://ghcr.io/token}"
+retries="${VERIFY_GHCR_VISIBILITY_RETRIES:-3}"
+delay="${VERIFY_GHCR_VISIBILITY_DELAY:-5}"
+
+trace() {
+  if [ "${VERIFY_GHCR_VISIBILITY_VERBOSE:-}" = "1" ]; then
+    echo "verify-ghcr-visibility: $*" >&2
+  fi
+}
+
+if [ -z "$GHCR_IMAGE" ]; then
+  echo "::error::GHCR_IMAGE is not set; nothing to verify"
+  exit 1
+fi
+if ! [[ "$retries" =~ ^[1-9][0-9]*$ ]]; then
+  echo "::error::VERIFY_GHCR_VISIBILITY_RETRIES must be a positive integer"
+  exit 1
+fi
+if ! [[ "$delay" =~ ^[0-9]+$ ]]; then
+  echo "::error::VERIFY_GHCR_VISIBILITY_DELAY must be a non-negative integer"
+  exit 1
+fi
+
+repository="${GHCR_IMAGE#ghcr.io/}"
+repository="${repository%%@*}"
+repository="${repository%%:*}"
+scope="repository:${repository}:pull"
+
+body="$(mktemp)"
+trap 'rm -f "$body"' EXIT
+
+attempt=1
+while :; do
+  if status="$(curl --silent --show-error --connect-timeout 10 --max-time 30 \
+    -o "$body" -w '%{http_code}' \
+    "${GHCR_TOKEN_ENDPOINT}?service=ghcr.io&scope=${scope}")"; then
+    :
+  else
+    status="000"
+  fi
+  trace "attempt ${attempt}/${retries} -> HTTP ${status}"
+
+  case "$status" in
+    200)
+      if grep -Eq '"token"[[:space:]]*:[[:space:]]*"[^"[:space:]][^"]*"' "$body"; then
+        echo "OK: ${GHCR_IMAGE} is public (GHCR issued an anonymous pull token)"
+        exit 0
+      fi
+      echo "::error::GHCR returned HTTP 200 for ${GHCR_IMAGE} but did not include a pull token"
+      exit 1
+      ;;
+    401)
+      echo "::error::${GHCR_IMAGE} is PRIVATE; anonymous pulls are unauthorized."
+      echo "An organization owner must open the package settings and change its visibility to Public, then rerun this job."
+      exit 1
+      ;;
+    403)
+      echo "::error::${GHCR_IMAGE} is DENIED to anonymous callers; the package may be missing or unavailable."
+      exit 1
+      ;;
+    000 | 5??)
+      if [ "$attempt" -ge "$retries" ]; then
+        echo "::error::The GHCR token endpoint kept failing for ${GHCR_IMAGE} (last status ${status}) after ${retries} attempt(s)"
+        exit 1
+      fi
+      trace "transient status ${status}; retrying in ${delay}s"
+      attempt=$((attempt + 1))
+      sleep "$delay"
+      ;;
+    *)
+      echo "::error::Unexpected HTTP ${status} from the GHCR token endpoint for ${GHCR_IMAGE}"
+      exit 1
+      ;;
+  esac
+done

--- a/tests/ghcr_visibility_test.rs
+++ b/tests/ghcr_visibility_test.rs
@@ -1,0 +1,219 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn script() -> String {
+    format!(
+        "{}/scripts/verify-ghcr-visibility.sh",
+        env!("CARGO_MANIFEST_DIR")
+    )
+}
+
+fn sandbox(status: &str, body: &str) -> PathBuf {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock must be after the Unix epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!(
+        "router-ghcr-visibility-{}-{nonce}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&dir).expect("sandbox must be created");
+
+    let curl = dir.join("curl");
+    fs::write(
+        &curl,
+        format!(
+            "#!/usr/bin/env bash\n\
+             printf '%s\\n' \"$*\" >> \"$SANDBOX/calls.log\"\n\
+             output=''\n\
+             while [ $# -gt 0 ]; do\n\
+               if [ \"$1\" = '-o' ]; then output=\"$2\"; fi\n\
+               shift\n\
+             done\n\
+             printf '%s' '{body}' > \"$output\"\n\
+             if [ '{status}' = 'transport' ]; then exit 7; fi\n\
+             printf '%s' '{status}'\n"
+        ),
+    )
+    .expect("fake curl must be written");
+    fs::set_permissions(&curl, fs::Permissions::from_mode(0o755))
+        .expect("fake curl must be executable");
+    dir
+}
+
+fn run(dir: &Path, image: Option<&str>) -> Output {
+    let path = format!(
+        "{}:{}",
+        dir.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    let mut command = Command::new("bash");
+    command
+        .arg(script())
+        .env("PATH", path)
+        .env("SANDBOX", dir)
+        .env("VERIFY_GHCR_VISIBILITY_DELAY", "0")
+        .env_remove("GHCR_IMAGE");
+    if let Some(image) = image {
+        command.env("GHCR_IMAGE", image);
+    }
+    command.output().expect("visibility probe must run")
+}
+
+fn calls(dir: &Path) -> String {
+    fs::read_to_string(dir.join("calls.log")).unwrap_or_default()
+}
+
+fn cleanup(dir: &Path) {
+    fs::remove_dir_all(dir).expect("sandbox must be removed");
+}
+
+fn output_text(output: &Output) -> String {
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn public_package_passes_without_printing_its_token() {
+    let dir = sandbox("200", r#"{"token":"secret-pull-token"}"#);
+    let output = run(&dir, Some("ghcr.io/link-assistant/router"));
+    let attempts = calls(&dir).lines().count();
+    cleanup(&dir);
+
+    let text = output_text(&output);
+    assert!(output.status.success(), "{text}");
+    assert!(text.contains("is public"), "{text}");
+    assert!(!text.contains("secret-pull-token"), "{text}");
+    assert_eq!(attempts, 1);
+}
+
+#[test]
+fn success_without_an_anonymous_token_fails_closed() {
+    let dir = sandbox("200", r#"{"expires_in":300}"#);
+    let output = run(&dir, Some("ghcr.io/link-assistant/router"));
+    cleanup(&dir);
+
+    assert!(!output.status.success());
+    assert!(output_text(&output).contains("did not include a pull token"));
+}
+
+#[test]
+fn private_and_missing_packages_fail_with_distinct_diagnostics() {
+    for (status, expected, unexpected) in
+        [("401", "PRIVATE", "DENIED"), ("403", "DENIED", "PRIVATE")]
+    {
+        let dir = sandbox(status, "{}");
+        let output = run(&dir, Some("ghcr.io/link-assistant/router"));
+        cleanup(&dir);
+
+        let text = output_text(&output);
+        assert!(!output.status.success(), "HTTP {status} must fail");
+        assert!(text.contains(expected), "{text}");
+        assert!(!text.contains(unexpected), "{text}");
+    }
+}
+
+#[test]
+fn transient_server_failures_use_the_bounded_retry_budget() {
+    let dir = sandbox("503", "{}");
+    let output = run(&dir, Some("ghcr.io/link-assistant/router"));
+    let attempts = calls(&dir).lines().count();
+    cleanup(&dir);
+
+    assert!(!output.status.success());
+    assert_eq!(attempts, 3);
+    assert!(output_text(&output).contains("kept failing"));
+}
+
+#[test]
+fn transport_failures_use_the_bounded_retry_budget() {
+    let dir = sandbox("transport", "");
+    let output = run(&dir, Some("ghcr.io/link-assistant/router"));
+    let attempts = calls(&dir).lines().count();
+    cleanup(&dir);
+
+    assert!(!output.status.success());
+    assert_eq!(attempts, 3);
+    assert!(output_text(&output).contains("last status 000"));
+}
+
+#[test]
+fn scope_omits_registry_tag_and_digest_and_request_has_no_credentials() {
+    for image in [
+        "ghcr.io/link-assistant/router:1.2.3",
+        "ghcr.io/link-assistant/router@sha256:0123456789abcdef",
+    ] {
+        let dir = sandbox("200", r#"{"token":"pull-token"}"#);
+        let output = run(&dir, Some(image));
+        let invocation = calls(&dir);
+        cleanup(&dir);
+
+        assert!(output.status.success(), "{}", output_text(&output));
+        assert!(
+            invocation.contains("scope=repository:link-assistant/router:pull"),
+            "{invocation}"
+        );
+        for credential in ["Authorization", "GITHUB_TOKEN", "--user", "-u "] {
+            assert!(!invocation.contains(credential), "{invocation}");
+        }
+    }
+}
+
+#[test]
+fn missing_image_and_invalid_bash_are_rejected() {
+    let dir = sandbox("200", r#"{"token":"pull-token"}"#);
+    let output = run(&dir, None);
+    cleanup(&dir);
+
+    assert!(!output.status.success());
+    assert!(output_text(&output).contains("GHCR_IMAGE is not set"));
+    assert!(
+        Command::new("bash")
+            .args(["-n", &script()])
+            .status()
+            .expect("bash must run")
+            .success()
+    );
+}
+
+#[test]
+fn release_manifest_job_checks_public_visibility_and_source_metadata() {
+    let workflow = fs::read_to_string(".github/workflows/release.yml")
+        .expect("release workflow should be readable");
+    let manifests = workflow
+        .split_once("  publish-docker-manifests:")
+        .expect("shared manifest job must exist")
+        .1
+        .split_once("\n  create-github-release:")
+        .expect("manifest job must end before the GitHub release job")
+        .0;
+
+    let creation = manifests
+        .find("- name: Create multi-platform manifests")
+        .expect("manifest job must publish tags");
+    let visibility = manifests
+        .find("- name: Verify GHCR package is publicly pullable")
+        .expect("manifest job must verify anonymous GHCR access");
+    assert!(
+        creation < visibility,
+        "visibility must be checked after publishing"
+    );
+    assert_eq!(
+        manifests
+            .matches("bash scripts/verify-ghcr-visibility.sh")
+            .count(),
+        1
+    );
+    assert!(manifests.contains("GHCR_IMAGE: ghcr.io/link-assistant/router"));
+    assert!(
+        workflow
+            .contains("org.opencontainers.image.source=https://github.com/link-assistant/router")
+    );
+}


### PR DESCRIPTION
## Summary

- probe GHCR's token endpoint without credentials after the shared multi-platform manifest publish job
- fail closed on private, denied, malformed, or persistently unavailable responses while retrying bounded transport and server failures
- add explicit `org.opencontainers.image.source` metadata and document the first-package visibility bootstrap
- cover anonymous token handling, failure diagnostics, retries, scope construction, credential absence, and workflow placement with regression tests

## Root cause and reproduction

The existing post-publish manifest check runs after authenticating to GHCR. It can therefore pass when `ghcr.io/link-assistant/router` is private, leaving anonymous users unable to pull an apparently successful release.

Before the fix, `cargo test --locked --test ghcr_visibility_test` failed because the anonymous visibility script and post-manifest workflow gate did not exist. The shared manifest job is reached from both automatic and manual release paths, so the new gate covers every path that publishes this GHCR package.

## Verification

- `cargo fmt --all -- --check`
- `cargo check --locked --all-targets --all-features`
- `cargo clippy --locked --all-targets --all-features`
- `cargo test --locked --all-features --verbose`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --no-deps --all-features`
- `cargo package --locked --list`
- release automation script tests and workflow/file-size checkers
- `bash -n scripts/verify-ghcr-visibility.sh`
- live anonymous GHCR probe: HTTP 200 with a pull token

This is a release-pipeline change, so screenshots are not applicable.

Fixes #144
