### PR TITLE
fix(clients): name clients after the commands they install as

### DIFF
--- a/README.md
+++ b/README.md
@@ -881,11 +881,11 @@ link-assistant-router providers list
 # Safely configure local agentic CLIs against this router:
 link-assistant-router clients list
 link-assistant-router clients setup codex
-link-assistant-router clients setup claude-code --token la_sk_...
+link-assistant-router clients setup claude --token la_sk_...
 link-assistant-router clients setup opencode
-link-assistant-router clients setup qwen-code
+link-assistant-router clients setup qwen
 link-assistant-router clients setup agent
-link-assistant-router clients setup grok-cli
+link-assistant-router clients setup grok
 link-assistant-router clients show codex
 link-assistant-router clients doctor codex
 link-assistant-router clients remove codex

--- a/changelog.d/20260819_100000_issue_220_client_names.md
+++ b/changelog.d/20260819_100000_issue_220_client_names.md
@@ -1,0 +1,9 @@
+---
+bump: minor
+---
+
+### Changed
+- Clients are now named after the command they install as: `claude`, `gemini`, `grok`, `qwen` and `cursor-agent`, rather than `claude-code`, `gemini-cli`, `grok-cli`, `qwen-code` and `cursor`. The descriptive names were what `--help`, the `invalid value` error, `clients list` and the docs all advertised, but they are not what the user's shell has — someone who had just installed `claude` had no reason to guess the router called it `claude-code`, and the error message taught the wrong name. The short forms already worked as aliases; nothing announced them.
+- The superseded names remain accepted, so existing scripts and previously documented commands keep working. `clients list`, `--help` and the error text now show the canonical names, and `docs/use-cases/` has been updated to match.
+- The managed environment and credential-metadata files are named from the client, so an installation set up before this release keeps its `claude-code.env` and `qwen-code.credential.json`: an existing file under the previous name is still found, and only new ones use the canonical name. Without that, a rename alone would have quietly orphaned those files and told the user to re-run a setup they had already run.
+- The `with` wrapper's argument-boundary detection now derives its client names from the client table instead of a hand-written copy, which had already fallen out of step: it listed no entry for `cursor-agent`, so that client's arguments would not have been protected.

--- a/docs/use-cases/cli-claude-code.md
+++ b/docs/use-cases/cli-claude-code.md
@@ -5,14 +5,14 @@
 ## One-line temporary launch
 
 ```bash
-link-assistant-router with claude-code "hi"
+link-assistant-router with claude "hi"
 ```
 
 The wrapper points a disposable `CLAUDE_CONFIG_DIR` at the router and supplies
 `ANTHROPIC_BASE_URL` plus `ANTHROPIC_AUTH_TOKEN`; the normal Claude settings are
 not changed. See [with-router.md](with-router.md) for server and token options.
 
