### PR TITLE
fix(ci): a backfilled release must not become 'Latest', and the audit must follow versions

### DIFF
--- a/.github/workflows/verify-releases.yml
+++ b/.github/workflows/verify-releases.yml
@@ -68,12 +68,25 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
 
+      # By highest version, not by whichever release was published most
+      # recently. A release page created late for an older version carries the
+      # newest publication timestamp, so `gh release view` with no tag answered
+      # for that one — and it legitimately has no assets, because the artifact
+      # jobs ran for the version being released at the time. Asking for the
+      # newest *version* is what this job's name has always meant.
       - name: Resolve the latest published release
         id: latest
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          version="$(gh release view --repo "${{ github.repository }}" --json tagName --jq '.tagName' | sed 's/^v//')"
+          version="$(gh release list --repo "${{ github.repository }}" --limit 1000 \
+            --json tagName --jq '.[].tagName' \
+            | sed 's/^v//' | sort -V | tail -1)"
+          if [ -z "$version" ]; then
+            echo "::error::no published releases found"
+            exit 1
+          fi
+          echo "resolved v$version" >> "$GITHUB_STEP_SUMMARY"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Download the published release assets

--- a/changelog.d/20260826_104500_backfill_latest_marker.md
+++ b/changelog.d/20260826_104500_backfill_latest_marker.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+### Fixed
+- A backfilled release page no longer takes the "Latest" marker from the version that actually is latest. GitHub derives that marker from publication time, so a page created late for an older version becomes "Latest" and every tool asking for the newest release gets the wrong one — v0.116.0, backfilled after v0.118.0 had shipped, did exactly that. Backfills now send `make_latest: false`; a release published on time still leaves the marker to GitHub.
+- The release-provenance audit resolves the newest *version* rather than the most recently published release. A backfilled page legitimately carries no binary assets, because the artifact jobs ran for whichever version was being released at the time, so auditing it reported a failure that described nothing wrong with the release it was really about.

--- a/scripts/create-github-release.rs
+++ b/scripts/create-github-release.rs
@@ -156,6 +156,15 @@ struct ReleasePayload {
     tag_name: String,
     name: String,
     body: String,
+    /// Whether this release becomes the one GitHub marks "Latest".
+    ///
+    /// GitHub derives that marker from publication time, so a release page
+    /// created late for an *older* version takes it from the newest one — and
+    /// every tool that asks for "the latest release" then gets the wrong
+    /// version. A backfill sends `"false"`; a current release omits the field
+    /// and keeps GitHub's default.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    make_latest: Option<String>,
 }
 
 
@@ -231,6 +240,7 @@ fn publish_release(
     tag_prefix: &str,
     crates_io_url: Option<&str>,
     docker_hub_url: Option<&str>,
+    backfill: bool,
 ) -> Result<(), String> {
     let tag = format!("{}{}", tag_prefix, version);
     println!("Creating GitHub release for {}...", tag);
@@ -254,6 +264,7 @@ fn publish_release(
         tag_name: tag.clone(),
         name: format!("{}{}", tag_prefix, version),
         body: fit_release_body(release_notes, &tag, repository),
+        make_latest: backfill.then(|| "false".to_string()),
     };
 
     let payload_json = serde_json::to_string(&payload).expect("Failed to serialize payload");
@@ -324,6 +335,7 @@ fn main() {
         &tag_prefix,
         crates_io_url.as_deref(),
         docker_hub_url.as_deref(),
+        false,
     ) {
         eprintln!("{error}");
         exit(1);
@@ -350,6 +362,7 @@ fn main() {
                 &tag_prefix,
                 crates_io_url.as_deref(),
                 docker_hub_url.as_deref(),
+                true,
             )
             .map_err(|error| eprintln!("{error}"))
             .is_err()
@@ -463,5 +476,41 @@ mod tests {
         let releases = "v0.116.0\n";
 
         assert!(missing_release_versions(tags, releases, "v").is_empty());
+    }
+
+    /// A backfilled release must never take the "Latest" marker. GitHub
+    /// derives it from publication time, so a page created late for an older
+    /// version becomes "Latest" and every tool asking for the newest release
+    /// gets the wrong one — which is exactly what v0.116.0 did to v0.118.0.
+    #[test]
+    fn a_backfilled_release_never_becomes_latest() {
+        let backfill = ReleasePayload {
+            tag_name: "v0.116.0".into(),
+            name: "v0.116.0".into(),
+            body: "notes".into(),
+            make_latest: true.then(|| "false".to_string()),
+        };
+        let json = serde_json::to_string(&backfill).expect("serialize");
+        assert!(
+            json.contains("\"make_latest\":\"false\""),
+            "a backfill must say so explicitly: {json}"
+        );
+    }
+
+    /// A release published on time keeps GitHub's own default, so the field is
+    /// omitted rather than guessed at.
+    #[test]
+    fn a_current_release_leaves_the_marker_to_github() {
+        let current = ReleasePayload {
+            tag_name: "v0.118.0".into(),
+            name: "v0.118.0".into(),
+            body: "notes".into(),
+            make_latest: false.then(|| "false".to_string()),
+        };
+        let json = serde_json::to_string(&current).expect("serialize");
+        assert!(
+            !json.contains("make_latest"),
+            "the field must be absent, not false: {json}"
+        );
     }
 }


### PR DESCRIPTION
The nightly release audit fails. Both causes are consequences of the backfill
added in #326, and neither is a problem with any release's actual contents.

```
✅ Every Tag Has a GitHub Release
❌ Latest Release Matches Its Tag Commit   → "no assets to download" for v0.116.0
```

## What happened

| release | created | published | assets |
|---|---|---|---|
| v0.118.0 | 10:14:03 | 10:19:21 | 12 |
| v0.117.0 | 09:28:12 | 09:35:03 | 12 |
| **v0.116.0** | 08:55:47 | **10:19:23** | **0** |

Backfilling v0.116.0 gave it the newest `published_at`, and GitHub derives the
**"Latest"** marker from exactly that. So the oldest of the three became
`releases/latest`, and `gh release view` with no tag — which the audit uses —
answered for a release that has no binary assets, because the artifact jobs had
run for whichever version was being released at the time.

Two distinct defects, one visible symptom.

## Fix

**1. A backfill must not claim the marker.** `ReleasePayload` gains
`make_latest`, sent as `"false"` for a backfill and omitted entirely for a
release published on time, so GitHub's own default still applies to the normal
path.

**2. The audit follows versions, not timestamps.** "Latest Release Matches Its
Tag Commit" now resolves the highest version via `sort -V`, which is what the
job's name has always meant. This is belt-and-braces: fix 1 alone keeps the
marker correct going forward, but a marker is repo state that anyone can change
by hand, and the audit should not depend on it.

## Note on v0.116.0's assets

It keeps zero assets, and that is correct — the binaries for that commit were
never built, because the original run died before reaching the artifact jobs.
The release page exists so the tag is not orphaned and the changelog is
reachable; v0.117.0 and v0.118.0 supersede it and both carry full assets.

## Verified

The new resolution returns `0.118.0` against the live repository. Nine tests on
the release script, including both marker cases; all eight release automation
scripts pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
