### PR TITLE
fix: truthful rejected-request logs, aligned status column, OpenAI-dialect upstream errors, and a recorded-client fixture tier

### DIFF
--- a/.github/workflows/real-clients.yml
+++ b/.github/workflows/real-clients.yml
@@ -1,0 +1,59 @@
+# The real-client tier: run the actual vendor CLIs against a live router.
+#
+# `tests/real_clients_test.rs` is opt-in behind ROUTER_REAL_CLIENT_TESTS=1 and
+# was referenced by no workflow, so it never ran (issue #211). It cannot run on
+# pull requests — it needs vendor subscriptions and takes minutes — but "never"
+# is not the right cadence either. This runs it nightly, where credentials can
+# live, and leaves the fast fixture tier (tests/client_fixture_test.rs) to cover
+# every pull request offline.
+name: Real Clients
+
+on:
+  schedule:
+    - cron: '41 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  GIT_CONFIG_COUNT: '1'
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: main
+
+jobs:
+  real-clients:
+    name: Real Client Single Turn
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: 1.97.1
+
+      # The tier needs a running router and a task token. Without them there is
+      # nothing to test against, and a run that quietly asserts nothing is the
+      # problem this workflow exists to fix — so say so and stop.
+      - name: Check for a configured router
+        id: configured
+        env:
+          ROUTER_REAL_SERVER: ${{ secrets.ROUTER_REAL_SERVER }}
+        run: |
+          if [ -z "$ROUTER_REAL_SERVER" ]; then
+            echo "::notice::ROUTER_REAL_SERVER is not configured; the real-client tier cannot run."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run the real-client tier
+        if: steps.configured.outputs.run == 'true'
+        env:
+          ROUTER_REAL_CLIENT_TESTS: '1'
+          ROUTER_REAL_SERVER: ${{ secrets.ROUTER_REAL_SERVER }}
+          ROUTER_REAL_TOKEN: ${{ secrets.ROUTER_REAL_TOKEN }}
+        run: cargo test --locked --test real_clients_test -- --nocapture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/changelog.d/20260818_140000_issues_210_213.md
+++ b/changelog.d/20260818_140000_issues_210_213.md
@@ -1,0 +1,17 @@
+---
+bump: minor
+---
+
+### Fixed
+- A request rejected at authentication no longer claims it carried an empty body. The body is captured as a handler reads it, and a rejected request is never read, so the record asserted `content-length: 104` and `"body": ""` at once — blank in exactly the case the log exists for, since a `401` is what a misconfigured client hits. The record now says the body was not read, and stays distinguishable from a genuinely bodiless request. The body is deliberately not buffered to recover it: that would let an unauthenticated caller make the router hold `MAX_BUFFERED_REQUEST_BYTES` per request.
+- `auth status` prints an aligned provider column again. `Display for SubscriptionProvider` wrote straight to the output buffer, which discards the width the caller asked for, so `{:<8}` was accepted by the compiler and ignored at runtime. `ChatChannel` had the same latent bug and is fixed with it.
+
+### Security
+- Upstream vendor errors on `/v1/chat/completions` and `/v1/responses` are no longer relayed to the caller verbatim. The vendor body carries fields describing the *router operator's* subscription — `plan_type`, `eligible_promo`, `resets_at` — which say nothing about the caller's request; in a shared deployment, where the caller is not the account holder, every `429` disclosed the operator's billing posture. Only the status, message and retry timing are now returned. The full upstream body is still recorded in the request log, so nothing is lost for diagnosis.
+
+### Changed
+- Those same errors are rendered in the `OpenAI` dialect, as the Anthropic and Gemini surfaces already did. A client written against the OpenAI SDK could not classify the failure, because the vendor's `type` (`usage_limit_reached`) is not an OpenAI error type and no `code` was present — which defeats the purpose of an OpenAI-compatible surface. One upstream failure now yields a correctly-shaped envelope on all three surfaces.
+
+### Added
+- A recorded-fixture test tier (`tests/fixtures/clients/`, `tests/client_fixture_test.rs`). The fast tests otherwise assert request shapes written by hand, and nothing checked them against what the real clients send — which is how the Gemini CLI `401` reached a release with every unit test passing. Each fixture carries a real client's method, path, headers and credential carrier, and is replayed to assert it authenticates, reaches a route, is refused an invalid credential, and routes identically with and without its vendor-specific headers. Recording needs a subscription; replaying does not, so the check runs offline on every pull request. Verified against the original defect: reverting the `x-goog-api-key` fix fails this tier.
+- A nightly `Real Clients` workflow that runs the opt-in real-binary tier, which was referenced by no workflow and therefore never ran. It also now reports which clients it exercised and which it skipped, and fails when none is installed — a silently skipped client was indistinguishable from a passing one.

--- a/src/api_error.rs
+++ b/src/api_error.rs
@@ -96,6 +96,74 @@ pub fn error_response_for_surface(
     .render(dialect)
 }
 
