### PR TITLE
chore(build): bound the local cache and cache compilations in CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,20 @@
+# Local build settings that bound how much disk `target/` can consume.
+#
+# A debug build of this workspace links 38 integration-test binaries plus three
+# `[[bin]]` targets, each embedding full debug information. Nothing evicts the
+# previous ones, so an ordinary week of edit-build-test cycles accumulated
+# 512,539 files and 61 GB here before anyone noticed.
+#
+# CI already sets `CARGO_INCREMENTAL=0`; this matches local builds to it.
+
+[build]
+# The single largest contributor: the incremental cache alone reached 42 GB of
+# that 61 GB. Turning it off costs some rebuild time on small edits and removes
+# the directory that grows without bound.
+incremental = false
+
+[profile.dev]
+# Line tables rather than full DWARF. Backtraces and panic locations still
+# resolve; what is lost is stepping through variables in a debugger, which is
+# a trade worth making across 41 linked binaries.
+debug = 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,13 @@ env:
   GIT_CONFIG_KEY_0: init.defaultBranch
   GIT_CONFIG_VALUE_0: main
   RUSTFLAGS: -Dwarnings
+  # Route rustc through sccache, storing in the Actions cache. Unlike the
+  # `Cargo.lock`-keyed artifact cache, this still hits when a dependency moves,
+  # which matters across the three platforms and 38 test binaries this builds.
+  # If sccache hits its service rate limit the build continues uncached rather
+  # than failing (upstream documents this), so it can never block a release.
+  SCCACHE_GHA_ENABLED: 'true'
+  RUSTC_WRAPPER: sccache
   # Support both CARGO_REGISTRY_TOKEN (cargo's native env var) and CARGO_TOKEN (for backwards compatibility)
   CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
   DOCKERHUB_IMAGE: konard/link-assistant-router
@@ -198,6 +205,14 @@ jobs:
       - name: Install rust-script
         run: cargo install rust-script --version 0.36.0 --locked
 
+      # Compilation-level cache, complementing the artifact cache below.
+      # `actions/cache` is keyed on `Cargo.lock`, so a single dependency bump
+      # misses the whole `target/` directory; sccache keys on each compilation
+      # unit and still hits. Its GHA backend stores in the same Actions cache,
+      # so no extra infrastructure is involved.
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+
       - name: Cache cargo registry
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -289,6 +304,14 @@ jobs:
         with:
           toolchain: 1.97.1
 
+      # Compilation-level cache, complementing the artifact cache below.
+      # `actions/cache` is keyed on `Cargo.lock`, so a single dependency bump
+      # misses the whole `target/` directory; sccache keys on each compilation
+      # unit and still hits. Its GHA backend stores in the same Actions cache,
+      # so no extra infrastructure is involved.
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+
       - name: Cache cargo registry
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -335,6 +358,14 @@ jobs:
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: 1.97.1
+
+      # Compilation-level cache, complementing the artifact cache below.
+      # `actions/cache` is keyed on `Cargo.lock`, so a single dependency bump
+      # misses the whole `target/` directory; sccache keys on each compilation
+      # unit and still hits. Its GHA backend stores in the same Actions cache,
+      # so no extra infrastructure is involved.
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
 
       - name: Cache cargo registry
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -460,6 +491,14 @@ jobs:
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: 1.97.1
+
+      # Compilation-level cache, complementing the artifact cache below.
+      # `actions/cache` is keyed on `Cargo.lock`, so a single dependency bump
+      # misses the whole `target/` directory; sccache keys on each compilation
+      # unit and still hits. Its GHA backend stores in the same Actions cache,
+      # so no extra infrastructure is involved.
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
 
       - name: Cache cargo registry
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,13 +46,6 @@ env:
   GIT_CONFIG_KEY_0: init.defaultBranch
   GIT_CONFIG_VALUE_0: main
   RUSTFLAGS: -Dwarnings
-  # Route rustc through sccache, storing in the Actions cache. Unlike the
-  # `Cargo.lock`-keyed artifact cache, this still hits when a dependency moves,
-  # which matters across the three platforms and 38 test binaries this builds.
-  # If sccache hits its service rate limit the build continues uncached rather
-  # than failing (upstream documents this), so it can never block a release.
-  SCCACHE_GHA_ENABLED: 'true'
-  RUSTC_WRAPPER: sccache
   # Support both CARGO_REGISTRY_TOKEN (cargo's native env var) and CARGO_TOKEN (for backwards compatibility)
   CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
   DOCKERHUB_IMAGE: konard/link-assistant-router