-Wrapper flags may appear before or after `claude-code`; an explicit `--`
+Wrapper flags may appear before or after `claude`; an explicit `--`
 forwards every later token verbatim. See
 [with-router.md](with-router.md#arguments-interaction-and-models).
 
@@ -21,8 +21,8 @@ forwards every later token verbatim. See
 Automatic setup (merges the router URL and backs up an existing settings file):
 
 ```bash
-link-assistant-router clients setup claude-code
-# Run the `source …/claude-code.env` command printed by setup.
+link-assistant-router clients setup claude
+# Run the `source …/claude.env` command printed by setup.
 ```
 
 See [configure-clients.md](configure-clients.md) for show, remove, and doctor.

--- a/docs/use-cases/cli-cursor.md
+++ b/docs/use-cases/cli-cursor.md
@@ -1,7 +1,7 @@
 # CLI: Cursor CLI (`cursor-agent`) — not implemented
 
 **Status: not implemented.** No router version routes Cursor CLI natively, and
-`with cursor` fails before launch. This is a statement about what exists, not a
+`with cursor-agent` fails before launch. This is a statement about what exists, not a
 prediction: the adapter below is scoped and buildable, it has simply not been
 built, and a contributor is welcome to take it (issue #207).
 
@@ -12,7 +12,7 @@ and carries a real security cost, which that section states in full.
 ## One-line capability check
 
 ```bash
-link-assistant-router with cursor "hi"
+link-assistant-router with cursor-agent "hi"
 ```
 
 This exits nonzero before launching Cursor and explains the missing Connect-RPC

--- a/docs/use-cases/cli-gemini-cli.md
+++ b/docs/use-cases/cli-gemini-cli.md
@@ -6,7 +6,7 @@
 ## One-line temporary launch
 
 ```bash
-link-assistant-router with gemini-cli "hi"
+link-assistant-router with gemini "hi"
 ```
 
 The wrapper selects the Gemini API-key flow below a disposable
@@ -15,7 +15,7 @@ passes the run token as `GEMINI_API_KEY`. The normal Gemini home is untouched.
 Permanent setup is not offered because this endpoint override belongs to the
 API-key environment. See [with-router.md](with-router.md).
 
-Wrapper flags may appear before or after `gemini-cli`; an explicit `--`
+Wrapper flags may appear before or after `gemini`; an explicit `--`
 forwards every later token verbatim. See
 [with-router.md](with-router.md#arguments-interaction-and-models).
 

--- a/docs/use-cases/cli-grok-cli.md
+++ b/docs/use-cases/cli-grok-cli.md
@@ -6,7 +6,7 @@
 ## One-line temporary launch
 
 ```bash
-link-assistant-router with grok-cli "hi"
+link-assistant-router with grok "hi"
 ```
 
 The wrapper isolates `HOME` and supplies `GROK_BASE_URL=URL/v1` and a per-run
@@ -14,7 +14,7 @@ The wrapper isolates `HOME` and supplies `GROK_BASE_URL=URL/v1` and a per-run
 users to the temporary or manual environment path. See
 [with-router.md](with-router.md).
 
-Wrapper flags may appear before or after `grok-cli`; an explicit `--` forwards
+Wrapper flags may appear before or after `grok`; an explicit `--` forwards
 every later token verbatim. See
 [with-router.md](with-router.md#arguments-interaction-and-models).
 
@@ -36,7 +36,7 @@ The current settings schema can store `apiKey` in
 from `GROK_BASE_URL`. The router therefore writes both exports to a protected
 mode-`0600` environment file instead of the client settings or terminal output.
 
-`link-assistant-router clients setup grok-cli` prints the command that sources
+`link-assistant-router clients setup grok` prints the command that sources
 that file. Chat token limits sent by Grok are dropped only when forwarding to a
 Codex subscription, whose backend cannot accept them.
 

--- a/docs/use-cases/cli-qwen-code.md
+++ b/docs/use-cases/cli-qwen-code.md
@@ -12,7 +12,7 @@ which is exactly what a per-task `la_sk_…` token wants.
 ## One-line temporary launch
 
 ```bash
-link-assistant-router with qwen-code "hi"
+link-assistant-router with qwen "hi"
 ```
 
 The wrapper uses an isolated `HOME`, writes a disposable Qwen settings file,
@@ -20,7 +20,7 @@ and supplies `OPENAI_BASE_URL`, `OPENAI_API_KEY`, and
 `LINK_ASSISTANT_TOKEN`. The normal `$QWEN_HOME` is untouched. See
 [with-router.md](with-router.md).
 
-Wrapper flags may appear before or after `qwen-code`; an explicit `--`
+Wrapper flags may appear before or after `qwen`; an explicit `--`
 forwards every later token verbatim. See
 [with-router.md](with-router.md#arguments-interaction-and-models).
 
@@ -42,8 +42,8 @@ forwards every later token verbatim. See
 ```
 
 ```bash
-link-assistant-router clients setup qwen-code
-# Run the `source …/qwen-code.env` command printed by setup.
+link-assistant-router clients setup qwen
+# Run the `source …/qwen.env` command printed by setup.
 qwen
 ```
 

--- a/docs/use-cases/configure-clients.md
+++ b/docs/use-cases/configure-clients.md
@@ -5,7 +5,7 @@ modify normal client configuration:
 
 ```bash
 link-assistant-router with codex "hi"
-with-router claude-code "hi"
+with-router claude "hi"
 ```
 
 See [with-router.md](with-router.md) for the integration registry, server
@@ -19,7 +19,7 @@ replacing unrelated user settings:
 link-assistant-router clients list
 link-assistant-router clients setup codex
 link-assistant-router clients setup opencode --token la_sk_...
-link-assistant-router clients setup qwen-code
+link-assistant-router clients setup qwen
 link-assistant-router clients setup agent
 link-assistant-router clients show codex
 link-assistant-router clients doctor codex
@@ -99,10 +99,10 @@ it never creates a duplicate.
 
 Grok's current settings schema can persist `apiKey`, but it reads the API base
 URL only from `GROK_BASE_URL`. To avoid writing an ignored setting,
-`clients setup grok-cli` puts both required exports in the protected environment
+`clients setup grok` puts both required exports in the protected environment
 file and leaves `user-settings.json` untouched.
 
-`clients setup cursor` and `clients setup gemini-cli` return the verified
+`clients setup cursor-agent` and `clients setup gemini` return the verified
 client-side limitation before minting a token or writing a file. Their matching
 `doctor` commands report the same reason directly; they do not misdiagnose a
 request that never reached the router.

--- a/docs/use-cases/with-router.md
+++ b/docs/use-cases/with-router.md
@@ -20,13 +20,17 @@ later invocation sweeps directories left behind by a wrapper killed with
 | Tool | Dialect and router base | Temporary isolation | Permanent target |
 | --- | --- | --- | --- |
 | `codex` | Responses, `URL/v1` | isolated `HOME` | `$CODEX_HOME/config.toml` or `~/.codex/config.toml` |
-| `claude-code` (`claude`) | Anthropic Messages, `URL` | `CLAUDE_CONFIG_DIR` | `$CLAUDE_CONFIG_DIR/settings.json` or `~/.claude/settings.json` |
-| `gemini-cli` (`gemini`) | Gemini native, `URL/api/gemini` | `GEMINI_CLI_HOME` | temporary only; API-key endpoint override is environmental |
-| `grok-cli` (`grok`) | Chat Completions, `URL/v1` | isolated `HOME` plus environment | owner-only managed environment file |
+| `claude` (`claude-code`) | Anthropic Messages, `URL` | `CLAUDE_CONFIG_DIR` | `$CLAUDE_CONFIG_DIR/settings.json` or `~/.claude/settings.json` |
+| `gemini` (`gemini-cli`) | Gemini native, `URL/api/gemini` | `GEMINI_CLI_HOME` | temporary only; API-key endpoint override is environmental |
+| `grok` (`grok-cli`) | Chat Completions, `URL/v1` | isolated `HOME` plus environment | owner-only managed environment file |
 | `opencode` | Chat Completions, `URL/v1` | `OPENCODE_CONFIG` | `$XDG_CONFIG_HOME/opencode/opencode.json` |
-| `qwen-code` (`qwen`) | Chat Completions, `URL/v1` | isolated `HOME` | `$QWEN_HOME/settings.json` or `~/.qwen/settings.json` |
+| `qwen` (`qwen-code`) | Chat Completions, `URL/v1` | isolated `HOME` | `$QWEN_HOME/settings.json` or `~/.qwen/settings.json` |
 | `agent` | Chat Completions, `URL/v1` | temporary config content | `$XDG_CONFIG_HOME/link-assistant-agent/opencode.json` |
-| `cursor` | Cursor Connect-RPC (`agent.v1` / `aiserver.v1`) | not implemented: router RPC adapter does not exist | none |
+| `cursor-agent` (`cursor`) | Cursor Connect-RPC (`agent.v1` / `aiserver.v1`) | not implemented: router RPC adapter does not exist | none |
+
+Each name is the command the client installs as, which is what your shell
+already has; the descriptive form in parentheses is kept as an alias, so
+`with claude-code` and `clients setup qwen-code` continue to work.
 
 Each client-specific document keeps a binary-free manual path with the exact
 environment variables or config fields. Cursor deliberately fails before

--- a/src/cli/with.rs
+++ b/src/cli/with.rs
@@ -28,20 +28,13 @@ pub fn protect_client_arguments(arguments: Vec<OsString>, nested: bool) -> Vec<O
         "--run-ttl-hours",
         "--run-max-requests",
     ];
-    let clients = [
-        "codex",
-        "claude-code",
-        "claude",
-        "cursor",
-        "gemini-cli",
-        "gemini",
-        "grok-cli",
-        "grok",
-        "opencode",
-        "qwen-code",
-        "qwen",
-        "agent",
-    ];
+    // Derived from the client table rather than hand-listed: a name missing
+    // here silently stops protecting that client's arguments, which is what a
+    // hardcoded copy invites every time a name changes (issue #220).
+    let clients: Vec<&str> = crate::clients::ClientKind::ALL
+        .iter()
+        .flat_map(|kind| [kind.canonical_name(), kind.legacy_name()])
+        .collect();
     let boolean_options = [
         "--global",
         "--undo",

--- a/src/clients.rs
+++ b/src/clients.rs
@@ -80,18 +80,31 @@ pub struct ClientIntegration {
 }
 
 /// Documented local clients, including clients whose vendor gates prevent setup.
+/// A supported client, named as the user's own shell names it.
+///
+/// The canonical value of each variant is the **installed command**, because
+/// that is the name the user typed to install the tool and types to run it. The
+/// descriptive long forms (`claude-code`, `qwen-code`, …) are kept as aliases so
+/// existing scripts and documented commands keep working.
+///
+/// Before this, the advertised names were the descriptive ones while the short
+/// names existed only as invisible aliases — so `--help` and the `invalid value`
+/// error taught a name the user's shell does not have (issue #220). The
+/// invariant that keeps the two in step is asserted in the tests below: every
+/// variant's canonical string equals its [`ClientIntegration::command`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
 pub enum ClientKind {
     Codex,
-    #[value(alias = "claude")]
+    #[value(name = "claude", alias = "claude-code")]
     ClaudeCode,
+    #[value(name = "cursor-agent", alias = "cursor")]
     Cursor,
-    #[value(alias = "gemini")]
+    #[value(name = "gemini", alias = "gemini-cli")]
     GeminiCli,
-    #[value(alias = "grok")]
+    #[value(name = "grok", alias = "grok-cli")]
     GrokCli,
     Opencode,
-    #[value(alias = "qwen")]
+    #[value(name = "qwen", alias = "qwen-code")]
     QwenCode,
     Agent,
 }
@@ -272,18 +285,42 @@ impl ClientKind {
     }
 }
 
+impl ClientKind {
+    /// The canonical name: the command the client installs as.
+    ///
+    /// This is the single source of the name every surface shows, so
+    /// `clients list`, `--help` and the `invalid value` error cannot disagree
+    /// (issue #220). It is asserted equal to [`ClientIntegration::command`] in
+    /// the tests, which is the invariant that keeps them from drifting.
+    #[must_use]
+    pub const fn canonical_name(self) -> &'static str {
+        self.integration().command
+    }
+
+    /// The name this client used before v0.91.0.
+    ///
+    /// Kept because it names files already on disk — the managed environment
+    /// and credential-metadata paths are derived from the client name, so a
+    /// rename alone would orphan an existing installation's `claude-code.env`
+    /// rather than migrate it.
+    #[must_use]
+    pub const fn legacy_name(self) -> &'static str {
+        match self {
+            Self::ClaudeCode => "claude-code",
+            Self::Cursor => "cursor",
+            Self::GeminiCli => "gemini-cli",
+            Self::GrokCli => "grok-cli",
+            Self::Codex => "codex",
+            Self::Opencode => "opencode",
+            Self::QwenCode => "qwen-code",
+            Self::Agent => "agent",
+        }
+    }
+}
+
 impl fmt::Display for ClientKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Codex => write!(f, "codex"),
-            Self::ClaudeCode => write!(f, "claude-code"),
-            Self::Cursor => write!(f, "cursor"),
-            Self::GeminiCli => write!(f, "gemini-cli"),
-            Self::GrokCli => write!(f, "grok-cli"),
-            Self::Opencode => write!(f, "opencode"),
-            Self::QwenCode => write!(f, "qwen-code"),
-            Self::Agent => write!(f, "agent"),
-        }
+        f.pad(self.canonical_name())
     }
 }
 
@@ -429,17 +466,33 @@ impl ClientManager {
 
     #[must_use]
     pub fn environment_path(&self, client: ClientKind) -> PathBuf {
-        self.config_home
-            .join("link-assistant-router/clients")
-            .join(format!("{client}.env"))
+        self.managed_path(client, "env")
+    }
+
+    /// The managed file for `client`, preferring the canonical name but
+    /// honouring a file already written under the pre-v0.91.0 name.
+    ///
+    /// The client names became the real command names in v0.91.0 (issue #220),
+    /// and these paths are derived from the name — so without this an existing
+    /// installation's `claude-code.env` would simply stop being found, and the
+    /// user would be told to run a setup they had already run.
+    fn managed_path(&self, client: ClientKind, extension: &str) -> PathBuf {
+        let directory = self.config_home.join("link-assistant-router/clients");
+        let canonical = directory.join(format!("{}.{extension}", client.canonical_name()));
+        if canonical.exists() {
+            return canonical;
+        }
+        let legacy = directory.join(format!("{}.{extension}", client.legacy_name()));
+        if legacy.exists() {
+            return legacy;
+        }
+        canonical
     }
 
     /// Where the secret-free record of the managed credential is kept.
     #[must_use]
     pub fn credential_metadata_path(&self, client: ClientKind) -> PathBuf {
-        self.config_home
-            .join("link-assistant-router/clients")
-            .join(format!("{client}.credential.json"))
+        self.managed_path(client, "credential.json")
     }
 
     /// Read the credential record written by the last `clients setup`.
@@ -909,19 +962,5 @@ fn shell_quote(value: &str) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn rejects_non_http_router_urls() {
-        assert!(normalize_base_url("router.internal:8080").is_err());
-    }
-
-    #[test]
-    fn compact_diagnostics_do_not_echo_unbounded_upstream_bodies() {
-        let body = "x".repeat(500);
-        let compact = compact_body(&body);
-        assert!(compact.ends_with('…'));
-        assert!(compact.chars().count() <= 241);
-    }
-}
+#[path = "clients_tests.rs"]
+mod tests;

--- a/src/clients_tests.rs
+++ b/src/clients_tests.rs
@@ -1,0 +1,118 @@
+//! Tests for [`crate::clients`].
+//!
+//! Split from `clients.rs` to keep that file within the repository's 1000-line
+//! limit.
+
+use clap::ValueEnum as _;
+
+/// The name every surface advertises must be the command the client
+/// actually installs as. Advertising `claude-code` while the user's shell
+/// has `claude` taught a name that does not exist (issue #220).
+///
+/// One assertion over the existing table, so the two cannot drift apart.
+#[test]
+fn the_canonical_name_is_the_real_command() {
+    for integration in super::CLIENT_INTEGRATIONS {
+        let advertised = integration
+            .kind
+            .to_possible_value()
+            .expect("every client is selectable")
+            .get_name()
+            .to_string();
+        assert_eq!(
+            advertised, integration.command,
+            "{advertised} is advertised but the command is {}",
+            integration.command
+        );
+        // `Display` drives `clients list` and the managed file names, so it
+        // must agree with what the parser advertises.
+        assert_eq!(integration.kind.to_string(), integration.command);
+        assert_eq!(integration.kind.canonical_name(), integration.command);
+    }
+}
+
+/// The superseded long forms must keep parsing, so this rename does not
+/// break existing scripts or the commands already documented elsewhere.
+#[test]
+fn every_legacy_client_name_still_parses() {
+    for (legacy, expected) in [
+        ("claude-code", super::ClientKind::ClaudeCode),
+        ("cursor", super::ClientKind::Cursor),
+        ("gemini-cli", super::ClientKind::GeminiCli),
+        ("grok-cli", super::ClientKind::GrokCli),
+        ("qwen-code", super::ClientKind::QwenCode),
+    ] {
+        assert_eq!(
+            super::ClientKind::from_str(legacy, true),
+            Ok(expected),
+            "{legacy} must remain accepted"
+        );
+    }
+    // And the canonical names parse, naturally.
+    for integration in super::CLIENT_INTEGRATIONS {
+        assert_eq!(
+            super::ClientKind::from_str(integration.command, true),
+            Ok(integration.kind),
+            "{} must parse",
+            integration.command
+        );
+    }
+}
+
+/// A managed file written under the pre-rename name must still be found.
+/// These paths are derived from the client name, so without the fallback an
+/// existing installation's `claude-code.env` would simply stop being seen
+/// and the user would be told to run a setup they had already run.
+#[test]
+fn a_file_written_under_the_legacy_name_is_still_found() {
+    let home = tempfile::tempdir().expect("temp home");
+    let clients = home.path().join(".config/link-assistant-router/clients");
+    std::fs::create_dir_all(&clients).expect("create managed directory");
+    let legacy = clients.join("claude-code.env");
+    std::fs::write(&legacy, "TOKEN=x").expect("write legacy file");
+
+    let manager = super::ClientManager::isolated(home.path());
+    assert_eq!(
+        manager.environment_path(super::ClientKind::ClaudeCode),
+        legacy,
+        "an existing legacy file must be honoured"
+    );
+}
+
+/// A fresh installation uses the canonical name, so the legacy names do not
+/// outlive the migration.
+#[test]
+fn a_fresh_installation_uses_the_canonical_name() {
+    let home = tempfile::tempdir().expect("temp home");
+    let manager = super::ClientManager::isolated(home.path());
+    let path = manager.environment_path(super::ClientKind::ClaudeCode);
+    assert!(
+        path.ends_with("claude.env"),
+        "expected the canonical name, got {}",
+        path.display()
+    );
+}
+
+/// Every variant is covered by the legacy table, so the file-migration
+/// fallback cannot silently miss one.
+#[test]
+fn every_client_has_a_legacy_name() {
+    for kind in super::ClientKind::ALL {
+        assert!(!kind.legacy_name().is_empty(), "{kind} has no legacy name");
+    }
+}
+
+use super::*;
+
+#[test]
+fn rejects_non_http_router_urls() {
+    assert!(normalize_base_url("router.internal:8080").is_err());
+}
+
+#[test]
+fn compact_diagnostics_do_not_echo_unbounded_upstream_bodies() {
+    let body = "x".repeat(500);
+    let compact = compact_body(&body);
+    assert!(compact.ends_with('…'));
+    assert!(compact.chars().count() <= 241);
+}

--- a/tests/clients_cli_test.rs
+++ b/tests/clients_cli_test.rs
@@ -225,7 +225,7 @@ fn claude_code_setup_preserves_settings_without_storing_the_token() {
     assert!(!String::from_utf8_lossy(&setup.stdout).contains("la_sk_existing"));
     let environment = fs::read_to_string(
         home.path()
-            .join(".config/link-assistant-router/clients/claude-code.env"),
+            .join(".config/link-assistant-router/clients/claude.env"),
     )
     .expect("read Claude credential file");
     assert!(environment.contains("export ANTHROPIC_AUTH_TOKEN='la_sk_existing'"));
@@ -474,17 +474,26 @@ fn list_covers_every_documented_client_and_agent() {
     let listed = router(home.path(), &["clients", "list"]);
     assert!(listed.status.success());
     let output = String::from_utf8_lossy(&listed.stdout);
+    // The canonical names are the real commands, so what `clients list` shows
+    // is what the user's shell has (issue #220).
     for client in [
         "codex",
-        "claude-code",
-        "cursor",
-        "gemini-cli",
-        "grok-cli",
+        "claude",
+        "cursor-agent",
+        "gemini",
+        "grok",
         "opencode",
-        "qwen-code",
+        "qwen",
         "agent",
     ] {
         assert!(output.contains(client), "missing {client} from:\n{output}");
+    }
+    // The superseded long forms must not reappear as displayed names.
+    for legacy in ["claude-code", "gemini-cli", "grok-cli", "qwen-code"] {
+        assert!(
+            !output.contains(legacy),
+            "list still shows the legacy name {legacy}:\n{output}"
+        );
     }
 }
 
@@ -733,7 +742,7 @@ fn grok_setup_stores_both_required_exports_without_persisting_in_client_config()
     assert!(!output.contains("la_sk_existing"));
     let environment = fs::read_to_string(
         home.path()
-            .join(".config/link-assistant-router/clients/grok-cli.env"),
+            .join(".config/link-assistant-router/clients/grok.env"),
     )
     .expect("read Grok credential file");
     assert!(environment.contains("export GROK_BASE_URL='http://router.test:8080/v1'"));

--- a/tests/clients_token_revocation_test.rs
+++ b/tests/clients_token_revocation_test.rs
@@ -16,18 +16,13 @@ use std::path::Path;
 use std::process::{Command, Output};
 
 /// Clients whose permanent setup this router supports.
-const SUPPORTED: [&str; 6] = [
-    "codex",
-    "claude-code",
-    "opencode",
-    "qwen-code",
-    "agent",
-    "grok-cli",
-];
+/// Named canonically: the client names are the real commands (issue #220), and
+/// these names also derive the managed file paths asserted below.
+const SUPPORTED: [&str; 6] = ["codex", "claude", "opencode", "qwen", "agent", "grok"];
 
 /// Clients whose setup fetches the model catalog before writing anything.
 fn needs_catalog(client: &str) -> bool {
-    matches!(client, "opencode" | "qwen-code" | "agent")
+    matches!(client, "opencode" | "qwen" | "agent")
 }
 
 const BACKENDS: [&str; 2] = ["text", "binary"];


### PR DESCRIPTION
Closes #220.

`--help`, the `invalid value` error, `clients list` and the docs all advertised `claude-code`, `gemini-cli`, `grok-cli`, `qwen-code` and `cursor` — none of which is what the user's shell has. Someone who had just installed `claude` had no reason to guess the router called it `claude-code`, and the error message actively taught the wrong name. The short forms already worked as aliases; nothing announced them, because clap does not list aliases.

Canonical names are now the real commands. The descriptive forms are kept as aliases, so existing scripts and previously documented commands keep working.

```
before: [possible values: codex, claude-code, cursor, gemini-cli, grok-cli, opencode, qwen-code, agent]
after:  [possible values: codex, claude, cursor-agent, gemini, grok, opencode, qwen, agent]
```

## Two consequences the issue doesn't raise — the important part of this PR

**1. `Display` had to change too, and it names files on disk.**

`clients list` prints via `Display`, not the ValueEnum, so changing only the enum attributes would have left the list showing names the CLI no longer accepts — and the existing test would not have caught it, because `assert!(output.contains("cursor"))` still passes against `cursor-agent`.

But `Display` *also* derives the managed file paths — `<client>.env` and `<client>.credential.json`. Renaming it alone would have silently orphaned every existing installation's `claude-code.env`, and told the user to run a setup they had already run.

So an existing file under the previous name is still found, and only new installations use the canonical name. Both directions are tested, and I verified the fallback is load-bearing by removing it and watching the test fail.

**2. The `with` wrapper's argument-boundary list had already drifted.**

`src/cli/with.rs` carried a hand-written copy of the client names used to find where router flags end and client arguments begin. It had no entry for `cursor-agent` — so that client's arguments would not have been protected. It now derives the list from the client table, so it cannot fall out of step again.

Also: `Display` uses `f.pad`, so the fixed-width column in `clients list` still aligns. That is the same trap as #212, where `write_str` silently discarded the caller's requested width — `cursor-agent` is exactly 12 characters and would have collided with the next column.

## Tests

The invariant the issue asks for, as one assertion over the existing table:

- every variant's advertised name equals its `ClientIntegration::command`, checked through the ValueEnum, `Display` *and* `canonical_name()`, so no surface can drift from another. **Verified to fail on drift** — reverting one attribute produces `qwen-code is advertised but the command is qwen`;
- every legacy name (`claude-code`, `cursor`, `gemini-cli`, `grok-cli`, `qwen-code`) still parses, so this is not a breaking change;
- `clients list` shows the canonical names **and no longer shows the legacy ones** — the negative half matters, since substring matching hid the old behaviour;
- a managed file written under the legacy name is still found; a fresh installation uses the canonical name.

I also updated three existing tests that asserted the old filenames and list output. Those were correct failures, not incidental ones.

## Scope

I did **not** rename the `docs/use-cases/cli-*.md` files themselves. They are referenced from `README.md`, `docs/use-cases/README.md`, a `setup_limitation` string in `src/clients.rs`, and two changelog entries; renaming them is churn beyond what the issue asks, and the issue's item 3 is about names the CLI *shows*. The commands inside those docs are updated.

`SubscriptionProvider` (`claude-code`/`qwen-code` as vendor aliases in `src/subscription.rs`, `src/config.rs`) is a different enum and is untouched.

## Verification
885 tests pass, exit code 0. `cargo fmt`, `clippy --all-targets --all-features -D warnings`, CI's exact rustdoc command, and the file-size check are clean. `clients.rs` crossed the 1000-line limit, so its test module moved to `clients_tests.rs` using the `#[path]` pattern already used in this repo; no test content changed in the move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)