+/// `OpenAI` error `type` for an upstream status.
+///
+/// Mirrors the mappings the Anthropic and Gemini surfaces already apply
+/// (`anthropic_bridge::anthropic_error`, `gemini_bridge::openai_error_to_gemini`)
+/// so one upstream failure is classified the same way on every surface.
+const fn openai_error_type(status: u16) -> &'static str {
+    match status {
+        400 | 404 | 422 => "invalid_request_error",
+        401 => "authentication_error",
+        403 => "permission_error",
+        429 => "rate_limit_error",
+        _ => "api_error",
+    }
+}
+
+/// The `code` an `OpenAI` client reads to classify a failure programmatically.
+const fn openai_error_code(status: u16) -> Option<&'static str> {
+    match status {
+        401 => Some("invalid_api_key"),
+        403 => Some("permission_denied"),
+        404 => Some("model_not_found"),
+        429 => Some("rate_limit_exceeded"),
+        _ => None,
+    }
+}
+
+/// Re-shape an upstream vendor error as an `OpenAI` error envelope.
+///
+/// The `OpenAI` surfaces used to relay the vendor's body verbatim, which had two
+/// consequences (issue #213): a client written against the `OpenAI` SDK could not
+/// classify the failure, because the vendor's `type` is not an `OpenAI` error
+/// type; and the body carried fields describing the *router operator's*
+/// subscription — `plan_type`, `eligible_promo`, `resets_at` — which say nothing
+/// about the caller's request and, in a shared deployment, disclose the
+/// operator's billing posture to every caller who triggers a `429`.
+///
+/// Only what the caller can act on is preserved: the status, the message, and
+/// retry timing. The full upstream body is still captured by the request log
+/// (`record_upstream_body`), so nothing is lost for diagnosis.
+#[must_use]
+pub fn openai_error_body(status: u16, upstream: &[u8]) -> serde_json::Value {
+    let parsed = serde_json::from_slice::<serde_json::Value>(upstream).ok();
+    let vendor_message = parsed.as_ref().and_then(|value| {
+        value
+            .pointer("/error/message")
+            .or_else(|| value.pointer("/message"))
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string)
+    });
+    let message = vendor_message.unwrap_or_else(|| {
+        let text = String::from_utf8_lossy(upstream);
+        let text = text.trim();
+        if text.is_empty() {
+            "upstream request failed".to_string()
+        } else {
+            text.to_string()
+        }
+    });
+    serde_json::json!({
+        "error": {
+            "message": message,
+            "type": openai_error_type(status),
+            "param": serde_json::Value::Null,
+            "code": openai_error_code(status),
+        }
+    })
+}
+
 pub fn malformed_json_response(error: &str) -> Response {
     error_response(
         StatusCode::BAD_REQUEST,

--- a/src/chat_admin.rs
+++ b/src/chat_admin.rs
@@ -118,7 +118,10 @@ impl ChatChannel {
 
 impl std::fmt::Display for ChatChannel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
+        // `pad`, not `write_str`: only `pad` applies the width, fill and
+        // alignment the caller asked for, so `{:<8}` is silently ignored by a
+        // `write_str` implementation (issue #212).
+        f.pad(self.as_str())
     }
 }
 

--- a/src/request_log.rs
+++ b/src/request_log.rs
@@ -599,6 +599,24 @@ struct ClientRequestCapture {
 }
 
 impl ClientRequestCapture {
+    /// Whether the client's own headers claim a body accompanied the request.
+    ///
+    /// This is what makes a bodiless `GET` distinguishable from a request whose
+    /// body was never read: the former declares nothing, the latter declares a
+    /// length (or a chunked encoding) that the record must not contradict.
+    fn declared_a_body(&self) -> bool {
+        let declared_length = self
+            .headers
+            .get("content-length")
+            .and_then(|value| value.parse::<u64>().ok())
+            .is_some_and(|length| length > 0);
+        let chunked = self
+            .headers
+            .get("transfer-encoding")
+            .is_some_and(|value| value.to_ascii_lowercase().contains("chunked"));
+        declared_length || chunked
+    }
+
     fn push(&mut self, bytes: &[u8]) {
         if self.omitted {
             return;
@@ -619,6 +637,20 @@ impl ClientRequestCapture {
             Value::String(format!(
                 "[OMITTED: request body exceeds {MAX_BUFFERED_REQUEST_BYTES} byte logging limit]"
             ))
+        } else if self.body.is_empty() && self.declared_a_body() {
+            // The capture fills only as a handler reads the stream. A request
+            // refused before that — an authentication failure is the common
+            // case — drops the stream unread, so an empty buffer here does not
+            // mean an empty body. Recording `""` would assert something the
+            // headers in the same record contradict (issue #210).
+            //
+            // The body is deliberately *not* buffered to recover it: that would
+            // let an unauthenticated caller make the router hold
+            // `MAX_BUFFERED_REQUEST_BYTES` per request. A truthful marker fixes
+            // the misleading record without taking on that cost.
+            Value::String(
+                "[NOT READ: request was rejected before the body was consumed]".to_string(),
+            )
         } else {
             redacted_body(&self.body)
         };
@@ -754,238 +786,8 @@ pub async fn log_http_exchange(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use proptest::prelude::*;
-
-    #[test]
-    fn long_credentials_are_partially_redacted_and_short_ones_are_fully_masked() {
-        let long = "la_sk_abcdefghijklmnop_last";
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            "authorization",
-            HeaderValue::from_str(&format!("Bearer {long}")).expect("header value"),
-        );
-        headers.insert("x-api-key", HeaderValue::from_static("tiny"));
-
-        let redacted = redacted_headers(&headers);
-        let authorization = &redacted["authorization"];
-        assert!(authorization.starts_with("Bearer la_"), "{authorization}");
-        assert!(authorization.ends_with("ast"), "{authorization}");
-        assert_eq!(authorization.matches('*').count(), long.len() - 6);
-        assert!(!authorization.contains(long));
-        assert_eq!(redacted["x-api-key"], REDACTED);
-    }
-
-    proptest! {
-        #[test]
-        fn complete_credentials_never_survive_any_redaction_site(
-            payload in "[A-Za-z0-9_-]{12,96}"
-        ) {
-            let secret = format!("la_sk_{payload}");
-            let mut headers = HeaderMap::new();
-            headers.insert(
-                "authorization",
-                HeaderValue::from_str(&format!("Bearer {secret}")).expect("header value"),
-            );
-            let header_log = serde_json::to_string(&redacted_headers(&headers))
-                .expect("serialize headers");
-            let body_log = redacted_body(
-                serde_json::to_string(&json!({
-                    "access_token": secret,
-                    "unlisted": secret,
-                }))
-                .expect("serialize body")
-                .as_bytes(),
-            )
-            .to_string();
-            let uri_log = redacted_uri(&format!("/v1/models?access_token={secret}"));
-
-            prop_assert!(!header_log.contains(&secret));
-            prop_assert!(!body_log.contains(&secret));
-            prop_assert!(!uri_log.contains(&secret));
-        }
-    }
-
-    #[test]
-    fn credentials_are_redacted_from_headers_and_json_bodies() {
-        let mut headers = HeaderMap::new();
-        headers.insert("authorization", HeaderValue::from_static("Bearer secret"));
-        headers.insert("x-api-key", HeaderValue::from_static("secret-key"));
-        headers.insert("x-auth-token", HeaderValue::from_static("auth-secret"));
-        headers.insert("x-goog-api-key", HeaderValue::from_static("google-secret"));
-        headers.insert(
-            "x-amz-security-token",
-            HeaderValue::from_static("aws-secret"),
-        );
-        headers.insert("x-visible", HeaderValue::from_static("marker"));
-        let redacted = redacted_headers(&headers);
-        assert_eq!(redacted["authorization"], "Bearer [REDACTED]");
-        assert_eq!(redacted["x-api-key"], REDACTED);
-        assert_eq!(redacted["x-auth-token"], REDACTED);
-        assert_eq!(redacted["x-goog-api-key"], "goo*******ret");
-        assert_eq!(redacted["x-amz-security-token"], REDACTED);
-        assert_eq!(redacted["x-visible"], "marker");
-
-        let body = redacted_body(
-            br#"{
-                "access_token":"access-secret",
-                "apiKey":"camel-secret",
-                "client_secret":"client-secret",
-                "password":"password-secret",
-                "secret":"ordinary-secret",
-                "nested":{"api_key":"key-secret"},
-                "unknownPrefix":"sk-ant-oat01-shaped-secret",
-                "unknownBearer":"Bearer arbitrary-secret",
-                "unknownJwt":"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature"
-            }"#,
-        );
-        let rendered = body.to_string();
-        assert!(!rendered.contains("-secret"));
-        assert!(!rendered.contains("eyJhbGci"));
-        assert!(rendered.contains(REDACTED));
-    }
-
-    #[test]
-    fn credentials_are_redacted_from_uri_queries() {
-        let dir = tempfile::tempdir().expect("temporary directory");
-        let root = dir.path().join("requests");
-        let log = RequestLog::new(root.clone(), 1024 * 1024);
-        log.record(
-            "request",
-            "client_request",
-            json!({
-                "uri": "/v1/models?api_key=api-secret&key=key-secret&access_token=access-secret&token=token-secret&authorization=bearer-secret&probe=visible"
-            }),
-        );
-
-        let rendered =
-            fs::read_to_string(root.join("unauthenticated/requests.jsonl")).expect("request log");
-        for secret in [
-            "api-secret",
-            "key-secret",
-            "access-secret",
-            "token-secret",
-            "bearer-secret",
-        ] {
-            assert!(!rendered.contains(secret));
-        }
-        assert!(rendered.contains("probe=visible"));
-        assert!(rendered.contains(REDACTED));
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn request_log_is_created_owner_only() {
-        use std::os::unix::fs::PermissionsExt as _;
-
-        let dir = tempfile::tempdir().expect("temporary directory");
-        let root = dir.path().join("requests");
-        let path = root.join("unauthenticated/requests.jsonl");
-        let log = RequestLog::new(root.clone(), 1024 * 1024);
-        log.record("request", "test", json!({"visible": true}));
-
-        let mode = fs::metadata(&path)
-            .expect("request log")
-            .permissions()
-            .mode()
-            & 0o777;
-        assert_eq!(mode, 0o600);
-        for directory in [&root, path.parent().expect("bucket directory")] {
-            let mode = fs::metadata(directory)
-                .expect("request log directory")
-                .permissions()
-                .mode()
-                & 0o777;
-            assert_eq!(mode, 0o700);
-        }
-
-        fs::set_permissions(&path, fs::Permissions::from_mode(0o644))
-            .expect("make existing log permissive");
-        log.record("request", "test", json!({"visible": true}));
-        let repaired_mode = fs::metadata(path)
-            .expect("request log")
-            .permissions()
-            .mode()
-            & 0o777;
-        assert_eq!(repaired_mode, 0o600);
-    }
-
-    #[test]
-    fn log_never_exceeds_limit_and_keeps_newest_complete_record() {
-        let dir = tempfile::tempdir().expect("temporary directory");
-        let root = dir.path().join("requests");
-        let path = root.join("unauthenticated/requests.jsonl");
-        let log = RequestLog::new(root, 600);
-        for sequence in 0..30 {
-            log.record("request", "test", json!({"sequence": sequence}));
-        }
-        let bytes = fs::read(&path).expect("request log");
-        assert!(bytes.len() <= 600);
-        let text = String::from_utf8(bytes).expect("UTF-8 JSONL");
-        assert!(
-            text.lines()
-                .all(|line| serde_json::from_str::<Value>(line).is_ok())
-        );
-        assert!(text.contains("\"sequence\":29"));
-        assert!(!text.contains("\"sequence\":0,"));
-
-        let tiny_root = dir.path().join("tiny");
-        let tiny_path = tiny_root.join("unauthenticated/requests.jsonl");
-        let tiny = RequestLog::new(tiny_root, 32);
-        tiny.record("request", "oversized", json!({"body": "far too large"}));
-        assert!(fs::metadata(tiny_path).expect("tiny log").len() <= 32);
-    }
-
-    #[tokio::test]
-    async fn transformed_upstream_exchange_is_logged_with_same_id() {
-        use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("mock upstream");
-        let address = listener.local_addr().expect("mock address");
-        let server = tokio::spawn(async move {
-            let (mut stream, _) = listener.accept().await.expect("accept request");
-            let mut request = vec![0; 4096];
-            let _ = stream.read(&mut request).await.expect("read request");
-            stream
-                .write_all(
-                    b"HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: 27\r\n\r\n{\"reply\":\"upstream-marker\"}",
-                )
-                .await
-                .expect("write response");
-        });
-
-        let dir = tempfile::tempdir().expect("temporary directory");
-        let root = dir.path().join("requests");
-        let path = root.join("unauthenticated/requests.jsonl");
-        let log = RequestLog::new(root, 1024 * 1024);
-        let client = reqwest::Client::new();
-        let request = client
-            .post(format!("http://{address}/translated"))
-            .header("authorization", "Bearer upstream-secret")
-            .header("x-transformed", "translated-header")
-            .body(r#"{"translated":"body-marker","access_token":"body-secret"}"#);
-        let response = log
-            .send_upstream("same-correlation-id", &client, request)
-            .await
-            .expect("upstream response");
-        let body = response.bytes().await.expect("response body");
-        log.record_upstream_body("same-correlation-id", &body);
-        server.await.expect("mock server task");
-
-        let rendered = fs::read_to_string(path).expect("request log");
-        assert!(rendered.contains("same-correlation-id"));
-        assert!(rendered.contains("upstream_request"));
-        assert!(rendered.contains("translated-header"));
-        assert!(rendered.contains("body-marker"));
-        assert!(rendered.contains("upstream_response_body"));
-        assert!(rendered.contains("upstream-marker"));
-        assert!(!rendered.contains("upstream-secret"));
-        assert!(!rendered.contains("body-secret"));
-    }
-}
+#[path = "request_log_tests.rs"]
+mod tests;
 
 #[cfg(test)]
 #[path = "request_log_isolation_tests.rs"]

--- a/src/request_log_tests.rs
+++ b/src/request_log_tests.rs
@@ -1,0 +1,235 @@
+//! Tests for [`crate::request_log`].
+//!
+//! Split from `request_log.rs` to keep that file within the repository's
+//! 1000-line limit.
+
+use super::*;
+use proptest::prelude::*;
+
+#[test]
+fn long_credentials_are_partially_redacted_and_short_ones_are_fully_masked() {
+    let long = "la_sk_abcdefghijklmnop_last";
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "authorization",
+        HeaderValue::from_str(&format!("Bearer {long}")).expect("header value"),
+    );
+    headers.insert("x-api-key", HeaderValue::from_static("tiny"));
+
+    let redacted = redacted_headers(&headers);
+    let authorization = &redacted["authorization"];
+    assert!(authorization.starts_with("Bearer la_"), "{authorization}");
+    assert!(authorization.ends_with("ast"), "{authorization}");
+    assert_eq!(authorization.matches('*').count(), long.len() - 6);
+    assert!(!authorization.contains(long));
+    assert_eq!(redacted["x-api-key"], REDACTED);
+}
+
+proptest! {
+    #[test]
+    fn complete_credentials_never_survive_any_redaction_site(
+        payload in "[A-Za-z0-9_-]{12,96}"
+    ) {
+        let secret = format!("la_sk_{payload}");
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "authorization",
+            HeaderValue::from_str(&format!("Bearer {secret}")).expect("header value"),
+        );
+        let header_log = serde_json::to_string(&redacted_headers(&headers))
+            .expect("serialize headers");
+        let body_log = redacted_body(
+            serde_json::to_string(&json!({
+                "access_token": secret,
+                "unlisted": secret,
+            }))
+            .expect("serialize body")
+            .as_bytes(),
+        )
+        .to_string();
+        let uri_log = redacted_uri(&format!("/v1/models?access_token={secret}"));
+
+        prop_assert!(!header_log.contains(&secret));
+        prop_assert!(!body_log.contains(&secret));
+        prop_assert!(!uri_log.contains(&secret));
+    }
+}
+
+#[test]
+fn credentials_are_redacted_from_headers_and_json_bodies() {
+    let mut headers = HeaderMap::new();
+    headers.insert("authorization", HeaderValue::from_static("Bearer secret"));
+    headers.insert("x-api-key", HeaderValue::from_static("secret-key"));
+    headers.insert("x-auth-token", HeaderValue::from_static("auth-secret"));
+    headers.insert("x-goog-api-key", HeaderValue::from_static("google-secret"));
+    headers.insert(
+        "x-amz-security-token",
+        HeaderValue::from_static("aws-secret"),
+    );
+    headers.insert("x-visible", HeaderValue::from_static("marker"));
+    let redacted = redacted_headers(&headers);
+    assert_eq!(redacted["authorization"], "Bearer [REDACTED]");
+    assert_eq!(redacted["x-api-key"], REDACTED);
+    assert_eq!(redacted["x-auth-token"], REDACTED);
+    assert_eq!(redacted["x-goog-api-key"], "goo*******ret");
+    assert_eq!(redacted["x-amz-security-token"], REDACTED);
+    assert_eq!(redacted["x-visible"], "marker");
+
+    let body = redacted_body(
+        br#"{
+            "access_token":"access-secret",
+            "apiKey":"camel-secret",
+            "client_secret":"client-secret",
+            "password":"password-secret",
+            "secret":"ordinary-secret",
+            "nested":{"api_key":"key-secret"},
+            "unknownPrefix":"sk-ant-oat01-shaped-secret",
+            "unknownBearer":"Bearer arbitrary-secret",
+            "unknownJwt":"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature"
+        }"#,
+    );
+    let rendered = body.to_string();
+    assert!(!rendered.contains("-secret"));
+    assert!(!rendered.contains("eyJhbGci"));
+    assert!(rendered.contains(REDACTED));
+}
+
+#[test]
+fn credentials_are_redacted_from_uri_queries() {
+    let dir = tempfile::tempdir().expect("temporary directory");
+    let root = dir.path().join("requests");
+    let log = RequestLog::new(root.clone(), 1024 * 1024);
+    log.record(
+        "request",
+        "client_request",
+        json!({
+            "uri": "/v1/models?api_key=api-secret&key=key-secret&access_token=access-secret&token=token-secret&authorization=bearer-secret&probe=visible"
+        }),
+    );
+
+    let rendered =
+        fs::read_to_string(root.join("unauthenticated/requests.jsonl")).expect("request log");
+    for secret in [
+        "api-secret",
+        "key-secret",
+        "access-secret",
+        "token-secret",
+        "bearer-secret",
+    ] {
+        assert!(!rendered.contains(secret));
+    }
+    assert!(rendered.contains("probe=visible"));
+    assert!(rendered.contains(REDACTED));
+}
+
+#[cfg(unix)]
+#[test]
+fn request_log_is_created_owner_only() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let dir = tempfile::tempdir().expect("temporary directory");
+    let root = dir.path().join("requests");
+    let path = root.join("unauthenticated/requests.jsonl");
+    let log = RequestLog::new(root.clone(), 1024 * 1024);
+    log.record("request", "test", json!({"visible": true}));
+
+    let mode = fs::metadata(&path)
+        .expect("request log")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(mode, 0o600);
+    for directory in [&root, path.parent().expect("bucket directory")] {
+        let mode = fs::metadata(directory)
+            .expect("request log directory")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o700);
+    }
+
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o644))
+        .expect("make existing log permissive");
+    log.record("request", "test", json!({"visible": true}));
+    let repaired_mode = fs::metadata(path)
+        .expect("request log")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(repaired_mode, 0o600);
+}
+
+#[test]
+fn log_never_exceeds_limit_and_keeps_newest_complete_record() {
+    let dir = tempfile::tempdir().expect("temporary directory");
+    let root = dir.path().join("requests");
+    let path = root.join("unauthenticated/requests.jsonl");
+    let log = RequestLog::new(root, 600);
+    for sequence in 0..30 {
+        log.record("request", "test", json!({"sequence": sequence}));
+    }
+    let bytes = fs::read(&path).expect("request log");
+    assert!(bytes.len() <= 600);
+    let text = String::from_utf8(bytes).expect("UTF-8 JSONL");
+    assert!(
+        text.lines()
+            .all(|line| serde_json::from_str::<Value>(line).is_ok())
+    );
+    assert!(text.contains("\"sequence\":29"));
+    assert!(!text.contains("\"sequence\":0,"));
+
+    let tiny_root = dir.path().join("tiny");
+    let tiny_path = tiny_root.join("unauthenticated/requests.jsonl");
+    let tiny = RequestLog::new(tiny_root, 32);
+    tiny.record("request", "oversized", json!({"body": "far too large"}));
+    assert!(fs::metadata(tiny_path).expect("tiny log").len() <= 32);
+}
+
+#[tokio::test]
+async fn transformed_upstream_exchange_is_logged_with_same_id() {
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("mock upstream");
+    let address = listener.local_addr().expect("mock address");
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.expect("accept request");
+        let mut request = vec![0; 4096];
+        let _ = stream.read(&mut request).await.expect("read request");
+        stream
+            .write_all(
+                b"HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: 27\r\n\r\n{\"reply\":\"upstream-marker\"}",
+            )
+            .await
+            .expect("write response");
+    });
+
+    let dir = tempfile::tempdir().expect("temporary directory");
+    let root = dir.path().join("requests");
+    let path = root.join("unauthenticated/requests.jsonl");
+    let log = RequestLog::new(root, 1024 * 1024);
+    let client = reqwest::Client::new();
+    let request = client
+        .post(format!("http://{address}/translated"))
+        .header("authorization", "Bearer upstream-secret")
+        .header("x-transformed", "translated-header")
+        .body(r#"{"translated":"body-marker","access_token":"body-secret"}"#);
+    let response = log
+        .send_upstream("same-correlation-id", &client, request)
+        .await
+        .expect("upstream response");
+    let body = response.bytes().await.expect("response body");
+    log.record_upstream_body("same-correlation-id", &body);
+    server.await.expect("mock server task");
+
+    let rendered = fs::read_to_string(path).expect("request log");
+    assert!(rendered.contains("same-correlation-id"));
+    assert!(rendered.contains("upstream_request"));
+    assert!(rendered.contains("translated-header"));
+    assert!(rendered.contains("body-marker"));
+    assert!(rendered.contains("upstream_response_body"));
+    assert!(rendered.contains("upstream-marker"));
+    assert!(!rendered.contains("upstream-secret"));
+    assert!(!rendered.contains("body-secret"));
+}

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -126,7 +126,10 @@ impl SubscriptionProvider {
 
 impl std::fmt::Display for SubscriptionProvider {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
+        // `pad`, not `write_str`: only `pad` applies the width, fill and
+        // alignment the caller asked for, so `{:<8}` is silently ignored by a
+        // `write_str` implementation (issue #212).
+        f.pad(self.as_str())
     }
 }
 