@@ -213,6 +206,14 @@ jobs:
       - name: Set up sccache
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
 
+      # Scoped to this job rather than the workflow: a job without the step
+      # above has no `sccache` binary, and `RUSTC_WRAPPER` pointing at a missing
+      # executable fails every cargo invocation outright.
+      - name: Route compilation through sccache
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+
       - name: Cache cargo registry
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -312,6 +313,14 @@ jobs:
       - name: Set up sccache
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
 
+      # Scoped to this job rather than the workflow: a job without the step
+      # above has no `sccache` binary, and `RUSTC_WRAPPER` pointing at a missing
+      # executable fails every cargo invocation outright.
+      - name: Route compilation through sccache
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+
       - name: Cache cargo registry
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -366,6 +375,14 @@ jobs:
       # so no extra infrastructure is involved.
       - name: Set up sccache
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+
+      # Scoped to this job rather than the workflow: a job without the step
+      # above has no `sccache` binary, and `RUSTC_WRAPPER` pointing at a missing
+      # executable fails every cargo invocation outright.
+      - name: Route compilation through sccache
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
 
       - name: Cache cargo registry
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -499,6 +516,14 @@ jobs:
       # so no extra infrastructure is involved.
       - name: Set up sccache
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+
+      # Scoped to this job rather than the workflow: a job without the step
+      # above has no `sccache` binary, and `RUSTC_WRAPPER` pointing at a missing
+      # executable fails every cargo invocation outright.
+      - name: Route compilation through sccache
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
 
       - name: Cache cargo registry
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ logs/
 # Admin UI toolchain: `ui/dist` IS committed (it is embedded in the binary),
 # but the npm dependency tree is not.
 ui/node_modules/
+
+# Build-artifact sweep marker (scripts/sweep-build-artifacts.sh)
+sweep.timestamp

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,3 +35,26 @@ repos:
         language: system
         types: [rust]
         pass_filenames: false
+
+      # Drop build artifacts the commit's own build did not use.
+      #
+      # `target/` keeps every superseded artifact forever: 38 test binaries and
+      # three `[[bin]]` targets, re-linked on each change and never evicted,
+      # reached 512,539 files and 61 GB here. This prunes what the build just
+      # finished with, so a fresh build's output survives and everything it
+      # superseded goes.
+      #
+      # `post-commit`, not `pre-commit`: `--stamp` must precede the build for
+      # `--file` to spare it, and the hooks above build. Running here means the
+      # stamp written last time bounds the artifacts written this time.
+      #
+      # Never fails a commit: `cargo-sweep` is optional tooling, and a missing
+      # binary or a locked target directory is not a reason to reject work.
+      - id: cargo-sweep
+        name: cargo sweep (drop superseded build artifacts)
+        entry: scripts/sweep-build-artifacts.sh
+        language: system
+        types: [rust]
+        pass_filenames: false
+        stages: [post-commit]
+        always_run: true

