### PR TITLE
fix(with): stop substituting a foreign-vendor model

### DIFF
--- a/changelog.d/20260819_160000_issue_225_model_owner.md
+++ b/changelog.d/20260819_160000_issue_225_model_owner.md
@@ -1,0 +1,8 @@
+---
+bump: minor
+---
+
+### Fixed
+- `with` no longer hands a client a model belonging to a different vendor. When the catalog advertised no model owned by the client's dialect — an Anthropic subscription that had lapsed, say — `with claude` launched Claude Code against an OpenAI model, and the run died inside the client with `"codex-auto-review" is not a model this version of Claude Code recognizes`. That names the wrong machine: the client was fine, the subscription was not. The router now reports the mismatch itself, and the existing "advertises no model" error — previously unreachable — is what the user sees.
+- The fallback the original code intended is kept: when no catalog entry declares an owner, the router cannot tell whether a model suits the client, so it still offers one. It is only refused when the catalog names owners and none of them is the client's.
+- That error now says what the catalog does hold — "it advertises only openai models" — so the next step is visible without reading the router's other surfaces.

--- a/src/managed_server.rs
+++ b/src/managed_server.rs
@@ -1,16 +1,15 @@
 //! Server selection, managed Docker lifecycle, and per-run token handling.
 
 use std::ffi::OsStr;
-use std::fs::{self, File, OpenOptions};
+use std::fs::{self};
 use std::io::{Read as _, Write as _};
 use std::net::{TcpListener, TcpStream};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::{Child, Command, ExitCode, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
 use base64::Engine as _;
-use fs2::FileExt as _;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -82,14 +81,41 @@ impl RunCredential {
     /// advertises (issue #192). `owner` narrows the choice to models a
     /// dialect-specific client can use; an empty owner accepts any.
     pub(crate) fn select_model(&self, owner: &str) -> Option<&str> {
-        // Prefer a model the catalog attributes to the client's dialect owner,
-        // but fall back to any advertised model: a catalog that declares no
-        // owner still describes real, usable models.
+        if owner.is_empty() {
+            // No dialect constraint: any advertised model will do.
+            return self.available_models.first().map(|model| model.id.as_str());
+        }
+        if let Some(model) = self
+            .available_models
+            .iter()
+            .find(|model| model.owned_by == owner)
+        {
+            return Some(model.id.as_str());
+        }
+        // Falling back is defensible only when the catalog does not say who owns
+        // its models: then the router cannot tell, and a usable model beats
+        // refusing. When every entry names a *different* owner it does know, and
+        // substituting one launched Claude Code against an `OpenAI` model — so the
+        // client blamed its own model name rather than the lapsed subscription
+        // (issue #225).
         self.available_models
             .iter()
-            .find(|model| !owner.is_empty() && model.owned_by == owner)
-            .or_else(|| self.available_models.first())
-            .map(|model| model.id.as_str())
+            .all(|model| model.owned_by.is_empty())
+            .then(|| self.available_models.first().map(|m| m.id.as_str()))
+            .flatten()
+    }
+
+    /// The distinct owners the catalog names, for reporting why nothing fit.
+    pub(crate) fn advertised_owners(&self) -> Vec<&str> {
+        let mut owners: Vec<&str> = self
+            .available_models
+            .iter()
+            .map(|model| model.owned_by.as_str())
+            .filter(|owner| !owner.is_empty())
+            .collect();
+        owners.sort_unstable();
+        owners.dedup();
+        owners
     }
 }
 
@@ -885,79 +911,6 @@ fn process_alive(pid: u32) -> bool {
     }
 }
 