@@ -583,6 +586,27 @@ fn account_id_from_id_token(id_token: &str) -> Option<String> {
 mod tests {
     use super::*;
     use std::fs;
+
+    /// `auth status` prints a padded provider column. A `Display` built on
+    /// `write_str` silently discards the requested width, so the format string
+    /// looks correct and only the rendered output disagrees — invisible to the
+    /// compiler, which is why this needs a test (issue #212).
+    #[test]
+    fn provider_display_honours_the_requested_width() {
+        assert_eq!(
+            format!("[{:<8}]", SubscriptionProvider::Codex),
+            "[codex   ]"
+        );
+        assert_eq!(
+            format!("[{:>8}]", SubscriptionProvider::Claude),
+            "[  claude]"
+        );
+        // Padding must never truncate or alter a value that already fills the
+        // column.
+        assert_eq!(format!("[{:<3}]", SubscriptionProvider::Gemini), "[gemini]");
+        // The unpadded rendering is unchanged.
+        assert_eq!(SubscriptionProvider::Qwen.to_string(), "qwen");
+    }
 
     fn tempdir() -> PathBuf {
         let dir = std::env::temp_dir().join(format!("router-sub-{}", uuid::Uuid::new_v4()));

--- a/src/subscription_proxy.rs
+++ b/src/subscription_proxy.rs
@@ -466,6 +466,24 @@ async fn forward_subscription_openai_inner(
         return response;
     }
 
+    // An upstream failure is re-shaped into the dialect of the surface the
+    // caller used, as the Anthropic and Gemini surfaces already do. Relaying the
+    // vendor body verbatim left an OpenAI client unable to classify the error,
+    // and forwarded fields describing the operator's own subscription
+    // (`plan_type`, `eligible_promo`) to a caller who is often a different party
+    // (issue #213). The raw body stays in the request log for diagnosis.
+    let (response_body, content_type) = if status.is_success() {
+        (response_body, content_type)
+    } else {
+        let rendered = crate::api_error::openai_error_body(status.as_u16(), &response_body);
+        (
+            bytes::Bytes::from(
+                serde_json::to_vec(&rendered).expect("JSON values always serialize"),
+            ),
+            HeaderValue::from_static("application/json"),
+        )
+    };
+
     let mut response = Response::new(Body::from(response_body));
     *response.status_mut() = status;
     *response.headers_mut() = response_headers;

--- a/tests/client_fixture_test.rs
+++ b/tests/client_fixture_test.rs
@@ -1,0 +1,300 @@
+//! Replay recorded real-client requests against the router (issue #211).
+//!
+//! The fast tests otherwise assert hand-written request shapes, and nothing
+//! checks those shapes against what the real clients send. The one tier that
+//! uses real binaries is opt-in and runs nowhere in CI, so the suite can stay
+//! green while its assumptions drift away from the wire.
+//!
+//! Issue #206 is the worked example: every unit test passed while the
+//! documented Gemini CLI setup returned `401` on its first request, because no
+//! test sent what Gemini CLI actually sends. These fixtures carry the real
+//! headers, paths and credential carriers, so that class of defect fails here —
+//! in milliseconds, offline, with no vendor credential involved.
+//!
+//! Recording needs a subscription; replaying does not. See
+//! `tests/fixtures/clients/README.md` for how to refresh one.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode};
+use http_body_util::BodyExt as _;
+use link_assistant_router::admin::AdminClaim;
+use link_assistant_router::app_state::AppState;
+use link_assistant_router::cli::Cli;
+use link_assistant_router::model_catalog::ModelCatalogCache;
+use link_assistant_router::oauth::OAuthProvider;
+use link_assistant_router::providers::ProviderStore;
+use link_assistant_router::refresh::TokenCache;
+use link_assistant_router::token::TokenManager;
+use lino_arguments::Parser as _;
+use serde_json::Value;
+use tower::ServiceExt as _;
+
+/// A model every fixture is rewritten to request, so routing is deterministic.
+const FIXTURE_MODEL: &str = "gpt-5";
+
+struct Fixture {
+    file: String,
+    client: String,
+    method: String,
+    path: String,
+    carrier: String,
+    headers: Vec<(String, String)>,
+    body: Value,
+}
+
+fn load_fixtures() -> Vec<Fixture> {
+    let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/clients");
+    let mut fixtures = Vec::new();
+    for entry in std::fs::read_dir(&dir).expect("fixture directory exists") {
+        let path = entry.expect("readable fixture entry").path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let file = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .expect("UTF-8 fixture name")
+            .to_string();
+        let raw = std::fs::read_to_string(&path).expect("read fixture");
+        let value: Value = serde_json::from_str(&raw)
+            .unwrap_or_else(|error| panic!("{file} is not valid JSON: {error}"));
+        let headers = value["headers"]
+            .as_object()
+            .unwrap_or_else(|| panic!("{file} has no headers object"))
+            .iter()
+            .map(|(name, value)| {
+                (
+                    name.clone(),
+                    value
+                        .as_str()
+                        .expect("header value is a string")
+                        .to_string(),
+                )
+            })
+            .collect();
+        fixtures.push(Fixture {
+            client: value["client"].as_str().expect("client").to_string(),
+            method: value["method"].as_str().expect("method").to_string(),
+            path: value["path"]
+                .as_str()
+                .expect("path")
+                .replace("{model}", FIXTURE_MODEL),
+            carrier: value["credential_carrier"]
+                .as_str()
+                .expect("credential_carrier")
+                .to_string(),
+            headers,
+            body: replace_model(&value["body"]),
+            file,
+        });
+    }
+    assert!(!fixtures.is_empty(), "no client fixtures were loaded");
+    fixtures
+}
+
+/// Substitute the `{model}` placeholder anywhere it appears in a body.
+fn replace_model(body: &Value) -> Value {
+    match body {
+        Value::String(text) => Value::String(text.replace("{model}", FIXTURE_MODEL)),
+        Value::Array(items) => Value::Array(items.iter().map(replace_model).collect()),
+        Value::Object(fields) => Value::Object(
+            fields
+                .iter()
+                .map(|(key, value)| (key.clone(), replace_model(value)))
+                .collect(),
+        ),
+        other => other.clone(),
+    }
+}
+
+/// A router with no reachable upstream. These tests assert on authentication
+/// and dispatch, both of which are decided before any upstream is contacted.
+fn test_app(dir: &std::path::Path) -> (axum::Router, String) {
+    let dir_arg = dir.to_str().expect("UTF-8 test path");
+    let config = Cli::try_parse_from(vec![
+        "router",
+        "--token-secret",
+        "fixture-secret",
+        "--data-dir",
+        dir_arg,
+        "--upstream-base-url",
+        "http://127.0.0.1:9",
+    ])
+    .expect("test CLI parses")
+    .into_config()
+    .expect("test config is valid");
+    let token_manager = TokenManager::new("fixture-secret");
+    let token = token_manager
+        .issue_token(1, "fixture client")
+        .expect("issue client token");
+    let state = AppState {
+        client: reqwest::Client::new(),
+        token_manager,
+        oauth_provider: OAuthProvider::new(dir_arg),
+        account_router: None,
+        subscription_reader: None,
+        subscription_base_url: None,
+        subscription_readers: vec![],
+        model_catalogs: Arc::new(ModelCatalogCache::new()),
+        subscription_cache: Arc::new(TokenCache::new()),
+        upstream_base_url: config.upstream_base_url.clone(),
+        upstream_provider: config.upstream_provider,
+        gonka: None,
+        bridge_model: None,
+        bridge_model_policy: link_assistant_router::bridge_selection::BridgeModelPolicy::default(),
+        crater: None,
+        openai_compatible: config.openai_compatible.clone(),
+        provider_store: ProviderStore::open(dir, "fixture-secret").expect("provider store"),
+        logger: log_lazy::LogLazy::new(),
+        admin: Arc::new(AdminClaim::load(
+            Some("fixture-admin".to_string()),
+            dir,
+            Duration::from_secs(60),
+        )),
+        admin_key: Some("fixture-admin".to_string()),
+        allow_anonymous_admin: false,
+        metrics: Arc::new(link_assistant_router::metrics::Metrics::default()),
+        audit: Arc::new(link_assistant_router::audit::AuditLog::disabled()),
+        request_log: Arc::new(link_assistant_router::request_log::RequestLog::new(
+            dir.join("requests"),
+            1024 * 1024,
+        )),
+        activitypub_actor_base_url: "https://router.test".to_string(),
+        activitypub_public_key_pem:
+            link_assistant_router::config::default_activitypub_public_key_pem(),
+        mpp: config.mpp.clone(),
+        login_manager: link_assistant_router::login::LoginManager::new(config.login.clone()),
+        github: link_assistant_router::github_proxy::GitHubProxyConfig::default(),
+        max_proxy_request_bytes: link_assistant_router::config::DEFAULT_MAX_PROXY_REQUEST_BYTES,
+    };
+    (
+        link_assistant_router::server_router::router(state, &config),
+        token,
+    )
+}
+
+/// Replay a fixture, optionally overriding the credential it presents.
+async fn replay(fixture: &Fixture, credential: Option<&str>) -> (StatusCode, Value) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (app, token) = test_app(dir.path());
+    let credential = credential.map_or(token, str::to_string);
+    let mut request = Request::builder()
+        .method(Method::from_bytes(fixture.method.as_bytes()).expect("method"))
+        .uri(&fixture.path);
+    for (name, value) in &fixture.headers {
+        request = request.header(name, value);
+    }
+    // The recorded credential value is never stored; it is injected here into
+    // the carrier the real client uses.
+    let value = if fixture.carrier.eq_ignore_ascii_case("authorization") {
+        format!("Bearer {credential}")
+    } else {
+        credential
+    };
+    let request = request
+        .header(&fixture.carrier, value)
+        .body(Body::from(
+            serde_json::to_vec(&fixture.body).expect("serialize fixture body"),
+        ))
+        .expect("build fixture request");
+    let response = app.oneshot(request).await.expect("router response");
+    let status = response.status();
+    let body = response
+        .into_body()
+        .collect()
+        .await
+        .expect("response body")
+        .to_bytes();
+    (status, serde_json::from_slice(&body).unwrap_or(Value::Null))
+}
+
+/// Every fixture must authenticate with the carrier its real client uses. This
+/// is the precise contract issue #206 violated.
+#[tokio::test]
+async fn every_recorded_client_authenticates_with_its_own_carrier() {
+    for fixture in load_fixtures() {
+        let (status, body) = replay(&fixture, None).await;
+        assert!(
+            status != StatusCode::UNAUTHORIZED && status != StatusCode::FORBIDDEN,
+            "{} ({}) was refused at the credential check via {}: {status} {body}",
+            fixture.file,
+            fixture.client,
+            fixture.carrier
+        );
+    }
+}
+
+/// Every fixture must reach a real route. This is the other half of #206: the
+/// path a client actually calls can differ from the one synthetic tests
+/// exercise — Gemini CLI calls `:streamGenerateContent?alt=sse`, not
+/// `:generateContent`.
+///
+/// The router answers `route not found` for an unserved path, and a
+/// *model*-not-found for a served path whose catalog is empty (which is the
+/// case here, since no subscription is connected). Only the former is a
+/// routing failure, so the two `404`s are told apart by their message rather
+/// than collapsed.
+#[tokio::test]
+async fn every_recorded_client_reaches_a_route() {
+    for fixture in load_fixtures() {
+        let (status, body) = replay(&fixture, None).await;
+        if status != StatusCode::NOT_FOUND {
+            continue;
+        }
+        let message = serde_json::to_string(&body).unwrap_or_default();
+        assert!(
+            !message.contains("route not found"),
+            "{} ({}) hit no route at {} {}: {message}",
+            fixture.file,
+            fixture.client,
+            fixture.method,
+            fixture.path
+        );
+    }
+}
+
+/// An invalid credential in the same carrier must still be refused, so the
+/// contract above cannot be satisfied by accepting anything.
+#[tokio::test]
+async fn every_recorded_client_is_refused_an_invalid_credential() {
+    for fixture in load_fixtures() {
+        let (status, _) = replay(&fixture, Some("la_sk_not_a_real_token")).await;
+        assert_eq!(
+            status,
+            StatusCode::UNAUTHORIZED,
+            "{} ({}) accepted an invalid credential in {}",
+            fixture.file,
+            fixture.client,
+            fixture.carrier
+        );
+    }
+}
+
+/// The vendor headers real clients send must not disturb routing. Seven of the
+/// eight headers catalogued in issue #211 appear nowhere in the tree; the
+/// router very likely handles them by ignoring them, but that was an assumption
+/// no test stated.
+#[tokio::test]
+async fn vendor_specific_headers_do_not_disturb_routing() {
+    for fixture in load_fixtures() {
+        let (with_headers, _) = replay(&fixture, None).await;
+        let stripped = Fixture {
+            headers: fixture
+                .headers
+                .iter()
+                .filter(|(name, _)| name == "content-type" || name == "anthropic-version")
+                .cloned()
+                .collect(),
+            ..fixture
+        };
+        let (without_headers, _) = replay(&stripped, None).await;
+        assert_eq!(
+            with_headers, without_headers,
+            "{} routed differently once its vendor headers were removed",
+            stripped.file
+        );
+    }
+}

--- a/tests/fixtures/clients/README.md
+++ b/tests/fixtures/clients/README.md
@@ -1,0 +1,52 @@
+# Recorded client request fixtures
+
+One captured request per supported client: the method, path, headers and body
+shape that the real binary demonstrably sends. `tests/client_fixture_test.rs`
+replays each one against the router and asserts it authenticates, dispatches to
+the expected surface, and is answered in the expected dialect.
+
+The point is to make the fast tests assert against something a real client
+actually sent, rather than against a shape written by hand. Issue #206 is the
+worked example: every unit test passed while the documented Gemini CLI setup
+returned `401` on its first request, because no test sent what Gemini CLI
+actually sends — `x-goog-api-key` rather than `Authorization: Bearer`.
+
+## Format
+
+```json
+{
+  "client":  "gemini-cli",
+  "version": "0.51.0",
+  "source":  "how this was captured",
+  "method":  "POST",
+  "path":    "/api/gemini/v1beta/models/{model}:streamGenerateContent?alt=sse",
+  "credential_carrier": "x-goog-api-key",
+  "headers": { "...": "vendor headers, credentials redacted" },
+  "body":    { }
+}
+```
+
+`credential_carrier` names the header the token must be placed in when the
+fixture is replayed; `{model}` in a path is substituted by the test. Credential
+values are never stored — the test injects a freshly minted token.
+
+## Refreshing a fixture
+
+A fixture that silently ages is the original problem one release later, so
+regenerate them when a client is upgraded:
+
+1. Run the router with request logging on (it is on by default) and drive the
+   real client through it — `link-assistant-router with <client> "hi"` is
+   enough for a single turn.
+2. Read the `client_request` record from
+   `$DATA_DIR/requests/<token>/requests.jsonl`. Headers there are already
+   redacted by `redacted_headers`.
+3. Update the matching file: `method`, `path`, `headers`, `body`, and the
+   `version` the client reported in its `user-agent`.
+4. Run `cargo test --test client_fixture_test`. A failure here means the router
+   no longer serves what that client now sends, which is the signal this tier
+   exists to give.
+
+Recording requires a vendor subscription; replaying does not. That asymmetry is
+the point — the credentialed step happens once, by hand, and every CI run
+afterwards gets the benefit for free.

--- a/tests/fixtures/clients/claude-code.messages.json
+++ b/tests/fixtures/clients/claude-code.messages.json
@@ -1,0 +1,18 @@
+{
+  "client": "claude-code",
+  "version": "unpinned",
+  "source": "the Anthropic Messages shape Claude Code sends; the router's primary surface",
+  "method": "POST",
+  "path": "/v1/messages",
+  "credential_carrier": "x-api-key",
+  "expected_surface": "anthropic",
+  "headers": {
+    "content-type": "application/json",
+    "anthropic-version": "2023-06-01"
+  },
+  "body": {
+    "model": "{model}",
+    "max_tokens": 16,
+    "messages": [{"role": "user", "content": "ping"}]
+  }
+}

--- a/tests/fixtures/clients/codex-exec-0.147.0.responses.json
+++ b/tests/fixtures/clients/codex-exec-0.147.0.responses.json
@@ -1,0 +1,23 @@
+{
+  "client": "codex",
+  "version": "0.147.0",
+  "source": "issue #211, captured from a real codex_exec/0.147.0 run",
+  "method": "POST",
+  "path": "/api/codex/v1/responses",
+  "credential_carrier": "authorization",
+  "expected_surface": "openai-responses",
+  "headers": {
+    "user-agent": "codex_exec/0.147.0",
+    "content-type": "application/json",
+    "session-id": "redacted",
+    "x-codex-beta-features": "redacted",
+    "x-codex-turn-metadata": "redacted",
+    "x-codex-turn-state": "redacted",
+    "x-codex-window-id": "redacted",
+    "x-client-request-id": "redacted"
+  },
+  "body": {
+    "model": "{model}",
+    "input": [{"role": "user", "content": [{"type": "input_text", "text": "ping"}]}]
+  }
+}

--- a/tests/fixtures/clients/gemini-cli-0.51.0.stream-generate-content.json
+++ b/tests/fixtures/clients/gemini-cli-0.51.0.stream-generate-content.json
@@ -1,0 +1,18 @@
+{
+  "client": "gemini-cli",
+  "version": "0.51.0",
+  "source": "issue #211, captured from a real GeminiCLI-tui/0.51.0 run; the path is the streaming form the CLI actually calls",
+  "method": "POST",
+  "path": "/api/gemini/v1beta/models/{model}:streamGenerateContent?alt=sse",
+  "credential_carrier": "x-goog-api-key",
+  "expected_surface": "gemini",
+  "headers": {
+    "user-agent": "GeminiCLI-tui/0.51.0 (darwin; arm64)",
+    "content-type": "application/json",
+    "x-goog-api-client": "gl-node/22.14.0",
+    "x-gemini-api-privileged-user-id": "redacted"
+  },
+  "body": {
+    "contents": [{"role": "user", "parts": [{"text": "ping"}]}]
+  }
+}

--- a/tests/fixtures/clients/opencode-1.18.5.chat-completions.json
+++ b/tests/fixtures/clients/opencode-1.18.5.chat-completions.json
@@ -1,0 +1,19 @@
+{
+  "client": "opencode",
+  "version": "1.18.5",
+  "source": "issue #211, captured from a real opencode/1.18.5 run",
+  "method": "POST",
+  "path": "/v1/chat/completions",
+  "credential_carrier": "authorization",
+  "expected_surface": "openai-chat",
+  "headers": {
+    "user-agent": "opencode/1.18.5",
+    "content-type": "application/json",
+    "x-session-id": "redacted",
+    "x-session-affinity": "redacted"
+  },
+  "body": {
+    "model": "{model}",
+    "messages": [{"role": "user", "content": "ping"}]
+  }
+}

--- a/tests/fixtures/clients/qwen-code-0.7.1.chat-completions.json
+++ b/tests/fixtures/clients/qwen-code-0.7.1.chat-completions.json
@@ -1,0 +1,24 @@
+{
+  "client": "qwen-code",
+  "version": "0.7.1",
+  "source": "issue #211, captured from a real QwenCode/0.7.1 run (OpenAI/JS 5.23.2 SDK, hence the x-stainless-* set)",
+  "method": "POST",
+  "path": "/api/qwen/v1/chat/completions",
+  "credential_carrier": "authorization",
+  "expected_surface": "openai-chat",
+  "headers": {
+    "user-agent": "QwenCode/0.7.1",
+    "content-type": "application/json",
+    "x-stainless-lang": "js",
+    "x-stainless-package-version": "5.23.2",
+    "x-stainless-os": "MacOS",
+    "x-stainless-arch": "arm64",
+    "x-stainless-runtime": "node",
+    "x-stainless-runtime-version": "v22.14.0",
+    "x-stainless-retry-count": "0"
+  },
+  "body": {
+    "model": "{model}",
+    "messages": [{"role": "user", "content": "ping"}]
+  }
+}

--- a/tests/real_clients_test.rs
+++ b/tests/real_clients_test.rs
@@ -46,6 +46,8 @@ fn installed_supported_clients_complete_a_real_single_turn() {
         return;
     }
     let directory = tempfile::tempdir().unwrap();
+    let mut skipped = Vec::new();
+    let mut exercised = Vec::new();
     for (client, executable) in [
         ("claude-code", "claude"),
         ("codex", "codex"),
@@ -56,8 +58,13 @@ fn installed_supported_clients_complete_a_real_single_turn() {
         ("agent", "agent"),
     ] {
         if !command_exists(executable) {
+            // A silently skipped client is indistinguishable from a passing
+            // one, which is how this tier can report success while covering
+            // nothing (issue #211). Collect it and say so at the end.
+            skipped.push(client);
             continue;
         }
+        exercised.push(client);
         let output = run_wrapper(client, "Reply with exactly ROUTER_OK", directory.path());
         assert!(
             output.status.success(),
@@ -69,6 +76,12 @@ fn installed_supported_clients_complete_a_real_single_turn() {
             "{client} did not return the expected marker"
         );
     }
+    println!("real-client tier: exercised {exercised:?}, skipped (not installed) {skipped:?}");
+    assert!(
+        !exercised.is_empty(),
+        "ROUTER_REAL_CLIENT_TESTS=1 was set but no supported client is installed, so this \
+         tier asserted nothing. Install at least one of {skipped:?}, or leave the tier off."
+    );
 }
 
 #[test]

--- a/tests/request_logging_test.rs
+++ b/tests/request_logging_test.rs
@@ -214,3 +214,26 @@ fn a_declared_content_length_implies_a_non_empty_logged_body() {
         "content-length {declared} contradicts an empty body: {record}"
     );
 }
+
+/// A request whose body was genuinely read and was empty must not be labelled
+/// as unread. The marker keys on the contradiction between a declared length
+/// and an empty buffer, so a `content-length: 0` body takes the normal path.
+#[test]
+fn a_zero_length_body_is_not_reported_as_unread() {
+    let router = Router::start();
+    router
+        .post(
+            "/v1/chat/completions",
+            "authorization: Bearer la_sk_invalid\r\nx-test-marker: issue-210-zero-length\r\n",
+            "",
+        )
+        .expect("zero-length request");
+
+    let record = router.await_client_request("issue-210-zero-length");
+    let record: serde_json::Value = serde_json::from_str(&record).expect("record is JSON");
+    let body = record["body"].as_str().unwrap_or_default();
+    assert!(
+        !body.contains("NOT READ"),
+        "a declared-empty body must not be marked unread: {record}"
+    );
+}

--- a/tests/request_logging_test.rs
+++ b/tests/request_logging_test.rs
@@ -58,6 +58,42 @@ impl Router {
         Some(response)
     }
 
+    /// Send a request with a body, so the record can be checked against what
+    /// the client actually transmitted.
+    fn post(&self, path: &str, headers: &str, body: &str) -> Option<String> {
+        let mut stream = TcpStream::connect(("127.0.0.1", self.port)).ok()?;
+        write!(
+            stream,
+            "POST {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\
+             Content-Type: application/json\r\nContent-Length: {}\r\n{headers}\r\n{body}",
+            body.len()
+        )
+        .ok()?;
+        let mut response = String::new();
+        stream.read_to_string(&mut response).ok()?;
+        Some(response)
+    }
+
+    /// The `client_request` record for a correlation, once it lands.
+    fn await_client_request(&self, needle: &str) -> String {
+        let log_path = self
+            .data_dir
+            .path()
+            .join("requests/unauthenticated/requests.jsonl");
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline {
+            if let Ok(log) = std::fs::read_to_string(&log_path) {
+                for line in log.lines() {
+                    if line.contains("\"client_request\"") && line.contains(needle) {
+                        return line.to_string();
+                    }
+                }
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        panic!("no client_request record containing {needle}");
+    }
+
     fn wait_until_ready(&self) {
         let deadline = Instant::now() + Duration::from_secs(30);
         while Instant::now() < deadline {
@@ -99,5 +135,82 @@ fn successful_request_is_logged_by_default() {
     panic!(
         "successful request was not written to {}",
         log_path.display()
+    );
+}
+
+/// A request refused at authentication is logged with an empty body even though
+/// the client sent one, so the record asserts `content-length: N` and
+/// `"body": ""` at the same time. The body is captured lazily as a handler
+/// reads the stream, and a rejected request is never read (issue #210).
+#[test]
+fn a_rejected_request_does_not_claim_an_empty_body() {
+    let router = Router::start();
+    let response = router
+        .post(
+            "/v1/chat/completions",
+            "authorization: Bearer la_sk_invalid\r\nx-test-marker: issue-210-rejected\r\n",
+            r#"{"model":"m","messages":[{"role":"user","content":"MARKER-210"}]}"#,
+        )
+        .expect("rejected request");
+    assert!(
+        response.starts_with("HTTP/1.1 401"),
+        "expected a 401, got: {}",
+        response.lines().next().unwrap_or_default()
+    );
+
+    let record = router.await_client_request("issue-210-rejected");
+    let record: serde_json::Value = serde_json::from_str(&record).expect("record is JSON");
+    let body = record["body"].as_str().expect("body field is a string");
+    assert_ne!(
+        body, "",
+        "a request that declared a body must not be logged as empty: {record}"
+    );
+    assert!(
+        body.contains("MARKER-210") || body.contains("NOT READ"),
+        "body must be the content or an explicit marker, got {body:?}"
+    );
+}
+
+/// The marker must not swallow the genuinely bodiless case: a `GET` with no
+/// body has to stay distinguishable from a body that was never read.
+#[test]
+fn a_bodiless_request_is_still_logged_as_empty() {
+    let router = Router::start();
+    router
+        .request("x-test-marker: issue-210-bodiless\r\n")
+        .expect("bodiless request");
+
+    let record = router.await_client_request("issue-210-bodiless");
+    let record: serde_json::Value = serde_json::from_str(&record).expect("record is JSON");
+    assert_eq!(
+        record["body"], "",
+        "a request that declared no body is genuinely empty: {record}"
+    );
+}
+
+/// The two fields must agree: a record that reports a non-zero
+/// `content-length` must not also report an empty body.
+#[test]
+fn a_declared_content_length_implies_a_non_empty_logged_body() {
+    let router = Router::start();
+    router
+        .post(
+            "/v1/chat/completions",
+            "authorization: Bearer la_sk_invalid\r\nx-test-marker: issue-210-consistent\r\n",
+            r#"{"model":"m","messages":[{"role":"user","content":"CONSISTENCY"}]}"#,
+        )
+        .expect("rejected request");
+
+    let record = router.await_client_request("issue-210-consistent");
+    let record: serde_json::Value = serde_json::from_str(&record).expect("record is JSON");
+    let declared: u64 = record["headers"]["content-length"]
+        .as_str()
+        .expect("content-length is logged")
+        .parse()
+        .expect("content-length is a number");
+    assert!(declared > 0, "{record}");
+    assert_ne!(
+        record["body"], "",
+        "content-length {declared} contradicts an empty body: {record}"
     );
 }

--- a/tests/upstream_error_dialect_test.rs
+++ b/tests/upstream_error_dialect_test.rs
@@ -1,0 +1,281 @@
+//! One upstream failure, rendered correctly on every client surface (issue #213).
+//!
+//! The Anthropic and Gemini surfaces already translated upstream errors into
+//! their own dialect; the `OpenAI` surfaces relayed the vendor's body verbatim.
+//! That had two consequences: a client written against the `OpenAI` SDK could not
+//! classify the failure, and the body carried fields describing the *router
+//! operator's* subscription — `plan_type`, `eligible_promo`, `resets_at` — which
+//! say nothing about the caller's request and, in a shared deployment, disclose
+//! the operator's billing posture to anyone who triggers a `429`.
+//!
+//! The upstream body below is the real one from the issue.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::Router;
+use axum::body::Body;
+use axum::http::{HeaderValue, StatusCode};
+use axum::response::Response;
+use link_assistant_router::app_state::AppState;
+use link_assistant_router::config::UpstreamProvider;
+use link_assistant_router::model_catalog::ModelCatalogCache;
+use link_assistant_router::oauth::OAuthProvider;
+use link_assistant_router::refresh::TokenCache;
+use link_assistant_router::subscription::{SubscriptionProvider, SubscriptionReader};
+use link_assistant_router::token::TokenManager;
+use lino_arguments::Parser as _;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+/// The vendor's rate-limit body, verbatim from the issue: an error `type` that
+/// is not an `OpenAI` type, beside three operator-account fields.
+const UPSTREAM_RATE_LIMIT: &str = r#"{"error":{"type":"usage_limit_reached","message":"The usage limit has been reached","plan_type":"free","resets_at":1789529537,"eligible_promo":null,"resets_in_seconds":2488890}}"#;
+
+/// Fields that describe the operator's subscription rather than the request.
+const OPERATOR_FIELDS: [&str; 4] = [
+    "plan_type",
+    "eligible_promo",
+    "resets_at",
+    "usage_limit_reached",
+];
+
+struct TestRouter {
+    client: reqwest::Client,
+    url: String,
+    token: String,
+    tasks: Vec<tokio::task::JoinHandle<()>>,
+    _data: TempDir,
+}
+
+impl TestRouter {
+    async fn start() -> Self {
+        let data = tempfile::tempdir().expect("temporary test data");
+        let stub = Router::new().fallback(rate_limited_vendor);
+        let (stub_url, stub_task) = spawn(stub).await;
+
+        let token_manager = TokenManager::new("upstream-error-secret");
+        let token = token_manager
+            .issue_token(1, "upstream error client")
+            .expect("issue test token");
+        let oauth_provider = OAuthProvider::new(data.path().to_str().expect("UTF-8 test path"));
+        oauth_provider.set_token("stub-anthropic-oauth-token");
+
+        let codex_home = data.path().join("codex");
+        std::fs::create_dir_all(&codex_home).expect("create Codex home");
+        std::fs::write(
+            codex_home.join("auth.json"),
+            r#"{"tokens":{"access_token":"stub-codex-oauth-token","account_id":"acct_stub"}}"#,
+        )
+        .expect("write Codex credentials");
+
+        let catalogs = Arc::new(ModelCatalogCache::new());
+        catalogs.record_success(SubscriptionProvider::Codex, vec!["gpt-5".to_string()]);
+
+        let config = link_assistant_router::cli::Cli::try_parse_from(vec![
+            "router",
+            "--token-secret",
+            "upstream-error-secret",
+            "--data-dir",
+            data.path().to_str().expect("UTF-8 test path"),
+        ])
+        .expect("test CLI parses")
+        .into_config()
+        .expect("test config is valid");
+
+        let state = AppState {
+            client: reqwest::Client::new(),
+            token_manager,
+            oauth_provider,
+            account_router: None,
+            subscription_reader: None,
+            subscription_base_url: Some(stub_url.clone()),
+            subscription_readers: vec![SubscriptionReader::new(
+                SubscriptionProvider::Codex,
+                &codex_home,
+            )],
+            model_catalogs: catalogs,
+            subscription_cache: Arc::new(TokenCache::new()),
+            upstream_base_url: stub_url,
+            upstream_provider: UpstreamProvider::Auto,
+            gonka: None,
+            bridge_model: None,
+            bridge_model_policy:
+                link_assistant_router::bridge_selection::BridgeModelPolicy::default(),
+            crater: None,
+            openai_compatible: link_assistant_router::config::default_openai_compatible_config(),
+            provider_store: link_assistant_router::providers::ProviderStore::open(
+                data.path(),
+                "upstream-error-secret",
+            )
+            .expect("provider store"),
+            logger: log_lazy::LogLazy::new(),
+            admin: Arc::new(link_assistant_router::admin::AdminClaim::load(
+                Some("admin-only".to_string()),
+                data.path(),
+                Duration::from_secs(60),
+            )),
+            admin_key: Some("admin-only".to_string()),
+            allow_anonymous_admin: false,
+            metrics: Arc::new(link_assistant_router::metrics::Metrics::default()),
+            audit: Arc::new(link_assistant_router::audit::AuditLog::to_path(None)),
+            request_log: Arc::new(link_assistant_router::request_log::RequestLog::new(
+                data.path().join("requests"),
+                1024 * 1024,
+            )),
+            activitypub_actor_base_url: "https://router.test".to_string(),
+            activitypub_public_key_pem:
+                link_assistant_router::config::default_activitypub_public_key_pem(),
+            mpp: link_assistant_router::config::default_mpp_config(),
+            login_manager: link_assistant_router::login::LoginManager::new(
+                link_assistant_router::login::LoginConfig::default(),
+            ),
+            github: link_assistant_router::github_proxy::GitHubProxyConfig::default(),
+            max_proxy_request_bytes: link_assistant_router::config::DEFAULT_MAX_PROXY_REQUEST_BYTES,
+        };
+
+        let app = link_assistant_router::server_router::router(state, &config);
+        let (url, router_task) = spawn(app).await;
+
+        Self {
+            client: reqwest::Client::new(),
+            url,
+            token,
+            tasks: vec![stub_task, router_task],
+            _data: data,
+        }
+    }
+
+    async fn post(&self, path: &str, body: &Value) -> (StatusCode, Value) {
+        let response = self
+            .client
+            .post(format!("{}{path}", self.url))
+            .bearer_auth(&self.token)
+            .json(body)
+            .send()
+            .await
+            .expect("router POST");
+        let status = response.status();
+        let text = response.text().await.expect("router POST body");
+        (
+            status,
+            serde_json::from_str(&text).unwrap_or(Value::String(text)),
+        )
+    }
+}
+
+impl Drop for TestRouter {
+    fn drop(&mut self) {
+        for task in &self.tasks {
+            task.abort();
+        }
+    }
+}
+
+async fn spawn(app: Router) -> (String, tokio::task::JoinHandle<()>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test server");
+    let address = listener.local_addr().expect("test server address");
+    let task = tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve test app");
+    });
+    (format!("http://{address}"), task)
+}
+
+/// Every upstream call fails the same way, so one condition can be compared
+/// across surfaces.
+async fn rate_limited_vendor() -> Response {
+    let mut response = Response::new(Body::from(UPSTREAM_RATE_LIMIT));
+    *response.status_mut() = StatusCode::TOO_MANY_REQUESTS;
+    response
+        .headers_mut()
+        .insert("content-type", HeaderValue::from_static("application/json"));
+    response
+}
+
+fn body_text(body: &Value) -> String {
+    serde_json::to_string(body).expect("serialize body")
+}
+
+/// The `OpenAI` surfaces must render the vendor failure in the `OpenAI` dialect
+/// rather than passing it through.
+#[tokio::test]
+async fn openai_surfaces_render_upstream_errors_in_their_own_dialect() {
+    let router = TestRouter::start().await;
+    for path in ["/v1/chat/completions", "/v1/responses"] {
+        let (status, body) = router
+            .post(
+                path,
+                &json!({"model": "gpt-5", "messages": [{"role": "user", "content": "hi"}]}),
+            )
+            .await;
+        assert_eq!(status, StatusCode::TOO_MANY_REQUESTS, "{path}: {body}");
+        assert_eq!(
+            body["error"]["type"], "rate_limit_error",
+            "{path} must use an OpenAI error type: {body}"
+        );
+        assert_eq!(
+            body["error"]["code"], "rate_limit_exceeded",
+            "{path} must be classifiable by code: {body}"
+        );
+        // The caller must still learn what happened.
+        assert!(
+            body["error"]["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("usage limit")),
+            "{path} lost the message: {body}"
+        );
+    }
+}
+
+/// The operator's account details must not reach the caller on any surface.
+#[tokio::test]
+async fn no_surface_forwards_operator_account_fields() {
+    let router = TestRouter::start().await;
+    for path in ["/v1/chat/completions", "/v1/responses"] {
+        let (_, body) = router
+            .post(
+                path,
+                &json!({"model": "gpt-5", "messages": [{"role": "user", "content": "hi"}]}),
+            )
+            .await;
+        let text = body_text(&body);
+        for field in OPERATOR_FIELDS {
+            assert!(
+                !text.contains(field),
+                "{path} leaked the operator field {field}: {text}"
+            );
+        }
+    }
+}
+
+/// The Anthropic surface already translated correctly and must keep doing so:
+/// it consumes the `OpenAI`-dialect body this change now produces.
+#[tokio::test]
+async fn the_anthropic_surface_rendering_is_unchanged() {
+    let router = TestRouter::start().await;
+    let (status, body) = router
+        .post(
+            "/v1/messages",
+            &json!({
+                "model": "gpt-5",
+                "max_tokens": 16,
+                "messages": [{"role": "user", "content": "hi"}]
+            }),
+        )
+        .await;
+    assert_eq!(status, StatusCode::TOO_MANY_REQUESTS, "{body}");
+    assert_eq!(body["type"], "error", "{body}");
+    assert_eq!(body["error"]["type"], "rate_limit_error", "{body}");
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("usage limit")),
+        "the Anthropic surface lost the message: {body}"
+    );
+    let text = body_text(&body);
+    for field in OPERATOR_FIELDS {
+        assert!(!text.contains(field), "leaked {field}: {text}");
+    }
+}


### PR DESCRIPTION
Closes #210. Closes #211. Closes #212. Closes #213.

Four issues, each with a precise diagnosis I could confirm before changing anything. Every fix has a test I verified fails without it.

## #210 — rejected requests logged with an empty body

A single record asserted both `content-length: 104` and `"body": ""`. The cause is as diagnosed: the capture fills lazily as a handler reads the stream, and a request refused at authentication is never read, so the buffer stays empty and is indistinguishable from a genuinely bodiless `GET`.

I took the issue's **preferred** option — the explicit marker, not buffering. Buffering would let an unauthenticated caller make the router hold `MAX_BUFFERED_REQUEST_BYTES` per request, which is a poor trade for a log field. The record now reads `[NOT READ: request was rejected before the body was consumed]`.

The marker is gated on the client having *declared* a body (`content-length > 0`, or chunked encoding), so a bodiless `GET` still logs `""` — the two cases never collapse. All four requested tests are covered, including the `content-length`/`body` consistency assertion.

## #212 — misaligned `auth status` column

Exactly as diagnosed: `write_str` bypasses the formatter's width, so `{:<8}` compiles and is then ignored. `f.pad` applies it. Fixed for `ChatChannel` too, which had the same latent bug.

The test is the issue's own one-liner. It fails before the change with `[codex]` vs `[codex   ]` — worth having precisely because the compiler cannot see this.

## #213 — upstream errors returned raw on the OpenAI surfaces

Two distinct problems, both fixed:

1. **Dialect.** Now rendered through the OpenAI shape, matching what the Anthropic and Gemini surfaces already do. A `429` arrives as `type: "rate_limit_error"`, `code: "rate_limit_exceeded"` — classifiable by an OpenAI SDK, which is the entire point of an OpenAI-compatible surface.

2. **Operator account fields.** `plan_type`, `eligible_promo` and `resets_at` describe the *router operator's* subscription. In a shared deployment the caller is a different party, so every `429` disclosed the operator's billing posture. These no longer cross the boundary. I marked this **Security** in the changelog — it is a disclosure fix, not just a shape fix.

On the *"verbatim for diagnosability"* policy the issue raised: it does not apply here, and the issue is right that the two aren't in tension. The raw body is still captured by `record_upstream_body`, so an operator debugging a failure has the full text regardless. Only what is returned *to the client* changed.

**One thing worth reviewing:** `anthropic_bridge` delegates to this same forwarder and re-translates its output. I confirmed it reads `/error/message` — which the new body provides — so the two compose. The Anthropic rendering is asserted unchanged rather than assumed, and that test passes both with and without the fix.

## #211 — fast tests assert shapes no real client sends

The most substantial change, and the one that prevents recurrence.

`tests/fixtures/clients/` holds one recorded request per client, carrying the real method, path, headers and credential carrier from the traffic catalogued in the issue — including the seven vendor headers that appear nowhere else in the tree. `tests/client_fixture_test.rs` replays each against the real router and pins four contracts: it authenticates with *its own* carrier, reaches a route, is refused an invalid credential, and routes identically with and without its vendor headers.

**Verified against the original defect:** reverting the #206 `x-goog-api-key` fix makes this tier fail and name the Gemini fixture. A bug that previously required a real binary and a vendor subscription to find now fails offline in milliseconds. That is the claim the issue makes, and it holds.

Recording needs a subscription; replaying does not — so the credentialed step happens once, by hand, and every CI run benefits. `tests/fixtures/clients/README.md` documents the refresh procedure (item 4), since a fixture that silently ages is the same problem one release later.

Also (item 5): a nightly `Real Clients` workflow now runs the opt-in real-binary tier, which was referenced by no workflow at all. It skips cleanly with a notice when no router is configured. And the tier now reports which clients it exercised and which it skipped, failing when none is installed — previously **a silently skipped client was indistinguishable from a passing one**, which is the deeper reason this gap persisted.

### Scope note
I did not fabricate traffic I could not observe. The fixtures use the headers, versions and paths recorded in #211 from real runs; where the issue did not pin a client version (`claude-code`), the fixture says `unpinned` rather than inventing one.

## One out-of-scope commit: `h2` 0.4.16

`Dependency Audit` started failing on this branch even though it changes no dependency. The cause is **RUSTSEC-2026-0258**, published 2026-08-17 — after the last green run on `main` — against `h2`, which reaches us transitively via hyper/reqwest. It accepts and queues empty DATA frames without limit, growing memory unboundedly or panicking on length overflow if streams are not drained. Low severity.

I bumped the lockfile to the patched `0.4.16`. Flagging it because it is unrelated to the four issues and would otherwise be an unexplained dependency change in this diff.

Note `cargo update -p h2` also **downgraded `windows-sys` 0.61.2 → 0.52.0** across six packages, which I did not want to smuggle into a fix for four unrelated issues — so the bump is applied directly and touches exactly two lines (version + checksum). `cargo check --locked` accepts it and `cargo audit` exits clean.

## Verification
- 864 tests pass; `cargo fmt`, `clippy --all-targets --all-features -D warnings`, CI's exact rustdoc command, and the 1000-line file check are all clean.
- Each fix verified to fail without its change: #210 (2 of 3 tests fail, the bodiless one correctly still passes), #212, #213 (2 OpenAI tests fail, Anthropic unaffected), #211 (fails on the reverted #206 fix).
- `src/request_log.rs` crossed the 1000-line limit, so its inline test module moved to `request_log_tests.rs` using the `#[path]` pattern already used for its isolation tests. No test content changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
