### PR TITLE
fix(ci): publish a release whose changelog exceeds GitHub's body limit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,6 +276,7 @@ jobs:
           rust-script --test scripts/detect-code-changes.rs
           rust-script --test scripts/check-changelog-fragment.rs
           rust-script --test scripts/check-release-provenance.rs
+          rust-script --test scripts/create-github-release.rs
           rust-script scripts/check-release-workflow.rs
 
   # === DEPENDENCY AUDIT ===

--- a/2026-08-26-125041-local-command-caveatcaveat-the-messages-below.txt
+++ b/2026-08-26-125041-local-command-caveatcaveat-the-messages-below.txt
@@ -1,0 +1,2794 @@
+╭─── Claude Code v2.1.245 ─────────────────────────────────────────────────────╮
+│                                          │ Tips for getting started          │
+│               Welcome back!              │ Run /init to create a CLAUDE.md … │
+│                                          │ ───────────────────────────────── │
+│                  ▐▛███▛█                 │ What's new                        │
+│                 ▝▜██████▀                │ Fixed a crash on startup on Linu… │
+│                   ▝▝ ▝▝                  │ Added a Loops breakdown to `/usa… │
+│                                          │ Added `modelPicker` setting: cur… │
+│        Opus 5 · API Usage Billing        │ /release-notes for more           │
+│   ~/Code/Archive/link-assistant/router   │                                   │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+
+❯ /model                                                                        
+  ⎿  Set model to Opus 5 (1M context) and saved as your default for new sessions
+
+❯ /Users/konard/Code/Archive/link-assistant/router/2026-08-25-212701-this-sessi 
+  on-is-being-continued-from-a-previous-c.txt - continue from there, you can    
+  create a single pull request for all issue in router and deliver them all to  
+  main.                                                                         
+
+⏺ I'll start by reading that session file to understand what work is in flight.
+
+  Read 1 file (ctrl+o to expand)
+
+⏺ Bash(sed -n '1,200p'
+      2026-08-25-212701-this-session-is-being-continued-from-a-previous-c.txt)
+  ⎿  ╭─── Claude Code v2.1.235 ────────────────────────────────────────────
+     ─────────╮
+     │                                                    │ Tips for gettin
+     … +197 lines (ctrl+o to expand)
+
+⏺ Bash(sed -n '200,520p'
+      2026-08-25-212701-this-session-is-being-continued-from-a-previous-c.txt)
+  ⎿  ⏺ Gh is the only variant with no AuthTarget. Now the dispatch path in
+       auth_cli.rs:
+     … +317 lines (ctrl+o to expand)
+
+  Read 1 file (ctrl+o to expand)
+
+⏺ Previous session ended with v0.115.0 released and everything closed. Let me
+  check the current state.
+
+⏺ Bash(git fetch -q 2>&1|tail -2; git status --short; echo "── log ──"; git log
+      --oneline -3; echo "── open issues ──"; gh issue list --state open --limit
+      60; echo "──…)
+  ⎿  ?? 2026-08-25-212701-this-session-is-being-continued-from-a-previous-c
+     .txt
+     ── log ──
+     … +15 lines (ctrl+o to expand)
+
+⏺ Three new issues, all about router with. Let me read them.
+
+⏺ Bash(for n in 295 296 297; do echo "════════════ ISSUE #$n ════════════"; gh
+      issue view $n; echo; done)
+  ⎿  ════════════ ISSUE #295 ════════════
+     title:     with forces a model and a thinking budget over the ones the
+     user
+      configured, so a bare launch silently changes model and effort
+     … +217 lines (ctrl+o to expand)
+
+⏺ Three issues in the with / client-configuration surface. Let me verify each at
+  the source.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      echo "── file sizes ──"…)
+  ⎿  ── file sizes ──
+          921 src/with_command.rs
+          966 src/clients.rs
+     … +11 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      ls src/clients/; echo "── client_command ──"; wc -l src/client_command.rs;
+      echo "── sizes of all src ──"; wc…)
+  ⎿  catalog.rs
+     credentials.rs
+     files.rs
+     … +24 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '1,140p' src/with_command.rs)
+  ⎿  //! Temporary-by-default launcher shared by `router with` and `with-ro
+     uter`.
+     … +137 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '140,300p' src/with_command.rs)
+  ⎿      }
+         let cleanup = cleanup_run_credential(credential).await;
+         let status = launch?;
+     … +158 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '360,470p' src/with_command.rs)
+  ⎿              if client == ClientKind::Opencode {
+                     command
+                         .env("OPENCODE_CONFIG", &path)
+     … +108 lines (ctrl+o to expand)
+
+⏺ All three confirmed structurally. Now the client integration table and model
+  selection.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '1,120p' src/clients.rs)
+  ⎿  //! Safe local configuration for agentic CLI clients.
+     //!
+     //! The writer deliberately owns only one Codex provider table and one
+     … +117 lines (ctrl+o to expand)
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '120,290p' src/clients.rs)
+  ⎿          base_url_env: None,
+             endpoint_suffix: "/v1",
+             model_owner: OPENAI_MODEL_OWNER,
+     … +168 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "select_model\|advertised_owners\|fn
+      models\|ensure_model_available" src/managed_server.rs | head…)
+  ⎿  97:    pub(crate) fn models(&self) -> &[RouterModel] {
+     107:    pub(crate) fn select_model(&self, owner: &str) -> Option<&str>
+      {
+     … +88 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cat src/client_command.rs)
+  ⎿  //! Output and dispatch layer for the `clients` CLI command.
+
+     use std::path::Path;
+     … +358 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cat src/client_global.rs)
+  ⎿  //! Exact, edit-aware backup and undo for `router with --global`.
+
+     use std::fs::{self, OpenOptions};
+     … +343 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "WithArgs" -A 120 src/cli.rs | head -150)
+  ⎿  41:pub use self::with::{ServerOp, WithArgs, protect_client_arguments};
+     42-
+     43-/// Parse a boolean switch that may also arrive from the environmen
+     … +147 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      ls src/cli/; echo "══════ with.rs ══════"; wc -l src/cli/with.rs; cat
+      src/cli/with.rs)
+  ⎿  auth_ops.rs
+     targets.rs
+     with.rs
+     … +461 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cat src/cli/targets.rs)
+  ⎿  //! Which router each subcommand acts on.
+     //!
+     //! Split from `cli.rs` to keep that file within the repository's 1000
+     … +56 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "struct AuthTarget" -B 30 -A 60 src/cli/auth_ops.rs | head -120)
+  ⎿  210-        match self {
+     211-            Self::Import { target, .. } => {
+     212-                if target.local || target.managed {
+     … +57 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      echo "── is_terminal / isatty usage ──"; grep -rn
+      "is_terminal\|IsTerminal\|atty" src/ | head…)
+  ⎿  ── is_terminal / isatty usage ──
+     ── TOKEN_SECRET requirement ──
+     src/config.rs:725:                write!(f, "TOKEN_SECRET environment
+     … +8 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '30,145p' src/main.rs)
+  ⎿  use link_assistant_router::oauth::OAuthProvider;
+     use link_assistant_router::providers::ProviderStore;
+     use link_assistant_router::proxy::AppState;
+     … +113 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      wc -l src/remote_command.rs; sed -n '1,140p' src/remote_command.rs)
+  ⎿       155 src/remote_command.rs
+     //! One targeting rule for every command that reads or changes router
+     state.
+     … +138 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "pub struct ResolvedServer" -A 25 src/managed_server.rs…)
+  ⎿  64:pub struct ResolvedServer {
+     65-    pub base_url: String,
+     66-    pub token: Option<String>,
+     … +100 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '318,400p' src/managed_server.rs)
+  ⎿          }
+             Ok(response) if response.status().as_u16() == 401 || response.
+     status().as_u16() == 403 => {
+     … +80 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      echo "── with_command tests ──"; grep -n "mod
+      tests\|#\[cfg(test)\]\|include!" src/with_command.rs | head…)
+  ⎿  ── with_command tests ──
+     572:#[cfg(test)]
+     573:mod tests {
+     … +43 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '572,700p' src/with_command.rs)
+  ⎿  #[cfg(test)]
+     mod tests {
+         use super::*;
+     … +126 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '700,921p' src/with_command.rs)
+  ⎿      /// file.
+         ///
+         /// A fallback rather than an error: the user did not ask for isol
+     … +219 lines (ctrl+o to expand)
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      echo "── with_router_test ──"; wc -l tests/with_router_test.rs; grep -n
+      "fn \|--print\|--model\|MAX_THINKING…)
+  ⎿  ── with_router_test ──
+          691 tests/with_router_test.rs
+     14:fn read_request(stream: &mut std::net::TcpStream) -> String {
+     … +18 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '187,335p' tests/with_router_test.rs)
+  ⎿  fn fake_codex(bin_dir: &std::path::Path) {
+         fs::create_dir_all(bin_dir).expect("create fake bin directory");
+         let path = bin_dir.join("codex");
+     … +145 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '520,600p' tests/with_router_test.rs)
+  ⎿  fn launcher_rejects_missing_credentials_and_unavailable_models_before_
+     exec() {
+         let directory = tempfile::tempdir().expect("temporary test directo
+     … +78 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "subscription_tests\|github_proxy_tests\|clients_tests" src/lib.rs
+      src/*.rs | head…)
+  ⎿  src/clients.rs:965:#[path = "clients_tests.rs"]
+     src/github_proxy.rs:674:#[path = "github_proxy_tests.rs"]
+     src/subscription.rs:889:#[path = "subscription_tests.rs"]
+     … +81 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      ls scripts/ | head -30; echo "── size guard ──"; grep -rn "1000"
+      scripts/*.sh 2>/dev/null | head)
+  ⎿  bump-version.rs
+     check-changelog-fragment.rs
+     check-coverage.rs
+     … +22 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      head -40 scripts/check-file-size.rs; echo "── changelog fragments ──"; ls
+      changelog.d 2>/dev/null | head; he…)
+  ⎿  #!/usr/bin/env rust-script
+     //! Check for files exceeding the maximum allowed line count
+     //! Exits with error code 1 if any files exceed the limit
+     … +78 lines (ctrl+o to expand)
+
+⏺ Setting up the branch and looking at conventions.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      git checkout -q -b fix/issue-295-297-with-and-configure && git status
+      --short | head -3…)
+  ⎿  ?? 2026-08-25-212701-this-session-is-being-continued-from-a-previous-c
+     .txt
+     ── recent changelog fragment ──
+     … +42 lines (ctrl+o to expand)
+
+⏺ Now implementing. First, extracting the argv builder into its own module to
+  make room.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "^/// Build the wrapped client's argv\|^fn client_arguments\|^fn
+      contains_native_mode\|^fn contains_…)
+  ⎿  377:/// Build the wrapped client's argv.
+     382:fn client_arguments(args: &WithArgs, resolved_model: &str) -> Vec<
+     OsString> {
+     … +5 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿      if matches!(client, ClientKind::Opencode | ClientKind::Agent) && !
+     model.contains('/') {
+             format!("link-assistant/{model}")
+     … +4 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cat > src/client_launch.rs <<'RS'…)
+  ⎿  written
+          171 src/client_launch.rs
+
+⏺ Now the tests for the new module, including the negative-check regressions the
+  issues asked for.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cat > src/client_launch_tests.rs <<'RS'…)
+  ⎿  written
+          235 src/client_launch_tests.rs
+
+⏺ Now removing the moved block from with_command.rs and rewiring the model
+  decision.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  ['}', '', 'fn endpoint(base_url: &str, suffix: &str) -> String {', '
+       format!("{}{}", base_url.trim_end_matches(\'/\'), suffix)', '}']
+          829 src/with_command.rs
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿       784 src/with_command.rs
+     error[E0425]: cannot find function `client_arguments` in this scope
+        --> src/with_command.rs:133:21
+     … +7 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '84,140p' src/with_command.rs)
+  ⎿              eprintln!("warning: {error}; the short token TTL remains t
+     he cleanup backstop");
+             }
+     … +54 lines (ctrl+o to expand)
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+          829 src/with_command.rs
+
+⏺ Now removing the forced reasoning-effort and thinking-budget environment.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "MAX_THINKING_TOKENS" -B 6 -A 30 src/with_command.rs | head -60)
+  ⎿  283-        }
+     284-        let model = model_override.unwrap_or("");
+     285-        match client {
+     … +34 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+     warning: file `/Users/konard/Code/Archive/link-assistant/router/src/ma
+     in.rs` found to be present in multiple build targets:
+     … +37 lines (ctrl+o to expand)
+
+⏺ Now wiring the module and adding --pick-model plus the help text updates.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+     ok
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cargo build 2>&1 | grep -E "^error" -A10 | head -40; echo "─── done ───")
+  ⎿  ─── done ───
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cargo test --lib client_launch 2>&1 | tail -30)
+  ⎿     Compiling fs-err v3.3.1
+        Compiling tokio-test v0.4.5
+        Compiling tower-http v0.6.11
+     … +26 lines (ctrl+o to expand)
+
+⏺ Negative check — confirming the new tests actually fail against the old
+  behaviour.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cp src/client_launch.rs /tmp/cl.bak…)
+  ⎿  ─── new tests against the OLD rules ───
+     test client_launch::tests::a_client_that_cannot_start_without_a_model_
+     still_gets_one ... ok
+     … +13 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cargo test --lib 2>&1 | grep -E "FAILED|failures:|test result" | head -20)
+  ⎿  test result: ok. 911 passed; 0 failed; 0 ignored; 0 measured; 0 filter
+     ed out; finished in 5.64s
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cargo test --test with_router_test --test cli_contract_test --test
+      real_clients_test --test client_fixture_t…)
+  ⎿  test revoke_and_expire_reject_unknown_token_ids ... ok
+     test help_never_prints_secret_environment_values ... ok
+     test missing_argument_usage_does_not_present_configured_globals_as_req
+     … +24 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -rn "portable_pty\|portable-pty" Cargo.toml tests/ src/login_pty*.rs
+      | head)
+  ⎿  Cargo.toml:68:portable-pty = "0.9"
+     src/login_pty.rs:30:use portable_pty::{Child, CommandBuilder, MasterPt
+     y, PtySize, native_pty_system};
+     src/login_pty_backend.rs:12:use portable_pty::CommandBuilder;
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "portable-pty" -B5 -A3 Cargo.toml; grep -n "^\[dev-dependencies\]"
+      -A 25 Cargo.toml)
+  ⎿  63-base64 = "0.23"
+     64-async-trait = "0.1"
+     65-sha2 = "0.11"
+     … +32 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '1,150p' tests/with_router_test.rs)
+  ⎿  //! Black-box coverage for the temporary-by-default client launcher (i
+     ssue #151).
+     … +147 lines (ctrl+o to expand)
+
+⏺ Adding the end-to-end test for the exact command from issue #297, driven
+  through a pty.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cat >> tests/with_router_test.rs <<'RS'…)
+  ⎿  test a_client_flag_starts_a_session_rather_than_a_one_shot_run ... ok
+     test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 9 filtered
+      out; finished in 0.72s
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cp src/client_launch.rs /tmp/cl.bak; cp src/with_command.rs /tmp/wc.bak…)
+  ⎿  ─── end-to-end test against the OLD behaviour ───
+     test a_client_flag_starts_a_session_rather_than_a_one_shot_run ... FAI
+     LED
+     … +4 lines (ctrl+o to expand)
+
+⏺ #297 and #295 land end-to-end. Now #296 — the largest. Checking the
+  TOKEN_SECRET relaxation machinery.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "relax_token_secret_for_auth" -A 30 src/auth_cli.rs | head -45)  ⎿  17:pub fn relax_token_secret_for_auth(
+     18-    mut cli: link_assistant_router::cli::Cli,
+     19-) -> link_assistant_router::cli::Cli {
+     … +42 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "enum ClientOp" -B 20 -A 60 src/cli.rs | head -100)
+  ⎿  768-        #[command(flatten)]
+     769-        target: AuthTarget,
+     770-    },
+     … +78 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "pub fn write_environment\|pub fn write_credential_metadata\|pub
+      fn from_env\|pub fn isolated\|pub f…)
+  ⎿  403:    pub fn from_env() -> Result<Self, ClientError> {
+     433:    pub fn isolated(home: &Path) -> Self {
+     454:    pub fn config_path(&self, client: ClientKind) -> PathBuf {
+     … +10 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "fn write_environment\|fn setup\|fn catalog\|fn doctor\|fn
+      environment_path" src/clients.rs src/clie…)
+  ⎿  src/clients.rs:273:    pub const fn setup_limitation(self) -> Option<&
+     'static str> {
+     src/clients.rs:468:    pub fn environment_path(&self, client: ClientKi
+     … +71 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '560,650p' src/clients.rs)
+  ⎿                          .is_some()
+                 }),
+             })
+     … +88 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '175,245p' src/managed_server.rs)
+  ⎿  ///
+     /// `force_managed` skips the discovery step, for workflows that want
+     a
+     … +68 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "fn discover_local_router\|fn load_persisted\|fn
+      normalize_server\|fn start_managed\|fn managed_fail…)
+  ⎿  457:pub fn load_persisted() -> Result<Option<PersistedServer>, AnyErro
+     r> {
+     528:pub fn managed_failure_hint() -> Option<String> {
+     … +2 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "discover_local_router" -A 30 src/managed_server.rs | head -40)
+  ⎿  22:use discovery::discover_local_router;
+     23-pub use discovery::{discovered_local_router, effective_source};
+     24-
+     … +37 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "pub async fn discovered_local_router\|pub fn effective_source" -A
+      25 src/managed_server/discovery.r…)
+  ⎿  165:pub async fn discovered_local_router() -> Option<ResolvedServer> {
+     166-    let base_url = discover_local_router(false).await?;
+     167-    let token = std::env::var("LINK_ASSISTANT_ROUTER_TOKEN")
+     … +23 lines (ctrl+o to expand)
+
+⏺ Now building router configure. Starting with the argument surface.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cat > src/cli/configure.rs <<'RS'…)
+  ⎿  36:mod auth_ops;
+     37:mod targets;
+     38:mod configure;
+     … +5 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched cli.rs
+          996 src/cli.rs
+     error[E0004]: non-exhaustive patterns: `Some(&link_assistant_router::c
+     … +18 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched client_global
+
+⏺ Now the configure implementation.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cat > src/configure.rs <<'RS'…)
+  ⎿  error[E0425]: cannot find function `configure` in module `crate::clien
+     t_global`
+       --> src/with_command.rs:65:35
+     … +26 lines (ctrl+o to expand)
+
+⏺ Now making with --global delegate to configure, so the two commands can no
+  longer disagree.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '32,92p' src/with_command.rs)
+  ⎿  async fn run_inner(args: &WithArgs) -> Result<ExitCode, AnyError> {
+         if args.undo {
+             crate::client_global::undo(args.client)?;
+     … +57 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched with_command
+     error[E0004]: non-exhaustive patterns: `Some(&link_assistant_router::c
+     li::Command::Configure(_))` not covered
+     … +17 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)  ⎿  patched main
+     ─── done ───
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cargo run -q --bin router -- configure --help 2>&1 | head -40)
+  ⎿  Point a client at the router permanently.
+
+     One name, one targeting rule and one reversal for what used to be two
+     … +36 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "fn token_subject" -A 20 src/managed_server.rs | head -25…)
+  ⎿  420:fn token_subject(token: &str) -> Result<String, AnyError> {
+     421-    let payload = token
+     422-        .split('.')
+     … +45 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched managed_server
+     patched credentials
+     error[E0063]: missing field `router` in initializer of `ManagedCredent
+     … +24 lines (ctrl+o to expand)
+
+⏺ Now completing the credential record and wiring revocation into configure 
+  --undo.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+     ─── done ───
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched undo
+     ─── done ───
+          280 src/configure.rs
+
+⏺ Now making clients setup stop silently writing the wrong address, and letting
+  read-only client commands run without TOKEN_SECRET.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+     ─── done ───
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+     ─── done ───
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+     ── sizes ──
+          996 src/cli.rs
+     … +8 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      ls src/managed_server/; grep -n "^mod \|^pub mod \|^use \|^pub use"
+      src/managed_server.rs | head -20…)
+  ⎿  bootstrap.rs
+     catalog.rs
+     discovery_tests.rs
+     … +27 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '440,530p' src/managed_server.rs)
+  ⎿          .ok_or("router returned a token without a JWT payload")?;
+         let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+             .decode(payload)
+     … +88 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  split out selection.rs
+     ─── done ───
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  split out client_ops.rs
+     ── sizes ──
+          945 src/cli.rs
+     … +4 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      rust-script scripts/check-file-size.rs 2>&1 | tail -5…)
+  ⎿  Checking Rust files for maximum 1000 lines...
+
+     All files are within the line limit
+     … +2 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cargo test --lib 2>&1 | tail -30)
+  ⎿     |
+        = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by
+      default
+     … +27 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  warning: file `/Users/konard/Code/Archive/link-assistant/router/src/ma
+     in.rs` found to be present in multiple build targets:
+       * `bin` target `link-assistant-router`
+     … +19 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '125,140p' src/clients/credentials.rs)
+  ⎿      #[test]
+         fn records_round_trip_through_disk_without_the_token() {
+             let directory = tempfile::tempdir().expect("temp dir");
+     … +15 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)  ⎿  warning: file `/Users/konard/Code/Archive/link-assistant/router/src/ma
+     in.rs` found to be present in multiple build targets:
+       * `bin` target `link-assistant-router`
+     … +7 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cargo test 2>&1 | grep -E "^error|FAILED|panicked|^failures:" -A3 | head
+      -50; echo "─── summary ───"; cargo…)
+  ⎿  test global_undo_removes_a_config_that_did_not_exist_before_setup ...
+     FAILED
+     test global_undo_restores_exact_config_and_permissions ... FAILED
+     … +35 lines (ctrl+o to expand)
+
+⏺ The three failures are the intended change: with --global now refuses to write
+  a configuration it cannot supply a credential for. Updating those tests.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '398,520p' tests/with_router_test.rs)
+  ⎿  fn global_undo_restores_exact_config_and_permissions() {
+         let directory = tempfile::tempdir().expect("temporary test directo
+     ry");
+     … +120 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+     patched tests
+     test persisted_remote_token_is_private_and_never_echoed ... ok
+     … +14 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cargo test 2>&1 | grep -E "FAILED|^failures:|panicked" -A3 | head -40;
+      echo "─── ok blocks ───"; cargo test…)
+  ⎿  ─── ok blocks ───
+     44
+
+⏺ All green. Now the #296 regression tests.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      ls tests/common/; head -30 tests/common/mod.rs 2>/dev/null; grep -rn "mod
+      common" tests/*.rs | head -5)
+  ⎿  mod.rs
+     //! Shared black-box helpers for the client-configurator test binaries
+     .
+     … +31 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '30,140p' tests/common/mod.rs)
+  ⎿      command.output().expect("router CLI should run")
+     }
+     … +74 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "fn state_directory" -A 20 src/managed_server/state.rs 2>/dev/null
+      | head -25)
+  ⎿  (No output)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -rn "fn state_directory" -A 18 src/managed_server*.rs
+      src/managed_server/ | head -25)
+  ⎿  src/managed_server_state.rs:16:pub(super) fn state_directory() -> Resu
+     lt<PathBuf, AnyError> {
+     src/managed_server_state.rs-17-    let root = std::env::var_os("XDG_CO
+     … +17 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cat > tests/configure_test.rs <<'RS'…)
+  ⎿  Error: Exit code 143
+     Command timed out after 2m 0s
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      timeout 180 cargo test --test configure_test -- --test-threads=1
+      listing_clients 2>&1 | grep -E "^test |FAIL…)
+  ⎿  test listing_clients_does_not_demand_a_signing_secret ... ok
+
+     test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 4 filtered
+      out; finished in 0.63s
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      timeout 90 cargo test --test configure_test -- --test-threads=1
+      configure_writes 2>&1 | grep -E "^test |FAIL…)
+  ⎿  test configure_writes_the_selected_router_and_stores_its_credential ..
+     .
+     EXIT=0
+
+⏺ The mock blocks waiting for a request that never comes. Making it
+  deadline-bounded.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched mock
+     test clients_setup_refuses_rather_than_writing_the_wrong_address ... o
+     k
+     … +8 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "ServerOp::Use" -A 30 src/server_command.rs | head -40)
+  ⎿  17:        ServerOp::Use {
+     18-            server,
+     19-            token,
+     … +28 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  18:fn mock_router(requests: usize) -> (String, thread::JoinHandle<Vec<
+     String>>) {
+     125:    let (server, requests) = mock_router(3);
+     … +14 lines (ctrl+o to expand)
+⏺ Negative check for the #296 fixes.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cp src/client_command.rs /tmp/cc.bak; cp src/configure.rs /tmp/cfg.bak; cp
+      src/main.rs /tmp/main.bak…)
+  ⎿  test clients_setup_refuses_rather_than_writing_the_wrong_address ... F
+     AILED
+     test configure_writes_the_selected_router_and_stores_its_credential ..
+     … +7 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cargo build 2>&1 | grep -E "^error" -A5 | head; echo "─── build ok ───"…)
+  ⎿  ─── build ok ───
+     README.md:1129:router clients setup codex
+     README.md:1130:router clients setup claude --token la_sk_...
+     … +19 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '1,60p' docs/use-cases/configure-clients.md)
+  ⎿  # Configure local agentic CLIs
+
+     For one run, use the temporary launcher. It is the default path and do
+     … +57 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched docs
+
+     See [with-router.md](with-router.md) for the integration registry, ser
+     … +39 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "MAX_THINKING_TOKENS\|model_reasoning_effort\|xhigh\|--print\|non-
+      interactive\|interactive" docs/use…)
+  ⎿  47:router with --non-interactive gemini "hi"
+     55:one-shot mode; use `--interactive` to suppress that behavior, or
+     56:`--non-interactive` to request it explicitly. `--model` overrides t
+     … +3 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '38,72p' docs/use-cases/with-router.md; echo "════ 140-155 ════";
+      sed -n '138,155p' docs/use-cases/wi…)
+  ⎿  can use an OpenAI URL.
+
+     ## Arguments, interaction, and models
+     … +50 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched with-router doc
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '1120,1145p' README.md; echo "════"; grep -n "^router with\|^###
+      \|^## " README.md | sed -n '1,10p')
+  ⎿  router accounts list
+
+     # Manage OpenAI-compatible upstream providers:
+     … +34 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched README
+     docs/use-cases/with-router.md:33:`with claude-code` and `clients setup
+      qwen-code` continue to work.
+     … +4 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '18,35p' docs/use-cases/cli-claude-code.md; echo "════ codex ════";
+      sed -n '25,38p' docs/use-cases/cl…)
+  ⎿  ## Manual or permanent configuration
+
+     Automatic setup (merges the router URL and backs up an existing settin
+     … +43 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched per-client docs
+     ok
+
+⏺ Now a live smoke test against a real router, reproducing the issues' own
+  commands.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cargo build -q 2>&1 | grep -E "^error" | head…)
+  ⎿  ok
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      SANDBOX=$(cat /tmp/sandbox_path); HOME_SB="$SANDBOX/home"…)
+  ⎿  TOKEN: Usage: route…
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      SANDBOX=$(cat /tmp/sandbox_path)…)
+  ⎿  Issue a new token and print it to stdout
+
+     Usage: router tokens issue [OPTIONS]
+     … +25 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      SANDBOX=$(cat /tmp/sandbox_path); HOME_SB="$SANDBOX/home"…)
+  ⎿  TOKEN: la_sk_eyJ0…
+     ── select the router ──
+     saved server selection in link-assistant-router/server.json (token set
+     )
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      SANDBOX=$(cat /tmp/sandbox_path); HOME_SB="$SANDBOX/home"…)
+  ⎿  ══════ issue #295: bare launch keeps the user's model and effort ═════
+     ═
+     error: http://127.0.0.1:18878 selected from already-running local serv
+     … +9 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      SANDBOX=$(cat /tmp/sandbox_path); HOME_SB="$SANDBOX/home"; TOKEN=$(cat
+      /tmp/smoke_token)…)
+  ⎿  saved server selection in /var/folders/cl/831lqjgd58v5mb_m74cfdfcw0000
+     gn/T/tmp.B8MdI9BrkR/home/.config/link-assistant-router/server.json (to
+     ken set)
+     … +10 lines (ctrl+o to expand)
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "MAX_THINKING_TOKENS" src/*.rs; echo "── rebuild ──"; cargo build
+      2>&1 | tail -2; ls -l target/debug…)
+  ⎿  src/with_command.rs:271:        // user's `MAX_THINKING_TOKENS` or `OP
+     ENAI_REASONING_EFFORT` reach it
+     ── rebuild ──
+     … +5 lines (ctrl+o to expand)
+
+⏺ Bash(echo "MAX_THINKING_TOKENS=[${MAX_THINKING_TOKENS}]"; env | grep -i
+      thinking)
+  ⎿  MAX_THINKING_TOKENS=[16384]
+     MAX_THINKING_TOKENS=16384
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      SANDBOX=$(cat /tmp/sandbox_path); HOME_SB="$SANDBOX/home"…)
+  ⎿  ══════ piped (no terminal): one-shot, no model, no thinking budget ═══
+     ═══
+     ARGS: --print
+     … +10 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      SANDBOX=$(cat /tmp/sandbox_path); HOME_SB="$SANDBOX/home"…)
+  ⎿  ══════ router configure claude ══════
+     router: http://127.0.0.1:18899 (from persisted configuration)
+     configured Claude Code in /var/folders/cl/831lqjgd58v5mb_m74cfdfcw0000
+     … +19 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      SANDBOX=$(cat /tmp/sandbox_path); HOME_SB="$SANDBOX/home"…)
+  ⎿  ══════ the credential record ══════
+     {
+       "client": "claude",
+     … +22 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      SANDBOX=$(cat /tmp/sandbox_path); HOME_SB="$SANDBOX/home"…)
+  ⎿  ══════ clients list without TOKEN_SECRET ══════
+     2026-08-25T15:20:27.082536Z  INFO router: Link.Assistant.Router v0.115
+     .0
+     … +58 lines (ctrl+o to expand)
+
+⏺ One gap found in live use: the clients setup refusal is preempted by the
+  TOKEN_SECRET error. Fixing that.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+     ══════ clients setup with another router selected ══════
+     error: `clients setup` configures the router it can mint a token for,
+     … +3 lines (ctrl+o to expand)
+
+❯ Add to work on this pull request all new issues, that you didn't see yet, and 
+  also double check for comments to issues.                                     
+
+⏺ The refusal now reaches the user. Let me check for new issues and any comments
+  before continuing.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      echo "── open issues now ──"; gh issue list --state open --limit 60…)
+  ⎿  ── open issues now ──
+     316        OPEN    with sends the working directory's name to the router as
+     n label, so the deployment accumulates a list of every project its use
+     … +56 lines (ctrl+o to expand)
+
+
+⏺ 19 new issues appeared. Reading the two comments first.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      gh issue view 297 --json comments --jq '.comments[] | "── #297 by
+      \(.author.login) ──\n\(.body)"'…)
+  ⎿  ── #297 by konard ──
+     Two more consequences of the same rule, found while checking the argum
+     ent path.
+     … +46 lines (ctrl+o to expand)
+
+⏺ Both comments bear directly on this work. Now reading all 19 new issues.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      for n in 298 299 300 301; do echo "════════════ #$n ════════════"; gh
+      issue view $n --json title,body --jq '…)
+  ⎿  ════════════ #298 ════════════
+     TITLE: clients that cannot be extended get a throwaway home every run,
+      so codex, gemini and agent can never resume a session through with
+     … +214 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      for n in 302 303 304 305 306; do echo "════════════ #$n ════════════"; gh
+      issue view $n --json title,body --…)
+  ⎿  ════════════ #302 ════════════
+     TITLE: clients remove claude deletes the user's own ANTHROPIC_BASE_URL
+      instead of restoring it, while codex restores its previous provider
+     … +188 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      for n in 307 308 309 310; do echo "════════════ #$n ════════════"; gh
+      issue view $n --json title,body --jq '…)
+  ⎿  ════════════ #307 ════════════
+     TITLE: auth import ignores $CLAUDE_CODE_HOME and $CODEX_HOME that its
+     own help names as the default source
+     … +150 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      for n in 311 312 313; do echo "════════════ #$n ════════════"; gh issue
+      view $n --json title,body --jq '"TIT…)
+  ⎿  ════════════ #311 ════════════
+     TITLE: with --server <the already-selected URL> ignores the token stor
+     ed for it and tells the user to run the command they already ran
+     … +123 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      for n in 314 315 316; do echo "════════════ #$n ════════════"; gh issue
+      view $n --json title,body --jq '"TIT…)  ⎿  ════════════ #314 ════════════
+     TITLE: the CLI vocabulary is inconsistent across families: three verbs
+      for create, four spellings for delete, --token with three meanings, -
+     … +163 lines (ctrl+o to expand)
+
+⏺ 22 open issues now. Let me commit the current work, then work through the
+  rest.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      PID=$(cat /tmp/router_pid); kill $PID 2>/dev/null; echo "stopped smoke
+      router"…)
+  ⎿  stopped smoke router
+     2c6ae4c wip: issues 295-297
+
+⏺ Starting with the security issue #300.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -rn "unused-by" src/ | grep -v "_tests.rs"…)
+  ⎿  src/remote_command.rs:120:        cli.token_secret = Some("unused-by-r
+     emote-command".to_string());
+     src/auth_cli.rs:25:        cli.token_secret = Some("unused-by-auth".to
+     … +9 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '195,240p' src/token.rs; echo "══════ cipher ══════"; sed -n
+      '452,472p' src/providers.rs)
+  ⎿  pub struct TokenManager {
+         secret: String,
+         store: Arc<dyn TokenStore>,
+     … +65 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cat > src/token_secret.rs <<'RS'…)
+  ⎿  89:pub mod token_secret;
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "pub fn issue_token_full\|pub fn validate_token\|fn
+      issue_with_id\|fn issue(" -A 12 src/token.rs | h…)
+  ⎿  249:    pub fn issue_token_full(
+     250-        &self,
+     251-        ttl_hours: i64,
+     … +47 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '311,345p' src/token.rs; echo "── TokenError ──"; grep -n "pub enum
+      TokenError" -A 20 src/token.rs |…)
+  ⎿          let claims = TokenClaims {
+                 sub: Uuid::new_v4().to_string(),
+                 iat: now.timestamp(),
+     … +54 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+     ─── done ───
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "MissingTokenSecret\|token_secret" src/config.rs | head -20…)
+  ⎿  188:    pub token_secret: String,
+     300:        let token_secret = env::var("TOKEN_SECRET").ok();
+     451:            token_secret: token_secret.as_deref(),
+     … +28 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+     fn run_tokens(config: &Config, op: &TokenOp) -> ExitCode {
+         let (store, _account_router) = match build_shared_state(config) {
+     … +27 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  ─── done ───
+
+⏺ Now #308: making the secret required where signing happens, not per family,
+  and giving tls a target.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '1,40p' src/tls_cli.rs)
+  ⎿  //! `router tls` — manage the certificate a self-signed deployment ser
+     ves.
+     //!
+     … +32 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched cli
+     ─── done ───
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '540,575p' src/main.rs; echo "── no_remote_form tail ──"; sed -n
+      '128,155p' src/remote_command.rs)
+  ⎿          // The routes exist and are admin-gated; only the wiring was m
+     issing.
+             Command::Tokens { op } => link_assistant_router::tokens_remote
+     … +62 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+     ─── done ───
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -rn "relax_token_secret" src/ tests/ | grep -v
+      "^src/remote_command.rs:1[12]\|^src/auth_cli.rs:1[0-9]\|…)
+  ⎿  src/remote_command_tests.rs:96:    let relaxed = relax_token_secret_fo
+     r_remote(cli);
+     src/remote_command_tests.rs:113:    let relaxed = relax_token_secret_f
+     … +13 lines (ctrl+o to expand)
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '88,130p' src/remote_command_tests.rs)
+  ⎿  #[test]
+     fn a_remote_command_does_not_need_the_local_signing_secret() {
+         let cli = Cli::try_parse_from(["router", "tokens", "list"]).expect
+     … +39 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+
+         tracing::info!("Link.Assistant.Router v{}", link_assistant_router:
+     … +26 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  removed
+     error: expected item after doc comment
+       --> src/auth_cli.rs:14:1
+     … +14 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  //! Foreground provider authorization commands.
+
+     use std::process::ExitCode;
+     … +19 lines (ctrl+o to expand)
+
+⏺ Now #305 — auth --clear silently clearing the wrong machine.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '10,70p' src/auth_cli.rs; echo "══════ run_clear ══════"; grep -n
+      "fn run_clear" -A 45 src/auth_cli.r…)
+  ⎿  pub async fn run(config: &Config, op: &AuthOp) -> ExitCode {
+         // Withdrawal is local by construction: it removes files this mach
+     ine holds,
+     … +105 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "pub enum AuthOp" -A 90 src/cli/auth_ops.rs | head -110)
+  ⎿  32:pub enum AuthOp {
+     33-    /// Adopt a login this machine already has, without a browser.
+     34-    ///
+     … +88 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "fn target\b\|pub const fn target\|fn remote_target" -A 20
+      src/cli/auth_ops.rs src/auth_cli.rs | hea…)
+  ⎿  src/cli/auth_ops.rs:285:    pub const fn target(&self) -> &AuthTarget
+     {
+     src/cli/auth_ops.rs-286-        match self {
+     … +24 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "pub enum ImportProvider" -A 25 src/cli/auth_ops.rs; grep -n "impl
+      ImportProvider" -A 30 src/cli/aut…)
+  ⎿  17:pub enum ImportProvider {
+     18-    #[value(name = "claude", alias = "anthropic")]
+     19-    Claude,
+     … +33 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+     error[E0004]: non-exhaustive patterns: `&AuthOp::Clear { .. }` not cov
+     ered
+     … +38 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+     error[E0004]: non-exhaustive patterns: `&AuthOp::Clear { .. }` not cov
+     ered
+     … +28 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '350,375p' src/auth_cli.rs)
+  ⎿  async fn run_remote(
+         config: &Config,
+         server: &link_assistant_router::managed_server::ResolvedServer,
+     … +23 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  ─── done ───
+     error[E0425]: cannot find function `relax_token_secret_for_remote` in
+     this scope
+     … +28 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched tests
+     test result: ok. 914 passed; 0 failed; 0 ignored; 0 measured; 0 filter
+     ed out; finished in 5.67s
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      timeout 400 cargo test 2>&1 | grep -E "FAILED|^failures:|panicked|^error"
+      -A3 | head -40; echo "─── ok block…)
+  ⎿  error[E0425]: cannot find function `relax_token_secret_for_auth` in th
+     is scope
+        --> src/auth_cli.rs:773:23
+     … +22 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '763,800p' src/auth_cli.rs)
+  ⎿          }
+         }
+     … +32 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  test clear_all_withdraws_every_identity_at_once ... FAILED
+     test gh_accepts_the_target_flags_the_other_subcommands_take ... ok
+     test import_all_cannot_also_name_one_provider ... ok
+     … +18 lines (ctrl+o to expand)
+
+⏺ The confirmation gate needs a --yes on the legacy spelling too.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "clear_all" -B 8 -A 4 src/cli/auth_ops.rs | head -25)
+  ⎿  167-    /// Report whether each provider credential is usable, expired
+     , or absent.
+     168-    Status {
+     … +14 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)  ⎿  331:/// One `--clear-all` withdraws every identity, so decommissioning
+      a test
+     355:        .args(["auth", "status", "--clear-all", "--yes", "--local"
+     … +2 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cat >> tests/auth_cli_test.rs <<'RS'…)
+  ⎿  test clear_cannot_be_combined_with_authorizing_flags ... ok
+     test claude_code_is_rejected_for_the_cli_fallback_without_starting_it
+     ... ok
+     … +27 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      timeout 500 cargo test 2>&1 | grep -E "FAILED|^failures:|panicked|^error"
+      -A3 | head -30; echo "─── ok block…)
+  ⎿  ─── ok blocks ───
+     45
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      git add -A && git commit -q -m "wip: issues 300, 305, 308" && echo
+      committed…)
+  ⎿  committed
+
+     All files are within the line limit
+
+⏺ Now the clients cluster — #302, #303, #304.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '751,800p' src/clients.rs; echo "════ remove_claude ════"; grep -n
+      "fn remove_claude" -A 30 src/clien…)
+  ⎿      fn setup_codex(&self, base_url: &str) -> Result<SetupResult, Clien
+     tError> {
+             let path = self.config_path(ClientKind::Codex);
+     … +79 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '793,852p' src/clients.rs; echo "════ markers ════"; grep -n "fn
+      write_claude_marker\|fn read_claude_…)
+  ⎿      fn setup_claude(&self, base_url: &str) -> Result<SetupResult, Clie
+     ntError> {
+             let path = self.config_path(ClientKind::ClaudeCode);
+     … +114 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+     warning: unused import: `read_claude_marker`
+       --> src/clients.rs:26:34
+     … +10 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  warning: file `/Users/konard/Code/Archive/link-assistant/router/src/ma
+     in.rs` found to be present in multiple build targets:
+       * `bin` target `link-assistant-router`
+     … +8 lines (ctrl+o to expand)
+
+⏺ Now #304 (listing must not abort) and #303 (outcomes matching actions).
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '525,565p' src/clients.rs; echo "── ClientStatus ──"; grep -n "pub
+      struct ClientStatus" -A 20 src/cli…)
+  ⎿                      .join(OWNERSHIP_MARKER),
+                 ),
+                 ClientKind::QwenCode => Some(self.qwen_home.join(OWNERSHIP
+     … +60 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched status
+     ─── done ───
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+     ─── done ───
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  test pending_sessions_are_capped ... FAILED
+     test setup_token_remains_an_explicit_alternative ... ok
+     test cancelling_releases_the_session_and_its_process ... ok
+     … +23 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      for i in 1 2 3; do timeout 120 cargo test --test login_flow_test
+      pending_sessions_are_capped 2>&1 | grep -E…)
+  ⎿  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 13 filtere
+     d out; finished in 7.86s
+     test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 13 filtere
+     … +3 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      timeout 500 cargo test 2>&1 | grep -E "FAILED|^failures:|panicked" -A3 |
+      head -30; echo "─── ok blocks ───";…)
+  ⎿  ─── ok blocks ───
+     45
+
+⏺ Now #306 (remote accounts list parity) and #307 (auth import home variables).
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '480,540p' src/auth_remote.rs; echo "════ local accounts printer
+      ════"; grep -rn "healthy" src/main.r…)
+  ⎿  /// router serving live traffic as unauthorized, and pointed the opera
+     tor at a
+     /// re-authentication it did not need (issue #281).
+     … +53 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -rn "healthy" src/accounts.rs src/main.rs src/*.rs 2>/dev/null | grep
+      -i "print\|format\|{:<" | head…)
+  ⎿  src/accounts_cli.rs:13:/// `credential` is printed beside `healthy` so
+      an operator can see *why* an
+     src/chat_commands.rs:488:                lines.push(format!("Accounts:
+     … +42 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cat src/accounts_cli.rs | head -90)
+  ⎿  //! The `accounts` subcommand: report what each configured account can
+      do.
+     //!
+     … +46 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '40,90p' src/monitoring_api.rs)  ⎿          return admin_required();
+         }
+         let snap = crate::metrics::usage_snapshot(&state.metrics);
+     … +48 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched accounts_cli
+     src/main.rs:16:#[path = "accounts_cli.rs"]
+     src/main.rs:17:mod accounts_cli;
+     … +22 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  use std::process::ExitCode;
+     use std::sync::Arc;
+     use std::time::Duration;
+     … +27 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  ─── done ───
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cargo clippy --all-targets --all-features 2>&1 | grep -E
+      "^(error|warning)" -A8 | head -40; echo "─── clippy…)
+  ⎿  warning: file `/Users/konard/Code/Archive/link-assistant/router/src/ma
+     in.rs` found to be present in multiple build targets:
+       * `bin` target `link-assistant-router`
+     … +38 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  error: item in documentation is missing backticks
+       --> src/token_secret.rs:15:19
+        |
+     … +18 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -i '' 's|the ordinary "TOKEN_SECRET is required" error|the ordinary
+      `TOKEN_SECRET is required` error|' s…)
+  ⎿  error: this could be a `const fn`
+        --> src/auth_cli.rs:315:1
+         |
+     … +27 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  ─── clippy done ───
+
+⏺ Now #307 — auth import honouring the home variables its own help names.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '215,250p' src/auth_import.rs; echo "════ resolve_home ════"; grep
+      -n "fn resolve_home" -A 25 src/sub…)
+  ⎿  /// its account id from `id_token` on every read, so a round-trip woul
+     d drop the
+     /// field the next read depends on.
+     … +74 lines (ctrl+o to expand)
+
+⏺ #307 has two halves — the help text is wrong, and the two "vendor home"
+  definitions disagree.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+     ─── done ───
+
+⏺ Now #309 — the doctor probe cost — and #301, the model-owner rule.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '680,725p' src/clients.rs; echo "════ catalog doctor_model ════";
+      sed -n '78,110p' src/clients/catalo…)
+  ⎿          }
+             Ok(path)
+         }
+     … +72 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '722,760p' src/clients.rs)
+  ⎿              ClientKind::ClaudeCode => (
+                     format!("{}/v1/messages", base_url.trim_end_matches('/
+     ')),
+     … +36 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+     ─── done ───
+
+⏺ Now #301 — one rule for which models suit a client, with the right vendors.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '48,62p' src/model_routing.rs)
+  ⎿      model_route_error_response(&ModelRouteError::NotFound(format!(
+     "model '{model}' is not available"
+         )))
+     … +13 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched table
+     error[E0609]: no field `model_owner` on type `&'static ClientIntegrati
+     on`
+     … +11 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched catalog
+     error[E0609]: no field `model_owner` on type `&'static ClientIntegrati
+     on`
+     … +13 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '135,180p' src/with_command.rs)
+  ⎿  /// configuration selects. A model is resolved only when the user aske
+     d for one
+     /// with `--model`, asked the router to choose with `--pick-model`, or
+     … +43 lines (ctrl+o to expand)
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+     error[E0364]: `select_model` is only public within the crate, and cann
+     ot be re-exported outside
+     … +29 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -i '' 's/^pub(crate) fn select_model/pub fn select_model/;
+      s/^pub(crate) fn usable_models/pub fn usable_…)
+  ⎿  ─── done ───
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+     error[E0433]: cannot find module or crate `link_assistant_router` in t
+     his scope
+     … +21 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -i '' 's|link_assistant_router::clients::usable_models(client,
+      \&models)|crate::clients::usable_models(c…)
+  ⎿  test auth_remote::tests::a_configured_pool_is_reported_as_before ... F
+     AILED
+     test admin::tests::jwt_model::the_claim_file_never_holds_the_token ...
+     … +33 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '400,480p' src/auth_remote_tests.rs)
+  ⎿      assert!(target.base_url.contains("127.0.0.1"), "{}", target.base_u
+     rl);
+     }
+     … +78 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  test codex_doctor_requires_an_openai_owned_catalog_model ... FAILED
+     test doctor_uses_chat_completions_for_opencode_compatible_clients ...
+     ok
+     … +21 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '410,430p' tests/clients_cli_test.rs)
+  ⎿                  "la_sk_doctor",
+                     "--base-url",
+                     &base_url,
+     … +19 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  ─── done ───
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cat >> src/clients_tests.rs <<'RS'…)
+  ⎿  test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 905 filte
+     red out; finished in 0.03s
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cp src/clients.rs /tmp/cl2.bak…)
+  ⎿  ─── the #301 tests against the OLD owners ───
+     test clients::tests::every_client_has_a_legacy_name ... ok
+     test clients::credentials::tests::minted_records_are_revocable_and_sup
+     … +16 lines (ctrl+o to expand)
+
+⏺ The negative check exposed a weak test — the single-model catalogue hid the
+  defect. Fixing it.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 905 filte
+     red out; finished in 0.02s
+     … +11 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cargo build -q 2>&1 | grep -E "^error" | head -3…)
+  ⎿  error: methods `select_model` and `advertised_owners` are never used
+        --> src/managed_server.rs:110:19
+         |
+     … +30 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  error: this file contains an unclosed delimiter
+        --> src/managed_server.rs:899:12
+         |
+     … +12 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '96,125p' src/managed_server.rs)
+  ⎿      revocation: Option<Revocation>,
+     }
+     … +29 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  error[E0599]: no method named `select_model` found for struct `managed
+     _server::RunCredential` in the current scope
+       --> src/managed_server_tests.rs:31:24
+     … +28 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '1,60p' src/managed_server_tests.rs)
+  ⎿  //! Tests for [`crate::managed_server`].
+
+     use super::*;
+     … +57 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '58,80p' src/managed_server_tests.rs)
+  ⎿  /// A client with no dialect constraint accepts anything advertised.
+     #[test]
+     fn an_unconstrained_client_accepts_any_model() {
+     … +20 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  error: function `credential` is never used
+       --> src/managed_server_tests.rs:12:4
+        |
+     … +10 lines (ctrl+o to expand)
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  ─── clippy ok ───
+     ─── tests ok ───
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cargo fmt --all && git add -A && git commit -q -m "wip: issues 301-309" &&
+      echo committed…)
+  ⎿  committed
+
+     Please refactor these files to be under 1000 lines
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      rust-script scripts/check-file-size.rs 2>&1 | head -10)
+  ⎿  Checking Rust files for maximum 1000 lines...
+
+     Found files exceeding the line limit:
+     … +4 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "^    fn setup_codex\|^    fn setup_claude\|^    fn
+      remove_codex\|^    fn remove_claude\|^    pub as…)
+  ⎿  29:};
+     68:}
+     107:}
+     … +27 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  Traceback (most recent call last):
+       File "<stdin>", line 19, in <module>
+     AssertionError: ''
+     … +15 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "pub async fn doctor" src/clients.rs; awk 'NR>=716 && NR<=730'
+      src/clients.rs | cat -n; echo "── fin…)
+  ⎿  721:    pub async fn doctor(&self, client: ClientKind) -> Result<Strin
+     g, ClientError> {
+          1             }
+     … +30 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  Error: claude-sonnet-5[1m] is temporarily unavailable (timed out), so auto 
+     mode cannot determine the safety of Bash right now. Wait a moment and then 
+     try this action again. If it keeps failing, continue with other tasks that 
+     don't require this action and come back to it later. Note: reading files, 
+     searching code, and other read-only operations do not require the 
+     classifier and can still be used.
+
+  Read 1 file (ctrl+o to expand)
+
+⏺ Bash(python3 - <<'PY'
+      p='src/clients.rs'…)
+  ⎿  split ok
+          964 src/clients.rs
+          123 src/clients/doctor.rs
+         1087 total
+
+⏺ Bash(cargo build 2>&1 | grep -E "^error" -A8 | head -30; echo "─── done ───")
+  ⎿  ─── done ───
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      rust-script scripts/check-file-size.rs 2>&1 | tail -2…)
+  ⎿  All files are within the line limit
+
+     error: unused import: `std::time::Duration`
+     … +16 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -i '' '/^use std::time::Duration;$/d' src/clients.rs…)
+  ⎿  Error: claude-sonnet-5[1m] is temporarily unavailable (timed out), so auto 
+     mode cannot determine the safety of Bash right now. Wait a moment and then 
+     try this action again. If it keeps failing, continue with other tasks that 
+     don't require this action and come back to it later. Note: reading files, 
+     searching code, and other read-only operations do not require the 
+     classifier and can still be used.
+
+  Searched for 1 pattern (ctrl+o to expand)
+
+⏺ Bash(python3 -c "
+      p='src/clients.rs'…)
+  ⎿  removed
+     clippy-done
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      timeout 500 cargo test 2>&1 | grep -E "FAILED|^failures:|panicked" -A3 |
+      head -20; echo "tests-ok"…)
+  ⎿  tests-ok
+     committed
+
+⏺ Now the with cluster. Starting with the mode-flag bugs from the #297 comment,
+  plus #310.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched integrations
+     build-done
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched client_launch
+     build-done
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  271:                // `GEMINI_CLI_TRUST_WORKSPACE` is deliberately no
+     t set here.
+     382:                .env("GEMINI_CLI_TRUST_WORKSPACE", "true");
+     544:                .get("GEMINI_CLI_TRUST_WORKSPACE")
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '370,392p' src/with_command.rs; echo "── prepare signature ──";
+      grep -n "fn prepare(" -A 12 src/with_…)
+  ⎿              // The router pointed `GEMINI_CLI_HOME` at the `.gemini` d
+     irectory
+                 // itself, so the CLI looked in `<root>/.gemini/.gemini/`
+     … +34 lines (ctrl+o to expand)
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+     error[E0061]: this function takes 7 arguments but 6 arguments were sup
+     plied
+     … +14 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '80,115p' src/with_command.rs)
+  ⎿          }
+         };
+         if let Some(model) = selected.as_deref()
+     … +33 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  build-done
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cargo test --lib 2>&1 | grep -E "^error|FAILED|test result" -A6 | head
+      -30)
+  ⎿  error[E0061]: this function takes 5 arguments but 4 arguments were sup
+     plied
+        --> src/with_command.rs:533:9
+     … +27 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  test result: ok. 919 passed; 0 failed; 0 ignored; 0 measured; 0 filter
+     ed out; finished in 5.57s
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cat >> src/client_launch_tests.rs <<'RS'…)
+  ⎿  test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 907 filte
+     red out; finished in 0.00s
+
+⏺ Now #311 (persisted token by origin), #316 (label privacy), #313 (sweep
+  safety).
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+     226-    let token = server.token.as_deref().ok_or_else(|| {
+     227-        if server.source == "managed local container" {
+     … +17 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  build-done
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+     build-done
+
+⏺ Now #313 — the stale-directory sweep deleting other users' live runs.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "fn sweep_stale_directories" -A 50 src/with_command.rs | head -60)
+  ⎿  454:fn sweep_stale_directories() {
+     455-    const PREFIX: &str = "link-assistant-router-with-";
+     456-    let Ok(entries) = fs::read_dir(std::env::temp_dir()) else {
+     … +48 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+     ok
+
+⏺ I invented two APIs there. Fixing with real ones.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+     build-done
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      timeout 500 cargo test 2>&1 | grep -E "FAILED|^failures:|panicked" -A4 |
+      head -30; echo "tests-done")
+  ⎿  tests-done
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cat >> src/with_command.rs <<'RS'…)
+  ⎿  error[E0063]: missing field `label` in initializer of `with::WithArgs`
+      --> src/client_launch_tests.rs:6:5
+       |
+     … +6 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 -c "…)
+  ⎿  test with_command::sweep_tests::the_sweep_only_removes_this_users_dire
+     ctories ... FAILED
+     … +21 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      ps -p 0 2>&1 | head -3; echo "exit=$?"; kill -0 0 2>&1; echo "kill0=$?")
+  ⎿    PID TTY           TIME CMD
+     exit=0
+     kill0=0
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 -c "…)
+  ⎿  test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 923 filter
+     ed out; finished in 0.04s
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cp src/with_command.rs /tmp/wc2.bak…)
+  ⎿  ─── the #313 test against the OLD liveness check ───
+     test with_command::sweep_tests::a_live_process_is_never_reported_dead
+     ... FAILED
+     … +4 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cargo build -q 2>&1 | grep error | head -3…)
+  ⎿  error: use Option::map_or_else instead of an if let/else
+        --> src/managed_server.rs:241:24
+         |
+     … +21 lines (ctrl+o to expand)
+
+❯ Не останавливайся пока не завершишь выполнение всех задач отсюда -            
+  https://github.com/link-assistant/router/issues (смотрии комментарии тоже).   
+  Continue in English.                                                          
+
+⏺ Understood — continuing until all issues are covered. Fixing lints, then on to
+  the rest.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  clippy-done
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      timeout 500 cargo test 2>&1 | grep -E "FAILED|^failures:|panicked" -A4 |
+      head -20; echo "tests-done"…)
+  ⎿  tests-done
+     committed
+
+❯ If any CI/CD errors after release - as always fix using next pull request.    
+  Before merging pull request do self review and double check that all          
+  requirements from all open issues are addressed.                              
+
+⏺ Now #299 — the argv split. Checking whether I can derive the option table from
+  the parser itself.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -rn "LinoParser\|lino_arguments" src/cli.rs | head -5…)
+  ⎿  src/cli.rs:5://! parsed by [`lino_arguments::Parser`] (which is a clap
+     -compatible drop-in
+     src/cli.rs:28:use lino_arguments::Parser as LinoParser;
+     … +4 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '1,40p' src/cli_tests.rs)
+  ⎿  use super::*;
+     use crate::config::{
+         default_gonka_model, default_gonka_source_url, default_openai_comp
+     … +37 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      ls src/bin/ 2>/dev/null; grep -rn "with-router" Cargo.toml | head; find
+      src -name "*with_router*" -o -name "…)
+  ⎿  with-router.rs
+     Cargo.toml:32:name = "with-router"
+     Cargo.toml:33:path = "src/bin/with-router.rs"
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cat src/bin/with-router.rs)
+  ⎿  //! Standalone entry point for the temporary router client wrapper.
+
+     use std::process::ExitCode;
+     … +26 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  rewritten
+     build-done
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      timeout 300 cargo test --lib 2>&1 | grep -E "FAILED|test result|panicked"
+      -A3 | head -30)
+  ⎿  test cli::with::collision_tests::a_repeated_boolean_option_is_forwarde
+     d ... FAILED
+     test cli::with::collision_tests::a_repeated_router_option_is_forwarded
+     … +27 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  tests rewritten
+     error[E0599]: no method named `as_configure` found for reference `&wit
+     h::WithArgs` in the current scope
+     … +10 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  test cli::with::tests::the_option_table_is_read_from_the_parser ... FA
+     ILED
+     test cli::with::tests::an_option_value_that_names_a_client_is_not_the_
+     … +23 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cat > /tmp/probe.rs <<'RS'…)
+  ⎿  probe skipped — inspect via a quick unit assertion instead
+     test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 917 filter
+     ed out; finished in 0.01s
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      timeout 500 cargo test 2>&1 | grep -E "FAILED|^failures:|panicked" -A4 |
+      head -30; echo "tests-done")
+  ⎿  tests-done
+
+⏺ Now the help-accuracy issues (#312, #315).
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "override_usage" src/cli.rs src/cli/*.rs | head -20…)  ⎿  src/cli/client_ops.rs:15:    #[command(override_usage = "link-assistan
+     t-router clients setup [OPTIONS] <CLIENT>")]
+     src/cli/client_ops.rs:35:    #[command(override_usage = "link-assistan
+     … +44 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '765,780p' src/cli.rs)
+  ⎿          #[arg(
+                 long,
+                 default_value_t = true,
+     … +14 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  usage lines normalised
+     src/cli/client_ops.rs:15:    #[command(override_usage = "router client
+     s setup [OPTIONS] <CLIENT>")]
+     … +18 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      git diff --stat src/cli.rs src/cli/client_ops.rs src/cli/auth_ops.rs; git
+      diff src/cli/auth_ops.rs | grep "^…)
+  ⎿   src/cli.rs            | 16 ++++++++--------
+      src/cli/auth_ops.rs   |  2 +-
+      src/cli/client_ops.rs |  8 ++++----
+      3 files changed, 13 insertions(+), 13 deletions(-)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      git diff src/cli.rs | grep "^[-+]" | grep -v "^[-+][-+]" | grep -v
+      override_usage | head -10; echo "── clean…)
+  ⎿  ── clean ──
+     dropped
+     src/cli/client_ops.rs:0
+     … +6 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cargo run -q --bin router -- tokens rotate --help 2>&1 | head -6; echo
+      "════"; cargo run -q --bin router --…)
+  ⎿  Replace a token, preserving its controls, and revoke the old token
+
+     Usage: router tokens rotate [OPTIONS] <ID>
+     … +11 lines (ctrl+o to expand)
+
+⏺ Now documenting providers add's flags (#315.4), adding --api-key-stdin (#314),
+  and --local for with.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched providers add
+     build-done
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "ProviderOp::Add" -A 30 src/providers_cli.rs | head -40)
+  ⎿  84:        ProviderOp::Add {
+     85-            name,
+     86-            kind,
+     … +37 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "ProviderOp::Add" -A 30 src/providers_cli.rs | sed -n '60,110p';
+      echo "── local add ──"; grep -n "fn…)
+  ⎿  217-                .get(key)
+     218-                .and_then(serde_json::Value::as_str)
+     219-                .unwrap_or_default()
+     … +34 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+     error[E0277]: the `?` operator can only be used on `Result`s, not `Opt
+     ion`s, in a function that returns `Result`
+     … +18 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 -c "…)
+  ⎿  build-done
+
+⏺ Now the with --help truths (#312) and --managed/--local consistency (#314,
+  #315).
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "Launch an agentic CLI" src/cli.rs src/cli/with.rs; sed -n
+      '525,545p' src/cli.rs)
+  ⎿  src/cli.rs:535:    /// Launch an agentic CLI with an isolated router c
+     onfiguration.
+         },
+     … +22 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+     error[E0026]: variant `Clients` does not have a field named `home`
+        --> src/main.rs:132:33
+     … +12 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  build-done
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      timeout 500 cargo test 2>&1 | grep -E "FAILED|^failures:|panicked" -A4 |
+      head -30; echo "tests-done")
+  ⎿  tests-done
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "pub async fn target_for" -A 40 src/auth_remote.rs | head -50)
+  ⎿  70:pub async fn target_for(
+     71-    local: bool,
+     72-    managed: bool,
+     … +38 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  tests-done
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+     build-done
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  664-    /// `create` and `add` are accepted too: creating something wa
+     s `tokens
+     665-    /// issue`, `providers add` and `clients setup` — three verbs
+     … +42 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched aliases
+     build-done
+     Revoke a token by id — an alias of `revoke`, kept for scripts.
+     … +4 lines (ctrl+o to expand)
+
+⏺ Now --json on the list commands and the --token/--base-url naming (#314).
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "token: Option<String>" -B 6 src/cli.rs | grep -n
+      "Summary\|Anomalies\|Show\|token" | head -20…)
+  ⎿  7:421:    pub telegram_bot_token: Option<String>,
+     9:423-    /// VK community access token. Unset keeps the VK admin chan
+     nel off.
+     … +54 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+     error[E0533]: expected unit struct, unit variant or constant, found st
+     ruct variant `ClientOp::List`
+     … +39 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  error[E0533]: expected unit struct, unit variant or constant, found st
+     ruct variant `ClientOp::List`
+       --> src/client_command.rs:27:9
+     … +10 lines (ctrl+o to expand)
+
+⏺ Now wiring --json through the four listings.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  425-
+     426-/// Secret-free state returned by `clients list` and `clients show
+     `.
+     … +3 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "TokenOp::List" -A 25 src/main.rs | head -30; echo "════ providers
+      list ════"; grep -n "ProviderOp::…)
+  ⎿  654:        TokenOp::List { .. } => match mgr.list_tokens() {
+     655-            Ok(records) => {
+     656-                // Rendered by the shared printer, so the local an
+     … +64 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+     build-done
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      timeout 500 cargo test 2>&1 | grep -E "FAILED|^failures:|panicked" -A4 |
+      head -30; echo "tests-done"…)
+  ⎿  tests-done
+     error[E0063]: missing field `home` in initializer of `cli::Cli`
+       --> src/cli_tests.rs:75:15
+     … +26 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+     error[E0063]: missing field `home` in initializer of `cli::Cli`
+       --> src/cli_tests.rs:75:15
+     … +29 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '70,80p' src/cli_tests.rs; echo "════"; sed -n '12,22p'
+      src/providers_cli_tests.rs; echo "════"; sed…)
+  ⎿      check(&Cli::command());
+     }
+     … +30 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  error[E0062]: field `home` specified more than once
+        --> src/cli_tests.rs:171:9
+         |
+     … +28 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  error[E0062]: field `json` specified more than once
+       --> src/providers_cli_tests.rs:66:17
+        |
+     … +10 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  clippy-done
+     test remote_command::tests::only_an_explicit_local_target_skips_resolu
+     tion ... FAILED
+     … +24 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '40,70p' src/remote_command_tests.rs; echo "════"; sed -n
+      '345,365p' src/auth_remote_tests.rs)
+  ⎿          );
+         }
+     }
+     … +50 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+     test auth_remote::tests::managed_names_the_managed_container ... FAILE
+     D
+     … +24 lines (ctrl+o to expand)
+
+⏺ --managed still deferred to a persisted selection. Making it mean what it says
+  everywhere.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  build-done
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      timeout 500 cargo test 2>&1 | grep -E "FAILED|^failures:|panicked" -A4 |
+      head -25; echo "tests-done"…)  ⎿  test claude_code_is_rejected_for_the_cli_fallback_without_starting_it
+     ... FAILED
+     test claude_code_without_a_pending_login_does_not_start_a_new_login ..
+     … +24 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '25,80p' tests/auth_cli_test.rs)
+  ⎿              "--code",
+                 "copied-code#previous-state",
+             ])
+     … +53 lines (ctrl+o to expand)
+
+⏺ The tests themselves used --managed as a synonym for --local — exactly what
+  #315 reported. Switching them.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -rn '"--managed"' tests/ src/ | grep -v
+      "_tests.rs:.*may_be_remote\|remote_command_tests\|auth_remote_t…)
+  ⎿  tests/local_discovery_test.rs:265:        .args(["auth", "status", "--
+     managed"])
+     tests/remote_targeting_test.rs:32:        for flag in ["--local", "--m
+     … +10 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '260,275p' tests/local_discovery_test.rs; echo "════ 205-215 ════";
+      sed -n '203,218p' tests/auth_cli_…)
+  ⎿      let router = Router::start();
+         let config = tempfile::tempdir().expect("config home");
+         let home = tempfile::tempdir().expect("home");
+     … +74 lines (ctrl+o to expand)
+
+⏺ That change had too wide a blast radius. Taking the issue's other option —
+  reject --managed where it cannot start a container.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿              run_max_requests,
+                 _lease: Some(lease),
+             });
+     … +17 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+     build-done
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  test missing_argument_usage_does_not_present_configured_globals_as_req
+     uired ... FAILED
+     test both_the_canonical_and_legacy_commands_run ... ok
+     … +24 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '125,165p' tests/cli_contract_test.rs)
+  ⎿              result.status.code(),
+                 Some(1),
+     "{operation} accepted unknown id"
+     … +38 lines (ctrl+o to expand)
+
+⏺ override_usage was load-bearing — it keeps globals out of the usage line.
+  Restoring it with the correct name.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      git stash list >/dev/null; git diff HEAD --stat src/cli.rs | tail -2…)
+  ⎿   src/cli.rs | 116 +++++++++++++++++++++++++++++++++++++++++++++++++---
+     ---------
+      1 file changed, 93 insertions(+), 23 deletions(-)
+     … +3 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  Traceback (most recent call last):
+       File "<stdin>", line 17, in <module>
+       File "<stdin>", line 14, in insert_before
+     … +19 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "Rotate {" -A 4 src/cli.rs | head -8)
+  ⎿  707:    Rotate {
+     708-        /// Subject id (`sub`) of the token being replaced.
+     709-        id: String,
+     … +2 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  cli.rs ok
+     test missing_argument_usage_does_not_present_configured_globals_as_req
+     uired ... FAILED
+     … +16 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "override_usage" src/cli/client_ops.rs; grep -n "Show {" -B 3
+      src/cli/client_ops.rs | head)
+  ⎿  45-        ttl_hours: i64,
+     46-    },
+     47-    /// Show the effective client integration with secrets redacted
+     … +2 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  ok
+     test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered
+      out; finished in 1.37s
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      timeout 500 cargo test 2>&1 | grep -E "FAILED|^failures:|panicked" -A4 |
+      head -25; echo "tests-done"…)
+  ⎿  tests-done
+     clippy-done
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      rust-script scripts/check-file-size.rs 2>&1 | tail -3…)
+  ⎿  Please refactor these files to be under 1000 lines
+
+     committed
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      rust-script scripts/check-file-size.rs 2>&1 | head -8)
+  ⎿  Checking Rust files for maximum 1000 lines...
+
+     Found files exceeding the line limit:
+     … +4 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "^pub enum TokenOp\|^pub enum AccountOp\|^pub enum
+      ProviderOp\|^pub enum LogsOp\|^impl Cli" src/cli.…)  ⎿  599:pub enum LogsOp {
+     670:pub enum TokenOp {
+     779:pub enum AccountOp {
+     … +2 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  split
+          818 src/cli.rs
+          226 src/cli/store_ops.rs
+     … +2 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      rust-script scripts/check-file-size.rs 2>&1 | tail -2…)
+  ⎿  All files are within the line limit
+
+     clippy-done
+     tests-done
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cargo fmt --all && git add -A && git commit -q -m "wip: split cli store
+      ops" && echo committed)
+  ⎿  committed
+
+⏺ Now #298 — a persistent profile for clients that cannot be extended.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '196,250p' src/with_command.rs)
+  ⎿  struct TemporaryClient {
+         directory: tempfile::TempDir,
+         command: Command,
+     … +51 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+             model_override: Option<&str>,
+             models: &[RouterModel],
+     … +31 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  error[E0425]: cannot find type `PathBuf` in this scope
+        --> src/with_command.rs:217:16
+         |
+     … +28 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 -c "…)
+  ⎿  build-done
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      timeout 500 cargo test 2>&1 | grep -E "FAILED|^failures:|panicked" -A5 |
+      head -30; echo "tests-done")
+  ⎿  test with_command::tests::every_supported_client_prepares_below_a_disp
+     osable_root ... FAILED
+     test with_command::tests::the_users_configuration_is_kept_by_default .
+     … +22 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  build-done
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      timeout 300 cargo test --lib with_command 2>&1 | grep -E "FAILED|test
+      result|panicked" -A5 | head -25)
+  ⎿  (No output)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      timeout 300 cargo test --lib with_command 2>&1 | tail -25)
+  ⎿      |
+     919 |         unsafe { std::env::set_var("XDG_CONFIG_HOME", profiles.p
+     ath()) };
+     … +24 lines (ctrl+o to expand)
+
+⏺ unsafe_code is denied, so env mutation is out. Injecting the profile root
+  instead.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  build-done
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      timeout 300 cargo test --lib with_command 2>&1 | grep -E "FAILED|test
+      result|panicked|^error" -A6 | head -30)
+  ⎿  error[E0425]: cannot find value `profiles` in this scope
+        --> src/with_command.rs:734:18
+         |
+     … +23 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 913 filte
+     red out; finished in 0.32s
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      for n in 734 763 812 851; do echo "── near $n ──"; awk -v n=$n 'NR>=n-20
+      && NR<=n {if ($0 ~ /fn [a-z_]+\(\)/…)
+  ⎿  ── near 734 ──
+     721:     fn the_users_configuration_is_kept_by_default() {
+     ── near 763 ──
+     … +4 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      awk 'NR>=790 && NR<=815 {print NR": "$0}' src/with_command.rs | head -30)
+  ⎿  790:         assert!(
+     791:             !extends_user_configuration(ClientKind::Opencode, fal
+     se),
+     … +23 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  6:733-            true,
+     13:761-            true,
+     14:762-            true,
+     … +2 lines (ctrl+o to expand)
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      timeout 500 cargo test 2>&1 | grep -E "FAILED|^failures:|panicked" -A5 |
+      head -25; echo "tests-done"…)
+  ⎿  test standalone_with_router_uses_the_same_safe_contract ... FAILED
+     test admin_credentials_are_exchanged_and_revoked_per_run ... ok
+     test router_with_uses_temporary_config_and_preserves_status ... FAILED
+     … +39 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  Error: Exit code 143
+     Command timed out after 2m 0s
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "TemporaryClient::prepare" -A 12 src/with_command.rs | head -40)
+  ⎿  111:    let temporary = match TemporaryClient::prepare(
+     112-        args.client,
+     113-        &server.base_url,
+     … +37 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "struct Preparation" src/with_command.rs; grep -n "let
+      &Preparation" src/with_command.rs)
+  ⎿  No matches found
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  rewritten
+     build-done
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cargo clippy --all-targets --all-features -- -D warnings 2>&1 | grep -E
+      "^error" -A8 | head -20; echo "clipp…)
+  ⎿  error: redundant field names in struct initialization
+        --> src/with_command.rs:948:25
+         |
+     … +19 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 -c "…)
+  ⎿  clippy-done
+
+⏺ Now splitting with_command.rs tests out and fixing the end-to-end assertions
+  for persistent profiles.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  split
+          681 src/with_command.rs
+          364 src/with_command_tests.rs
+     … +2 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      timeout 300 cargo test --lib with_command 2>&1 | grep -E "FAILED|test
+      result|panicked|^error" -A5 | head -20…)
+  ⎿  test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 913 filte
+     red out; finished in 0.38s
+
+     All files are within the line limit
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "mod sweep_tests\|mod tests" src/with_command.rs
+      src/with_command_tests.rs | head)
+  ⎿  src/with_command.rs:681:mod tests;
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      tail -5 src/with_command_tests.rs; echo "── does the file mention sweep?
+      ──"; grep -c "sweep" src/with_comma…)
+  ⎿  fn registry_order_matches_client_discriminants() {
+         for client in ClientKind::ALL {
+             assert_eq!(client.integration().kind, client);
+     … +4 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cat >> src/with_command.rs <<'RS'…)
+  ⎿  test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 913 filte
+     red out; finished in 0.38s
+
+⏺ Now updating the end-to-end tests that assumed codex's home is thrown away.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '305,320p' tests/with_router_test.rs; echo "════ 380-395 ════"; sed
+      -n '378,395p' tests/with_router_t…)
+  ⎿      assert_eq!(args.lines().last(), Some("hi"));
+         let config = fs::read_to_string(capture.join("config")).expect("ca
+     ptured temp config");
+     … +32 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtere
+     d out; finished in 2.66s
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      timeout 500 cargo test 2>&1 | grep -E "FAILED|^failures:|panicked" -A5 |
+      head -25; echo "tests-done"…)
+  ⎿  tests-done
+     clippy-done
+     committed
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  build-done
+     warning: unused import: `Cli`
+       --> src/main.rs:23:45
+     … +28 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cargo run -q --bin router -- with --help 2>&1 | grep -cE "^
+      --(host|port|storage-policy|upstream-base-u…)
+  ⎿  6
+     ── globals still parse ──
+     warning: unused import: `Cli`
+     … +2 lines (ctrl+o to expand)
+⏺ The globals aren't propagated yet at that point. Hiding them at the root for
+  those invocations instead.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  ── globals in with --help ──
+     0
+     ── globals in tokens list --help ──
+     … +3 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched
+     build-done
+     tests-done
+
+❯ [Image #1] и ещё запиши себе где-нибудь, что во всех местах где мы UI         
+  таймлайна используем нужно поддержать такую же возможность массового выбора   
+  промежутков времени как мы делаем в матрице - используя мышку и тянуть +      
+  сочетания клавиш.                                                             
+  ⎿  [Image #1]
+
+❯ В общем нужно всё полностью доделать, покрыть тестами и т.п. При этом ничего  
+  не поломать в реальном кабинете селлера.                                      
+
+❯ Обязательно в процессе работы коммить, пуш и где-то веди учёт всего плана в   
+  виде markdown в pull request, чтобы не потерялось и обновляй его по мере      
+  готовности, как полностью закончишь - дооформляй pull request и делай полное  
+  ревью себя сам на согласованность всего кода.                                 
+
+⏺ Three things arrived at once. Let me record the timeline-UI note, then push
+  and open the PR with a live plan.
+
+  Wrote 1 memory (ctrl+o to expand)
+
+❯ Так же обо всех проблемах которые не смог решить сам в самом конце пиши в     
+  какой-нибудь документ, но посторайся как можно дольше работать                
+  самостоятельно.                                                               
+
+❯ /model 
+  ⎿  Kept model as Opus 5 (1M context)
+
+⏺ Bash(cd /Users/konard/.claude/projects/-Users-konard-Code-Archive-link-assista
+      nt-router/memory
+      printf -- '- [Timeline UI needs matrix-style range selection](timeline…)
+  ⎿  - [GitHub credential is boot-time only](github-credential-is-boot-time
+     -only.md) — three things block changing it at runtime; "remote auth gh
+     " is a router-state change, not a CLI one.
+     … +6 lines (ctrl+o to expand)
+  ⎿  Shell cwd was reset to 
+     /Users/konard/Code/Archive/link-assistant/router
+
+⏺ Noted. Now pushing and opening the PR with a live plan document.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cargo fmt --all && git add -A && git commit -q -m "wip: issue 312 help
+      accuracy" && git push -q -u origin fi…)
+  ⎿  Interrupted · What should Claude do instead?
+
+❯ Sorry, it was related to another repository. Keep working on router here,     
+  ignore my prompts about adv compaing schedule.                                
+
+⏺ Understood — ignoring the schedule/seller-cabinet prompts. Removing that
+  misplaced memory since it belongs to another repo.
+
+⏺ Bash(cd /Users/konard/.claude/projects/-Users-konard-Code-Archive-link-assista
+      nt-router/memory
+      rm -f timeline-ui-needs-matrix-style-range-selection.md…)
+  ⎿  - [GitHub credential is boot-time only](github-credential-is-boot-time
+     -only.md) — three things block changing it at runtime; "remote auth gh
+     " is a router-state change, not a CLI one.
+     … +3 lines (ctrl+o to expand)
+  ⎿  Shell cwd was reset to 
+     /Users/konard/Code/Archive/link-assistant/router
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      timeout 500 cargo test 2>&1 | grep -E "FAILED|^failures:|panicked" -A5 |
+      head -20; echo "tests-ok"…)
+  ⎿  test auth_targets_the_discovered_router ... FAILED
+
+     failures:
+     … +19 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      for i in 1 2; do timeout 200 cargo test --test local_discovery_test
+      auth_targets_the_discovered_router 2>&1…)
+  ⎿  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 4 filtered
+      out; finished in 0.76s
+     test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 4 filtered
+      out; finished in 0.87s
+
+⏺ Flake under full-suite load; passes in isolation. Pushing and opening the PR
+  with a live plan.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      git push -q -u origin fix/issue-295-297-with-and-configure 2>&1 | tail -3;
+      echo "pushed"; git log --oneline…)
+  ⎿  remote: Create a pull request for 'fix/issue-295-297-with-and-configur
+     e' on GitHub by visiting:
+     remote:      https://github.com/link-assistant/router/pull/new/fix/iss
+     … +4 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cat > /tmp/pr_body.md <<'MD'…)
+  ⎿  https://github.com/link-assistant/router/pull/317
+
+⏺ PR #317 is open with the plan. Now finishing the remaining items — docs, then
+  self-review.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      grep -n "Issue / list / revoke / show tokens locally\|doctor" README.md |
+      sed -n '1,12p'…)
+  ⎿  40:- **First-class CLI** — `serve`, token/provider/account management,
+      `clients list|setup|show|remove|doctor`, and deployment diagnostics
+     97:OpenAI-compatible). Run `router doctor` to verify each credential f
+     … +27 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)  ⎿  patched
+     the name used before v0.92.0, so existing scripts and deployment units
+      keep
+     … +43 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  patched README
+     210:export TOKEN_SECRET=your-secure-secret-here
+     312:export TOKEN_SECRET=your-secure-secret
+     … +8 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      sed -n '655,660p' README.md)
+  ⎿  | Flag / env | Default | Required | Description |
+     |---|---|---|---|
+     | `--token-secret` / `TOKEN_SECRET` | — | Yes | Secret key for signing
+     … +5 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      python3 - <<'PY'…)
+  ⎿  written
+           39 changelog.d/20260826_090000_one_rule_each.md
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      timeout 500 cargo test 2>&1 | grep -E "FAILED|^failures:|panicked" -A4 |
+      head -20; echo "tests-ok"…)
+  ⎿  test storage::tests::dual_store_recovers_a_synced_transaction_journal
+     ... FAILED
+     test with_command::tests::a_client_needing_a_written_file_is_isolated_
+     … +19 lines (ctrl+o to expand)
+
+⏺ Disk filled up — that's environmental. Cleaning up.
+
+⏺ Bash(df -h / /tmp 2>/dev/null | head -5; echo "── target size ──"; du -sh
+      /Users/konard/Code/Archive/link-assistant/router/target 2>/dev/null; echo
+      "── tmp leftovers…)
+  ⎿  Filesystem        Size    Used   Avail Capacity iused ifree %iused  Mo
+     unted on
+     /dev/disk3s1s1   460Gi    10Gi   1.3Gi    89%    427k   14M    3%   /
+     … +6 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      ls scripts/sweep-build-artifacts.sh >/dev/null && cat
+      scripts/sweep-build-artifacts.sh | head -20)
+  ⎿  #!/usr/bin/env bash
+     # Prune build artifacts the most recent build did not touch, then re-s
+     tamp.
+     … +23 lines (ctrl+o to expand)
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      rm -rf ${TMPDIR}link-assistant-router-with-* 2>/dev/null…)
+  ⎿  /dev/disk3s5   460Gi   431Gi   2.5Gi   100%    8.3M   26M   24%   /Sys
+     tem/Volumes/Data
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      du -sh target 2>/dev/null; timeout 500 cargo test 2>&1 | grep -E
+      "FAILED|^failures:|panicked" -A4 | head -20…)
+  ⎿  873M       target
+     tests-done
+
+⏺ All green. Now the coverage ratchet and the self-review.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cat coverage-baseline.txt; command -v cargo-llvm-cov >/dev/null && echo
+      "llvm-cov present" || echo "llvm-cov…)
+  ⎿  81.802083
+     llvm-cov present
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      timeout 1500 cargo llvm-cov --summary-only --json --output-path
+      /tmp/cov317.json 2>&1 | tail -3…)
+  ⎿  Error: Exit code 1
+     error: process didn't exit successfully: 
+     `/Users/konard/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc 
+     --crate-name regex_syntax --edition=2021 /Users/konard/.cargo/registry/src/
+     index.crates.io-1949cf8c6b5b557f/regex-syntax-0.8.11/src/lib.rs 
+     --error-format=json 
+     --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib 
+     --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=1 -C 
+     split-debuginfo=unpacked --allow=unexpected_cfgs --check-cfg 
+     'cfg(docsrs_regex)' --cfg 'feature="default"' --cfg 'feature="std"' --cfg 
+     'feature="unicode"' --cfg 'feature="unicode-age"' --cfg 
+     'feature="unicode-bool"' --cfg 'feature="unicode-case"' --cfg 
+     'feature="unicode-gencat"' --cfg 'feature="unicode-perl"' --cfg 
+     'feature="unicode-script"' --cfg 'feature="unicode-segment"' --check-cfg 
+     'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("arbitrary", "default",
+     "std", "unicode", "unicode-age", "unicode-bool", "unicode-case", 
+     "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"))' -C
+     metadata=5e6447efd482faca -C extra-filename=-fa3981674ac05643 --out-dir 
+     /Users/konard/Code/Archive/link-assistant/router/target/llvm-cov-target/deb
+     ug/deps -L dependency=/Users/konard/Code/Archive/link-assistant/router/targ
+     et/llvm-cov-target/debug/deps --cap-lints allow` (exit status: 1)
+     error: could not compile `regex-syntax` (lib) due to 1 previous error
+     error: process didn't exit successfully: 
+     `/Users/konard/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo 
+     test --tests --manifest-path 
+     /Users/konard/Code/Archive/link-assistant/router/Cargo.toml --target-dir 
+     /Users/konard/Code/Archive/link-assistant/router/target/llvm-cov-target` 
+     (exit status: 101)
+     Traceback (most recent call last):
+       File "<stdin>", line 2, in <module>
+     FileNotFoundError: [Errno 2] No such file or directory: '/tmp/cov317.json'
+
+⏺ Bash(df -h /System/Volumes/Data | tail -1; du -sh
+      /Users/konard/Code/Archive/link-assistant/router/target 2>/dev/null)
+  ⎿  /dev/disk3s5   460Gi   433Gi   176Mi   100%    8.3M  1.8M   82%   /Sys
+     tem/Volumes/Data
+     2.2G       /Users/konard/Code/Archive/link-assistant/router/target
+
+⏺ Coverage needs a second instrumented target dir and the disk is genuinely full
+  (433 GB used by other things). Cleaning up and letting CI measure it.
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      rm -rf target/llvm-cov-target target/llvm-cov 2>/dev/null; df -h
+      /System/Volumes/Data | tail -1; du -sh targ…)
+  ⎿  /dev/disk3s5   460Gi   433Gi   307Mi   100%    8.3M  3.1M   73%   /Sys
+     tem/Volumes/Data
+     2.0G       target
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      cargo clean 2>&1 | tail -1; df -h /System/Volumes/Data | tail -1)
+  ⎿       Removed 7448 files, 2.0GiB total
+     /dev/disk3s5   460Gi   429Gi   4.2Gi   100%    8.2M   44M   16%   /Sys
+     tem/Volumes/Data
+
+⏺ Bash(cd /Users/konard/Code/Archive/link-assistant/router
+      timeout 1500 cargo llvm-cov --summary-only --json --output-path
+      /tmp/cov317.json 2>&1 | grep -E "^error|test…)
+  ⎿  test result: FAILED. 918 passed; 7 failed; 0 ignored; 0 measured; 0 fi
+     ltered out; finished in 5.54s
+     error: test failed, to rerun pass `--lib`
+     … +6 lines (ctrl+o to expand)
+
+⏺ Your organization has disabled Claude subscription access for Claude 
+  Code · Use an Anthropic API key instead, or ask your admin to enable 
+  access
+
+✻ Brewed for 10m 42s
+
+❯ continue                                                                      
+
+⏺ There's an issue with the selected model (claude-opus-5[1m]). It may 
+  not exist or you may not have access to it. Run /model to pick a 
+  different model.
+
+✻ Worked for 4s

--- a/changelog.d/20260826_093000_release_body_limit.md
+++ b/changelog.d/20260826_093000_release_body_limit.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Fixed
+- A release whose changelog entry exceeds GitHub's undocumented 125,000-character body limit is now published, truncated, with a line saying so and linking the complete entry in `CHANGELOG.md`. The API rejects an oversized body with a bare HTTP 422 and no explanation, so v0.116.0 — built, tested, tagged and pushed — ended with no release page and a failing pipeline. The previous release came in at 122,652 characters, which is why this surfaced only now.

--- a/scripts/create-github-release.rs
+++ b/scripts/create-github-release.rs
@@ -31,6 +31,49 @@ fn get_arg(name: &str) -> Option<String> {
     env::var(&env_name).ok().filter(|s| !s.is_empty())
 }
 
+/// The largest release body the GitHub API accepts.
+///
+/// Undocumented in the REST reference and enforced as a plain HTTP 422 with no
+/// explanatory message, which is how a release for a large changelog failed
+/// with nothing on the line to say why.
+const MAX_RELEASE_BODY: usize = 125_000;
+
+/// Keep a release body inside what the API will accept, saying what was cut.
+///
+/// A truncated body that names the full changelog is a release page; a 422 is
+/// no release page at all. The marker matters as much as the cut: without it a
+/// reader cannot tell a short changelog from a shortened one.
+fn fit_release_body(body: String, tag: &str, repository: &str) -> String {
+    if body.len() <= MAX_RELEASE_BODY {
+        return body;
+    }
+    let notice = format!(
+        "\n\n---\n\n*This release note was truncated to fit GitHub's {MAX_RELEASE_BODY}-character \
+         limit. The complete entry is in [CHANGELOG.md](https://github.com/{repository}/blob/{tag}/CHANGELOG.md).*\n"
+    );
+    // Cut on a line boundary so the body never ends mid-sentence, and never
+    // inside a multi-byte character.
+    let budget = MAX_RELEASE_BODY.saturating_sub(notice.len());
+    let mut end = 0;
+    for (index, byte) in body.bytes().enumerate() {
+        if index >= budget {
+            break;
+        }
+        if byte == b'\n' {
+            end = index + 1;
+        }
+    }
+    if end == 0 {
+        end = body
+            .char_indices()
+            .map(|(index, _)| index)
+            .take_while(|index| *index <= budget)
+            .last()
+            .unwrap_or(0);
+    }
+    format!("{}{}", &body[..end], notice)
+}
+
 fn get_changelog_for_version(version: &str) -> String {
     let changelog_path = "CHANGELOG.md";
 
@@ -159,7 +202,7 @@ fn main() {
     let payload = ReleasePayload {
         tag_name: tag.clone(),
         name: format!("{}{}", tag_prefix, version),
-        body: release_notes,
+        body: fit_release_body(release_notes, &tag, &repository),
     };
 
     let payload_json = serde_json::to_string(&payload).expect("Failed to serialize payload");
@@ -199,5 +242,61 @@ fn main() {
             eprintln!("Error creating release: {}", stderr);
             exit(1);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A body inside the limit is published exactly as written.
+    #[test]
+    fn an_ordinary_release_note_is_left_alone() {
+        let body = "## [1.2.3]\n\n- one fix\n".to_string();
+        assert_eq!(
+            fit_release_body(body.clone(), "v1.2.3", "owner/repo"),
+            body
+        );
+    }
+
+    /// A changelog larger than the limit produced an HTTP 422 with no message,
+    /// so a release that was built, tested and tagged had no release page.
+    /// Truncating publishes it and says where the rest is.
+    #[test]
+    fn an_oversized_release_note_is_published_truncated_and_says_so() {
+        let body = "- a changelog entry that repeats\n".repeat(8_000);
+        assert!(body.len() > MAX_RELEASE_BODY, "the fixture must overflow");
+
+        let fitted = fit_release_body(body, "v0.116.0", "owner/repo");
+
+        assert!(
+            fitted.len() <= MAX_RELEASE_BODY,
+            "the API rejects anything larger: {} bytes",
+            fitted.len()
+        );
+        assert!(
+            fitted.contains("truncated"),
+            "a shortened body must not read as a complete one"
+        );
+        assert!(
+            fitted.contains("owner/repo/blob/v0.116.0/CHANGELOG.md"),
+            "and must name where the rest is: {}",
+            &fitted[fitted.len() - 300..]
+        );
+        // Cut on a line boundary, so the body never ends mid-entry.
+        let kept = fitted.split("\n\n---\n\n").next().expect("body");
+        assert!(kept.ends_with('\n'), "the cut lands between entries");
+    }
+
+    /// The cut must never land inside a multi-byte character, which would
+    /// panic on the slice and lose the release entirely.
+    #[test]
+    fn a_body_of_multibyte_characters_is_cut_safely() {
+        // No newlines at all, so the line-boundary search finds nothing and
+        // the character-boundary fallback has to carry it.
+        let body = "é".repeat(MAX_RELEASE_BODY);
+        let fitted = fit_release_body(body, "v1.0.0", "owner/repo");
+        assert!(fitted.len() <= MAX_RELEASE_BODY);
+        assert!(fitted.contains("truncated"));
     }
 }


### PR DESCRIPTION
The v0.116.0 pipeline built, tested, tagged and pushed — and then produced no
release page. `gh api repos/.../releases` answered a bare **HTTP 422** with no
message, and the step failed with `Error creating release:` and nothing after
the colon.

## Cause

GitHub caps a release body at **125,000 characters**. The limit is undocumented
in the REST reference and enforced as an unexplained 422.

| release | body |
|---|---|
| v0.115.0 | 122,652 characters — under, by 2,348 |
| v0.116.0 | 139,121 characters — over, by 14,121 |

The limit has always been there. #317 closed twenty-nine issues in one release,
whose changelog entry was the first to cross it.

## Fix

`fit_release_body` publishes the release truncated rather than not at all:

- cut on a **line boundary**, so the body never ends mid-entry, with a
  character-boundary fallback so a multi-byte character can never be split
  (slicing one panics and loses the release entirely);
- a notice saying the note was truncated and linking the complete entry in
  `CHANGELOG.md` at that tag — a shortened release note must not read as a
  complete one, which is the same rule #322 applied to the request log;
- unchanged for every body that already fits.

`scripts/create-github-release.rs` had no tests and was not in CI's release
automation test list, which is how a limit this deterministic shipped untested.
Both are fixed: three tests, and the script now runs beside the other seven.

## Verified

The real v0.116.0 section measures 139,121 bytes and is the exact input that
failed; it now fits with the notice attached. All eight release scripts pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