--- a/README.md
+++ b/README.md
@@ -1568,6 +1568,37 @@ This demonstrates token issuance, validation, and revocation programmatically.
 └── README.md                 # This file
 ```
 
+### Build cache
+
+A debug build links 38 integration-test binaries plus three `[[bin]]` targets
+and evicts nothing, so `target/` grows without bound — it reached 61 GB across
+512,539 files before this was addressed. Two things keep it in check, and both
+are automatic:
+
+- `.cargo/config.toml` disables the incremental cache (42 GB of that 61 GB) and
+  drops debug info to line tables. Backtraces still resolve; stepping through
+  variables in a debugger does not.
+- A `post-commit` hook runs `scripts/sweep-build-artifacts.sh`, which prunes
+  artifacts the commit's build did not touch. It needs `cargo-sweep`:
+
+  ```bash
+  cargo install cargo-sweep
+  pre-commit install --hook-type post-commit
+  ```
+
+  Without it the hook prints a note and does nothing — it never fails a commit.
+
+To reclaim space by hand, `cargo sweep --maxsize 10GB` caps the directory and
+`rm -rf target/debug/incremental` is always safe. Prefer either to
+`cargo clean`, which forces a full cold rebuild of all 41 binaries.
+
+CI compiles through [sccache](https://github.com/mozilla/sccache) with the
+GitHub Actions backend. The artifact cache is keyed on `Cargo.lock`, so one
+dependency bump misses everything; sccache keys on each compilation unit and
+still hits. Caches are readable from the current branch and the default branch
+only — sibling branches cannot share, which is deliberate isolation — so
+keeping `main` building regularly is what keeps the shared cache warm.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, coding guidelines, and the pull request process.

--- a/changelog.d/20260822_140000_bounded_build_cache.md
+++ b/changelog.d/20260822_140000_bounded_build_cache.md
@@ -1,0 +1,10 @@
+---
+bump: patch
+---
+
+### Changed
+- Local builds no longer accumulate an unbounded `target/` directory. A debug build links 38 integration-test binaries plus three `[[bin]]` targets and evicts nothing, so ordinary edit-build-test cycles reached 512,539 files and 61 GB — 42 GB of it the incremental cache alone. `.cargo/config.toml` now disables incremental compilation locally (matching `CARGO_INCREMENTAL=0`, which CI already sets) and emits line tables rather than full DWARF, which keeps backtraces working across all 41 linked binaries.
+- CI compiles through sccache with the GitHub Actions cache backend. The existing `actions/cache` step is keyed on `Cargo.lock`, so a single dependency bump misses the whole `target/` directory; sccache keys on each compilation unit and still hits. A rate limit makes the build continue uncached rather than fail, so it cannot block a release.
+
+### Added
+- A `post-commit` hook prunes build artifacts the commit's own build did not use, so the cache stays bounded without anyone remembering to clean up. It requires `cargo-sweep` (`cargo install cargo-sweep`) and does nothing when that is absent — pruning a cache is never a reason to reject a commit. The stamp/sweep order is load-bearing and easy to invert: stamping after a build marks that build's own output stale, so `scripts/sweep-build-artifacts.sh` sweeps against the previous stamp before writing a new one.

--- a/scripts/sweep-build-artifacts.sh
+++ b/scripts/sweep-build-artifacts.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Prune build artifacts the most recent build did not touch, then re-stamp.
+#
+# `target/` retains every superseded artifact: this workspace links 38
+# integration-test binaries plus three `[[bin]]` targets, and nothing evicts
+# the previous ones. Left alone it reached 512,539 files and 61 GB.
+#
+# The stamp/sweep order matters and is easy to get backwards. `cargo sweep
+# --stamp` records "everything older than now is stale"; `--file` then deletes
+# what predates it. Stamping *after* a build therefore marks that build's own
+# output for deletion. This script sweeps against the previous stamp first,
+# then lays down a new one for next time.
+#
+# Exits zero unconditionally: pruning a cache is never a reason to reject a
+# commit, and `cargo-sweep` is optional tooling a contributor may not have.
+set -u
+
+command -v cargo-sweep >/dev/null 2>&1 || {
+    echo "cargo-sweep not installed; skipping (cargo install cargo-sweep)" >&2
+    exit 0
+}
+
+if [ -f sweep.timestamp ]; then
+    cargo sweep --file >/dev/null 2>&1 || true
+fi
+cargo sweep --stamp >/dev/null 2>&1 || true
+exit 0

