### PR TITLE
fix(tests): survive losing the port race in the admin endpoint tests

### DIFF
--- a/changelog.d/20260822_223000_admin_endpoint_port_race.md
+++ b/changelog.d/20260822_223000_admin_endpoint_port_race.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Fixed
+- The admin-endpoint tests no longer fail when another test claims their port first. `free_port` closes its listener before returning the number, so any test in the same parallel run can take that port before the router child binds it; `serve` propagates the bind error and exits without retrying, so the loser polled `/health` for the full 30-second timeout and then panicked. This surfaced as a green PR run turning red once merged to `main`, which held the v0.108.0 release back a commit. The harness now re-rolls the port up to five times and gives up on an attempt as soon as the child exits, so the race is recoverable rather than fatal.

--- a/tests/admin_endpoints_test.rs
+++ b/tests/admin_endpoints_test.rs
@@ -33,6 +33,9 @@ impl Drop for Router {
     }
 }
 
+/// How many times to re-roll the port before declaring a real failure.
+const ATTEMPTS: usize = 5;
+
 fn free_port() -> u16 {
     TcpListener::bind("127.0.0.1:0")
         .expect("should bind an ephemeral port")
@@ -42,9 +45,32 @@ fn free_port() -> u16 {
 }
 
 impl Router {
+    /// Start a router, retrying if the port was taken between reservation and
+    /// use.
+    ///
+    /// `free_port` closes its listener before returning the number, so any
+    /// other test in the same parallel run can claim that port in the interval
+    /// before the child binds it. The child does not retry — `serve` propagates
+    /// the bind error and exits — so the loser of that race waited the full
+    /// health timeout and failed, which is how a green PR run turned red on
+    /// main and held up a release (the run for #266). Retrying on a fresh port
+    /// makes the race recoverable instead of fatal.
     fn start(extra_env: &[(&str, &str)]) -> Self {
+        let mut last_port = 0;
+        for _ in 0..ATTEMPTS {
+            if let Some(router) = Self::try_start(extra_env, &mut last_port) {
+                return router;
+            }
+        }
+        panic!("router never became healthy after {ATTEMPTS} attempts (last port {last_port})");
+    }
+
+    /// One start attempt: `None` if the child died or never answered, which
+    /// the caller retries on a different port.
+    fn try_start(extra_env: &[(&str, &str)], last_port: &mut u16) -> Option<Self> {
         let data_dir = tempfile::tempdir().expect("temp data dir");
         let port = free_port();
+        *last_port = port;
         let mut cmd = Command::new(env!("CARGO_BIN_EXE_link-assistant-router"));
         cmd.arg("serve")
             .env("TOKEN_SECRET", "admin-endpoint-test-secret")
@@ -80,7 +106,9 @@ impl Router {
             bootstrap_token: None,
             _data_dir: data_dir,
         };
-        router.await_health();
+        if !router.await_health() {
+            return None;
+        }
         // The banner is printed before the listener binds, so by the time
         // `/health` answers everything we care about has been captured.
         router.bootstrap_token = lines
@@ -89,18 +117,25 @@ impl Router {
             .iter()
             .find_map(|line| line.split("store it now): ").nth(1))
             .map(|token| token.trim().to_string());
-        router
+        Some(router)
     }
 
-    fn await_health(&self) {
+    /// Wait for `/health`, giving up early if the child has already exited.
+    ///
+    /// A router that lost the port race dies within milliseconds, so polling
+    /// the full timeout would turn each retry into a 30-second stall.
+    fn await_health(&mut self) -> bool {
         let deadline = Instant::now() + Duration::from_secs(30);
         while Instant::now() < deadline {
             if ureq_get(&self.url("/health"), None).is_some() {
-                return;
+                return true;
+            }
+            if matches!(self.child.try_wait(), Ok(Some(_))) {
+                return false;
             }
             std::thread::sleep(Duration::from_millis(100));
         }
-        panic!("router never became healthy on port {}", self.port);
+        false
     }
 
     fn url(&self, path: &str) -> String {


### PR DESCRIPTION
## The defect

`tests/admin_endpoints_test.rs` reserves a port like this:

```rust
fn free_port() -> u16 {
    TcpListener::bind("127.0.0.1:0")  // listener dropped at the end of this expression
        .expect("should bind an ephemeral port")
        .local_addr().expect("should have a local address").port()
}
```

The listener closes before the number is returned, so the port is free again for the whole interval until the spawned router binds it. Any of the other tests running in parallel can take it. The child does not retry — `serve` propagates the bind error through `?` (`src/main.rs:409`) and exits — so the loser polls `/health` until the 30-second deadline and panics at line 103.

## Why it mattered

This is not a cosmetic flake. The run for #266 **passed as a PR and failed once merged to `main`**, and because `auto-release` needs `test`, the failure held the v0.108.0 release back a commit.

```
test admin_scoped_tokens_are_issuable_and_rotatable_over_http ... FAILED
panicked at tests/admin_endpoints_test.rs:103:9
test result: FAILED. 7 passed; 1 failed; finished in 30.10s
```

## The fix

Re-roll the port up to five times, and abandon an attempt as soon as the child has exited instead of polling a dead process for the full timeout. That second half matters: without it each retry would stall 30 seconds.

Retrying, rather than holding the listener open until spawn, is what actually closes the window — handing the child a port that something else still holds would just move the conflict.

## Verification

Deterministic probe: hand out a port that is still bound, exactly once.

| | before | after |
|---|---|---|
| Result | **FAILED** — `router never became healthy on port 49199` | **ok** — 8 passed |
| Duration | 30.32s | 10.15s |

The failure text and the 30s stall reproduce the CI log exactly. Unprobed, the suite runs in 0.57s.

Full suite, `cargo fmt --check`, and `cargo clippy --all-targets --all-features -- -D warnings` are all clean.

## Scope

16 other test files share the bind-then-drop pattern. This PR fixes the one with a confirmed CI failure rather than churning all of them speculatively; the same fix applies if another starts flaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)