### PR TITLE
test: stop a login test failing on a loaded machine

### DIFF
--- a/changelog.d/20260827_093000_login_test_settle.md
+++ b/changelog.d/20260827_093000_login_test_settle.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Fixed
+- A login test no longer fails on a busy machine. `a_rejected_code_fails_the_session_without_writing_a_credential` set `idle_settle` to 50 ms — fifteen times tighter than the 750 ms the router actually ships — so under parallel load the PTY settled before the fake CLI had printed its rejection and the test reported a failed rejection path that works. Reproduced at roughly one run in six under contention, and not at all when run alone, which is the shape of failure that gets dismissed as noise and trains everyone to re-run a red build. The settle is now 250 ms, still far inside the 3-second `code_timeout` the test's timing assertion is actually about.

--- a/tests/login_flow_test.rs
+++ b/tests/login_flow_test.rs
@@ -329,7 +329,13 @@ async fn a_rejected_code_fails_the_session_without_writing_a_credential() {
         command: fake_cli(),
         args: vec![],
         claude_code_home: home.clone(),
-        idle_settle: Duration::from_millis(50),
+        // Comfortably under `code_timeout`, which is what the elapsed-time
+        // assertion below is about, but not so tight that a loaded machine
+        // settles the PTY before the CLI has printed its rejection. At 50 ms
+        // this test failed roughly one run in six under parallel load, which
+        // reads as a real regression in rejection handling rather than as the
+        // scheduling artefact it is.
+        idle_settle: Duration::from_millis(250),
         url_timeout: HANDSHAKE_TIMEOUT,
         code_timeout: timeout,
         ..LoginConfig::default()


### PR DESCRIPTION
Found while running the full suite for #348. Unrelated to that change, so it lands separately.

## The defect

`a_rejected_code_fails_the_session_without_writing_a_credential` sets `idle_settle` to **50 ms**. The router ships **750 ms** — fifteen times looser. Under parallel load the PTY settles before the fake CLI has printed its rejection, so `submit_code` returns before the verdict arrives and the status is not `Failed`.

The test then reports a broken rejection path that is in fact working.

## Evidence

Measured, not estimated. Six runs with another suite contending for CPU:

| | Before (`50 ms`) | After (`250 ms`) |
|---|---|---|
| Runs failed | **1 / 6** | **0 / 6** |
| Run alone | always passes | always passes |

I confirmed on **clean `main` with all my other changes stashed** that it fails there too, so this is pre-existing rather than something #348 introduced.

## Why this shape of failure is worth fixing

A test that fails one run in six and passes when you re-run it is worse than one that fails every time. It gets dismissed as noise, and it teaches everyone to re-run a red build rather than read it — so the next real regression in this area gets the same shrug.

## The fix

`idle_settle` 50 ms → 250 ms.

The test's timing assertion is `started.elapsed() < timeout` where `timeout` is `code_timeout: 3s`. It exists to prove a *recognized* rejection returns without waiting out the timeout. 250 ms is still an order of magnitude inside that, so the assertion keeps its meaning; it just stops requiring the fake CLI to produce output within 50 ms on a loaded machine.

No production code changes — this is a test-only timing correction.

## Checks

- `cargo test --test login_flow_test` — 14 passed, 6/6 runs under the contention that previously failed
- `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)