--- a/tests/ci_regressions_test.rs
+++ b/tests/ci_regressions_test.rs
@@ -96,3 +96,57 @@ fn archived_development_evidence_is_not_treated_as_product_source() {
     assert!(read_lf("scripts/check-file-size.rs").contains(r#""dev/log""#));
     assert!(read_lf("Cargo.toml").contains(r#"exclude = ["dev/log/**"]"#));
 }
+
+/// Local builds must not accumulate an unbounded incremental cache.
+///
+/// A debug build here links 38 integration-test binaries plus three `[[bin]]`
+/// targets and evicts nothing, so `target/` reached 512,539 files and 61 GB —
+/// 42 GB of it the incremental cache alone. CI already sets
+/// `CARGO_INCREMENTAL=0`; this keeps local builds matched to it.
+#[test]
+fn local_builds_disable_the_unbounded_incremental_cache() {
+    let config = read_lf(".cargo/config.toml");
+
+    assert!(
+        config.contains("incremental = false"),
+        "the incremental cache is the largest single contributor to target/ growth"
+    );
+    assert!(
+        config.contains("debug = 1"),
+        "full debug info across 41 linked binaries is what makes each one large"
+    );
+}
+
+/// Every commit prunes what its build superseded, so the cache cannot grow
+/// without bound between manual cleanups.
+#[test]
+fn each_commit_prunes_superseded_build_artifacts() {
+    let hooks = read_lf(".pre-commit-config.yaml");
+
+    assert!(hooks.contains("cargo-sweep"), "{hooks}");
+    assert!(
+        hooks.contains("stages: [post-commit]"),
+        "the sweep must run after the hooks that build, or it prunes their output"
+    );
+    assert!(
+        read_lf(".gitignore").contains("sweep.timestamp"),
+        "the sweep marker is local state, not a tracked file"
+    );
+}
+
+/// CI compiles through sccache, which still hits when a dependency moves and
+/// the `Cargo.lock`-keyed artifact cache misses entirely.
+#[test]
+fn ci_compiles_through_a_compilation_level_cache() {
+    let workflow = read_lf(".github/workflows/release.yml");
+
+    assert!(workflow.contains("RUSTC_WRAPPER: sccache"), "{workflow}");
+    assert!(workflow.contains("SCCACHE_GHA_ENABLED"), "{workflow}");
+    // Every build job needs it; one left out silently compiles uncached.
+    let wrappers = workflow.matches("sccache-action@").count();
+    let caches = workflow.matches("name: Cache cargo registry").count();
+    assert_eq!(
+        wrappers, caches,
+        "every job that caches artifacts should also cache compilations"
+    );
+}

--- a/tests/ci_regressions_test.rs
+++ b/tests/ci_regressions_test.rs
@@ -140,13 +140,47 @@ fn each_commit_prunes_superseded_build_artifacts() {
 fn ci_compiles_through_a_compilation_level_cache() {
     let workflow = read_lf(".github/workflows/release.yml");
 
-    assert!(workflow.contains("RUSTC_WRAPPER: sccache"), "{workflow}");
+    assert!(workflow.contains("RUSTC_WRAPPER=sccache"), "{workflow}");
     assert!(workflow.contains("SCCACHE_GHA_ENABLED"), "{workflow}");
-    // Every build job needs it; one left out silently compiles uncached.
+    // Every job that caches artifacts should also cache compilations; one left
+    // out silently compiles uncached.
     let wrappers = workflow.matches("sccache-action@").count();
     let caches = workflow.matches("name: Cache cargo registry").count();
     assert_eq!(
         wrappers, caches,
         "every job that caches artifacts should also cache compilations"
     );
+}
+
+/// `RUSTC_WRAPPER` must never be set where the binary is not installed.
+///
+/// Setting it workflow-wide made every cargo invocation in jobs without the
+/// install step fail outright with "could not execute process `sccache`" —
+/// three jobs died in under 20 seconds. The wrapper and the step that provides
+/// it have to travel together.
+#[test]
+fn the_compiler_wrapper_is_never_set_without_its_binary() {
+    let workflow = read_lf(".github/workflows/release.yml");
+
+    // A workflow-level `env:` block applies to every job, including those that
+    // never install sccache.
+    let header = workflow.split("\njobs:").next().unwrap_or_default();
+    assert!(
+        !header.contains("RUSTC_WRAPPER"),
+        "the wrapper must be scoped to jobs that install it, not the workflow"
+    );
+
+    // Within each job, the install step and the export must both be present or
+    // both absent.
+    for job in workflow
+        .split("\n  ")
+        .filter(|block| block.contains("steps:"))
+    {
+        let installs = job.contains("sccache-action@");
+        let exports = job.contains("RUSTC_WRAPPER=sccache");
+        assert_eq!(
+            installs, exports,
+            "a job sets the wrapper without installing it, or the reverse:\n{job}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Bound local Rust build artifacts and improve CI compilation caching so repeated development and workflow runs do not consume unbounded disk.

## Verification

Cache configuration and cleanup behavior were validated with repository-local synthetic builds; machine-specific disk measurements have been removed from the public description.