-fn state_directory() -> Result<PathBuf, AnyError> {
-    let root = std::env::var_os("XDG_CONFIG_HOME")
-        .map(PathBuf::from)
-        .or_else(|| std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".config")))
-        .or_else(|| std::env::var_os("APPDATA").map(PathBuf::from))
-        .ok_or("HOME, XDG_CONFIG_HOME, and APPDATA are unset; cannot store server state")?;
-    let path = root.join(CONFIG_DIRECTORY);
-    fs::create_dir_all(&path)?;
-    set_owner_only(&path)?;
-    Ok(path)
-}
-
-fn lock_state() -> Result<File, AnyError> {
-    let path = state_directory()?.join(MANAGED_LOCK);
-    let file = OpenOptions::new()
-        .create(true)
-        .truncate(false)
-        .read(true)
-        .write(true)
-        .open(path)?;
-    file.lock_exclusive()?;
-    Ok(file)
-}
-
-fn load_managed() -> Result<Option<ManagedState>, AnyError> {
-    let path = state_directory()?.join(MANAGED_STATE);
-    match fs::read_to_string(&path) {
-        Ok(source) => Ok(Some(serde_json::from_str(&source).map_err(|error| {
-            format!("invalid managed server state {}: {error}", path.display())
-        })?)),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(error) => Err(error.into()),
-    }
-}
-
-fn save_managed(state: &ManagedState) -> Result<(), AnyError> {
-    write_private_json(&state_directory()?.join(MANAGED_STATE), state)
-}
-
-fn write_private_json(path: &Path, value: &impl Serialize) -> Result<(), AnyError> {
-    let temporary = path.with_extension(format!("tmp-{}", uuid::Uuid::new_v4()));
-    let mut options = OpenOptions::new();
-    options.write(true).create_new(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt as _;
-        options.mode(0o600);
-    }
-    let mut file = options.open(&temporary)?;
-    serde_json::to_writer_pretty(&mut file, value)?;
-    file.write_all(b"\n")?;
-    file.sync_all()?;
-    #[cfg(windows)]
-    if path.exists() {
-        fs::remove_file(path)?;
-    }
-    fs::rename(&temporary, path)?;
-    set_owner_only(path)?;
-    Ok(())
-}
-
-fn set_owner_only(path: &Path) -> Result<(), std::io::Error> {
-    #[cfg(not(unix))]
-    let _ = path;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt as _;
-        let mode = if path.is_dir() { 0o700 } else { 0o600 };
-        fs::set_permissions(path, fs::Permissions::from_mode(mode))?;
-    }
-    Ok(())
-}
-
 fn normalize_server(server: &str) -> Result<String, AnyError> {
     let server = server.trim().trim_end_matches('/');
     if server.starts_with("http://") || server.starts_with("https://") {
@@ -976,3 +929,12 @@ fn compact(value: &str) -> String {
         format!("{}…", compact.chars().take(LIMIT).collect::<String>())
     }
 }
+
+#[path = "managed_server_state.rs"]
+mod state;
+
+use state::{load_managed, lock_state, save_managed, state_directory, write_private_json};
+
+#[cfg(test)]
+#[path = "managed_server_tests.rs"]
+mod tests;

--- a/src/managed_server_state.rs
+++ b/src/managed_server_state.rs
@@ -1,0 +1,87 @@
+//! Owner-only on-disk state for the managed background router.
+//!
+//! Split from `managed_server.rs` to keep that file within the repository's
+//! 1000-line limit.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+
+use fs2::FileExt as _;
+
+use serde::Serialize;
+
+use super::{AnyError, CONFIG_DIRECTORY, MANAGED_LOCK, MANAGED_STATE, ManagedState};
+
+pub(super) fn state_directory() -> Result<PathBuf, AnyError> {
+    let root = std::env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".config")))
+        .or_else(|| std::env::var_os("APPDATA").map(PathBuf::from))
+        .ok_or("HOME, XDG_CONFIG_HOME, and APPDATA are unset; cannot store server state")?;
+    let path = root.join(CONFIG_DIRECTORY);
+    fs::create_dir_all(&path)?;
+    set_owner_only(&path)?;
+    Ok(path)
+}
+
+pub(super) fn lock_state() -> Result<File, AnyError> {
+    let path = state_directory()?.join(MANAGED_LOCK);
+    let file = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(path)?;
+    file.lock_exclusive()?;
+    Ok(file)
+}
+
+pub(super) fn load_managed() -> Result<Option<ManagedState>, AnyError> {
+    let path = state_directory()?.join(MANAGED_STATE);
+    match fs::read_to_string(&path) {
+        Ok(source) => Ok(Some(serde_json::from_str(&source).map_err(|error| {
+            format!("invalid managed server state {}: {error}", path.display())
+        })?)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
+pub(super) fn save_managed(state: &ManagedState) -> Result<(), AnyError> {
+    write_private_json(&state_directory()?.join(MANAGED_STATE), state)
+}
+
+pub(super) fn write_private_json(path: &Path, value: &impl Serialize) -> Result<(), AnyError> {
+    let temporary = path.with_extension(format!("tmp-{}", uuid::Uuid::new_v4()));
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.mode(0o600);
+    }
+    let mut file = options.open(&temporary)?;
+    serde_json::to_writer_pretty(&mut file, value)?;
+    file.write_all(b"\n")?;
+    file.sync_all()?;
+    #[cfg(windows)]
+    if path.exists() {
+        fs::remove_file(path)?;
+    }
+    fs::rename(&temporary, path)?;
+    set_owner_only(path)?;
+    Ok(())
+}
+
+pub(super) fn set_owner_only(path: &Path) -> Result<(), std::io::Error> {
+    #[cfg(not(unix))]
+    let _ = path;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        let mode = if path.is_dir() { 0o700 } else { 0o600 };
+        fs::set_permissions(path, fs::Permissions::from_mode(mode))?;
+    }
+    Ok(())
+}

--- a/src/managed_server_tests.rs
+++ b/src/managed_server_tests.rs
@@ -1,0 +1,79 @@
+//! Tests for [`crate::managed_server`].
+
+use super::*;
+
+fn model(id: &str, owner: &str) -> RouterModel {
+    RouterModel {
+        id: id.to_string(),
+        owned_by: owner.to_string(),
+    }
+}
+
+fn credential(models: Vec<RouterModel>) -> RunCredential {
+    RunCredential {
+        token: "la_sk_test".to_string(),
+        available_models: models,
+        revocation: None,
+    }
+}
+
+/// A catalog whose every model belongs to another vendor cannot serve this
+/// client, and the router knows it. Substituting one launched Claude Code
+/// against an `OpenAI` model, so the client reported an unrecognised model name
+/// and the user was pointed at their own tool rather than at the subscription
+/// that had lapsed (issue #225).
+#[test]
+fn a_foreign_owner_is_not_substituted() {
+    let catalog = credential(vec![
+        model("codex-auto-review", "openai"),
+        model("gpt-5.5", "openai"),
+    ]);
+    assert_eq!(catalog.select_model("anthropic"), None);
+    // The owners are reported so the error can name what the catalog holds.
+    assert_eq!(catalog.advertised_owners(), vec!["openai"]);
+}
+
+/// The case the original fallback defends: with no owner declared, the router
+/// cannot tell whether a model suits this client, and a usable model beats
+/// refusing.
+#[test]
+fn an_undeclared_owner_still_falls_back() {
+    let catalog = credential(vec![model("mystery-1", ""), model("mystery-2", "")]);
+    assert_eq!(catalog.select_model("anthropic"), Some("mystery-1"));
+    assert!(catalog.advertised_owners().is_empty());
+}
+
+/// A mixed catalog gives each client a model of its own owner.
+#[test]
+fn each_client_gets_a_model_of_its_own_owner() {
+    let catalog = credential(vec![
+        model("gpt-5.5", "openai"),
+        model("claude-haiku-4-5", "anthropic"),
+    ]);
+    assert_eq!(catalog.select_model("anthropic"), Some("claude-haiku-4-5"));
+    assert_eq!(catalog.select_model("openai"), Some("gpt-5.5"));
+    assert_eq!(catalog.advertised_owners(), vec!["anthropic", "openai"]);
+}
+
+/// A client with no dialect constraint accepts anything advertised.
+#[test]
+fn an_unconstrained_client_accepts_any_model() {
+    let catalog = credential(vec![model("gpt-5.5", "openai")]);
+    assert_eq!(catalog.select_model(""), Some("gpt-5.5"));
+}
+
+/// An empty catalog yields nothing, whatever the owner.
+#[test]
+fn an_empty_catalog_selects_nothing() {
+    let catalog = credential(Vec::new());
+    assert_eq!(catalog.select_model("anthropic"), None);
+    assert_eq!(catalog.select_model(""), None);
+}
+
+/// A partially-declared catalog is treated as knowing its owners: one entry
+/// naming a vendor is enough to conclude the client's own is absent.
+#[test]
+fn a_partially_declared_catalog_does_not_substitute() {
+    let catalog = credential(vec![model("gpt-5.5", "openai"), model("mystery", "")]);
+    assert_eq!(catalog.select_model("anthropic"), None);
+}

--- a/src/with_command.rs
+++ b/src/with_command.rs
@@ -92,10 +92,20 @@ async fn run_inner(args: &WithArgs) -> Result<ExitCode, AnyError> {
     } else if let Some(model) = credential.select_model(owner) {
         model.to_string()
     } else {
+        // Name what the catalog *does* hold: "only openai models" is a much
+        // shorter path to the real cause — a lapsed subscription — than the
+        // unrecognised-model error the client would otherwise report about
+        // itself (issue #225).
+        let advertised = credential.advertised_owners();
+        let holdings = if advertised.is_empty() {
+            "the catalog is empty".to_string()
+        } else {
+            format!("it advertises only {} models", advertised.join(", "))
+        };
         cleanup_after_setup_failure(credential).await;
         return Err(format!(
-            "the router advertises no model for {}; authorize a matching subscription on the \
-             router host, or pass --model explicitly",
+            "the router advertises no model for {} ({owner} models): {holdings}. Authorize a \
+             matching subscription on the router host, or pass --model explicitly",
             args.client.integration().name
         )
         .into());


### PR DESCRIPTION
Closes #225.

When the catalog advertised no model owned by the client's dialect, `select_model` fell back to whatever was first — so `with claude` launched Claude Code against an OpenAI model:

```
"codex-auto-review" is not a model this version of Claude Code recognizes…
[claude-code:unrecognized_model]
```

**That names the wrong machine.** The client is fine; a subscription on the router host had lapsed. Nothing in that output mentions the router or the real cause.

## The distinction the original code missed

The comment on the fallback defended a genuine case — a catalog that declares no owner at all — but the code never tested for it, falling back whenever nothing matched. Two situations needing opposite handling were collapsed into one:

- **no entry declares an owner** → the router cannot tell whether a model suits the client; falling back is right, and still happens;
- **every entry names a different owner** → the router *does* know the dialect cannot be served, and now says so.

This makes the error in `with_command.rs` reachable for the first time. It already named the two useful next steps; it now also names what the catalog holds, so **"it advertises only openai models"** replaces a client-side error about a model id the user never chose (issue item 3).

## Tests

All six cases the issue lists, offline against a synthetic catalog:

- only `openai` models, client owner `anthropic` → `None`;
- no declared owner → the fallback still applies (the case the comment defends);
- both owners present → each client gets its own;
- unconstrained client accepts anything; empty catalog yields nothing;
- **partially declared** — one entry naming a vendor, one blank → still refuses. Not in the issue, but it is the boundary between the two rules, and I would rather pin it than leave it to the next reader.

`--model` continues to override, including to a foreign owner: that branch runs before selection and is untouched.

**Verified to fail on the old behaviour** — restoring the fallback fails exactly the two owner-mismatch tests and no others.

## Refactor note

`managed_server.rs` crossed the 1000-line limit, so the on-disk state helpers moved to `managed_server_state.rs` and the new tests to `managed_server_tests.rs`. No logic changed in either move; the fix and the split review separately.

## Verification
897 tests pass, exit code 0. `cargo fmt`, `clippy --all-targets --all-features -D warnings`, CI's exact rustdoc command, and the file-size check are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)