### PR TITLE
chore(deps): update every dependency to its latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,9 +316,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -987,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1250,9 +1250,9 @@ checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1461,7 +1461,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "jsonwebtoken",
- "links-notation 0.13.0",
+ "links-notation",
  "lino-arguments",
  "lino-objects-codec",
  "log-lazy",
@@ -1483,15 +1483,6 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "wait-timeout",
-]
-
-[[package]]
-name = "links-notation"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c952b42a8c6ff6f849d7cafe3b1e13f1063a51bbb144bc6c62026ab327814c"
-dependencies = [
- "nom",
 ]
 
 [[package]]
@@ -1537,12 +1528,12 @@ checksum = "5f453c53827aabe91a3d3856d61d14ae3867ab1a4344db22f9fa5396664c8d0e"
 
 [[package]]
 name = "lino-objects-codec"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddca5f17dbe7caf9dbbbb499cb5022db7ed884bb57808c3a367f0df83f24c976"
+checksum = "faab60e0894cde06f0c571798350644c8be092d625e6a0e45f543212101da561"
 dependencies = [
  "base64 0.22.1",
- "links-notation 0.14.0",
+ "links-notation",
 ]
 
 [[package]]
@@ -1956,9 +1947,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.16"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -3603,9 +3594,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3614,9 +3605,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.4"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47402523226a02bfe5230160dc3ccc089aa6f6f19e7fcbb4e6f824bbb1b4aa62"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,8 +55,8 @@ futures-util = "0.3"
 http = "1.5"
 http-body-util = "0.1"
 lino-arguments = "0.3"
-lino-objects-codec = "0.3.0"
-links-notation = "0.13.0"
+lino-objects-codec = "0.4.1"
+links-notation = "0.14.0"
 doublets = "0.4.0"
 mem = { package = "platform-mem", version = "0.3.0" }
 clap = { version = "4", features = ["derive", "env"] }

--- a/changelog.d/20260821_151000_dependency_refresh.md
+++ b/changelog.d/20260821_151000_dependency_refresh.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Changed
+- Every dependency is at its latest published version. `links-notation` 0.13 → 0.14 and `lino-objects-codec` 0.3 → 0.4 are major bumps: both back the links-notation storage layer, so the whole suite was run against them rather than the build alone. Six transitive crates moved within their existing constraints (`cc`, `h2`, `icu_provider`, `quinn-proto`, `zerovec`, `zerovec-derive`); `h2` 0.4.16 → 0.4.18 is the one worth naming, since it carries the HTTP/2 framing the proxy relays through.


### PR DESCRIPTION
Requested alongside #254 and #255, kept as its own pull request.

`cargo outdated` now reports **all dependencies up to date**.

## Major bumps

| crate | from | to |
|---|---|---|
| `links-notation` | 0.13.0 | 0.14.0 |
| `lino-objects-codec` | 0.3.0 | 0.4.1 |

Both back the links-notation storage layer, so this was verified with the **full suite** rather than a build alone — a storage-layer major that compiles is not the same as one that behaves. Neither needed a source change.

## Compatible bumps

Six transitive crates moved within their existing constraints: `cc`, `h2`, `icu_provider`, `quinn-proto`, `zerovec`, `zerovec-derive`. `h2` 0.4.16 → 0.4.18 is the one worth naming, since it carries the HTTP/2 framing the proxy relays through.

## Verification

- **854 tests, 0 failures**
- `cargo clippy --all-targets --all-features` clean under `-D warnings`
- `cargo fmt --check` clean
- `cargo build --locked` succeeds, so the lockfile is consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)