### PR TITLE
Superseded: issue #133 already fixed by #139

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-14T06:07:56.266Z for PR creation at branch issue-133-9d3a7e5e4cc9 for issue https://github.com/link-assistant/router/issues/133


### PR DESCRIPTION
## Disposition

No additional code change is required. Issue #133 was already fixed by #139 (`03d49ff`), and that commit is included in v0.62.0 and every current release.

The latest issue recheck inspected the response body but missed the HTTP response headers that explicitly disclose the unsupported limit:

- `x-link-assistant-output-limit: unsupported`
- HTTP `Warning` describing why Codex cannot enforce Anthropic `max_tokens`

The behavior is documented and covered by `codex_output_limit_policy_distinguishes_client_surfaces`, which passes locally. The fresh CI run for this prepared branch also passed.

Closing this generated placeholder PR as superseded by #139; merging its sole `.gitkeep` file would add no product value.



Fixes #133