### PR TITLE
test: say why the router did not start on the unix socket (#365)

### DIFF
--- a/changelog.d/20260829_120000_socket_test_diagnostics.md
+++ b/changelog.d/20260829_120000_socket_test_diagnostics.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Fixed
+- A unix-socket test that cannot start the router now says why. `Router::start` spawned the process with `stderr` discarded, so when startup failed the only evidence was `router never answered on <path>` — the router's own explanation was thrown away. It failed once on macOS in CI with nothing to diagnose it by. The child's stderr is now captured and included in the panic, and the helper checks whether the process has already exited instead of waiting out the full 40-second deadline, so a startup failure is reported in about a second with the reason attached.

--- a/tests/unix_socket_test.rs
+++ b/tests/unix_socket_test.rs
@@ -29,6 +29,7 @@ struct Router {
     socket: std::path::PathBuf,
     _directory: tempfile::TempDir,
     data: tempfile::TempDir,
+    log: std::path::PathBuf,
 }
 
 impl Drop for Router {
@@ -43,6 +44,12 @@ impl Router {
         let directory = tempfile::tempdir().expect("socket directory");
         let data = tempfile::tempdir().expect("data dir");
         let socket = directory.path().join("router.sock");
+        // The router reports why it could not start on stderr, so it is kept
+        // rather than discarded: a startup failure here used to surface only
+        // as "never answered", with the reason thrown away, which left a CI
+        // failure with nothing to diagnose it by (issue #365).
+        let log = directory.path().join("router.log");
+        let stderr = std::fs::File::create(&log).expect("create the router log");
         let child = Command::new(env!("CARGO_BIN_EXE_link-assistant-router"))
             .arg("serve")
             .env("TOKEN_SECRET", "unix-socket-test-secret")
@@ -53,23 +60,46 @@ impl Router {
             .env("DISABLE_LOGIN_API", "true")
             .env("LISTEN_UNIX_SOCKET", &socket)
             .stdout(Stdio::null())
-            .stderr(Stdio::null())
+            .stderr(Stdio::from(stderr))
             .spawn()
             .expect("start the router");
-        let router = Self {
+        let mut router = Self {
             child,
             socket,
             _directory: directory,
             data,
+            log,
         };
         let deadline = Instant::now() + Duration::from_secs(40);
         while Instant::now() < deadline {
             if router.request("GET /health HTTP/1.1").contains(" 200 ") {
                 return router;
             }
+            // A process that has already exited will never answer, so waiting
+            // out the full deadline only delays the report.
+            if let Ok(Some(status)) = router.child.try_wait() {
+                panic!(
+                    "the router exited with {status} before answering on {}\n{}",
+                    router.socket.display(),
+                    router.log()
+                );
+            }
             std::thread::sleep(Duration::from_millis(150));
         }
-        panic!("router never answered on {}", router.socket.display());
+        panic!(
+            "router never answered on {} within 40s\n{}",
+            router.socket.display(),
+            router.log()
+        );
+    }
+
+    /// What the router wrote to stderr, for a panic message that can be acted on.
+    fn log(&self) -> String {
+        match std::fs::read_to_string(&self.log) {
+            Ok(text) if text.trim().is_empty() => "router stderr: <empty>".to_string(),
+            Ok(text) => format!("router stderr:\n{text}"),
+            Err(error) => format!("router stderr unavailable: {error}"),
+        }
     }
 
     /// One plain-HTTP request over the socket — no TLS anywhere.


### PR DESCRIPTION
Closes #365

`Test (macos-latest)` failed once on main ([run 33214002225](https://github.com/link-assistant/router/actions/runs/33214002225)) with everything else green, and the failure carried no evidence:

```
thread 'the_socket_answers_plain_http' panicked at tests/unix_socket_test.rs:72:9:
router never answered on /var/folders/.../router.sock
test result: FAILED. 2 passed; 1 failed; finished in 40.04s
```

## The real defect is the missing diagnostic

`Router::start` spawned the router with `.stderr(Stdio::null())`, so when startup failed the reason went to `/dev/null`. "Never answered" is the symptom; the cause was discarded at the moment it was produced.

The router is not silent about this. Run by hand with a bad configuration it says exactly what is wrong — the test was simply not listening.

## Changes

1. **Capture stderr** into the test's own tempdir and include it in the panic.
2. **Fail fast on an exited child** — the loop polls `try_wait()` instead of waiting out the 40-second deadline for a process that is already gone.

## Proven, by forcing a real failure

Running with an empty `TOKEN_SECRET`:

```
the router exited with exit status: 2 before answering on /var/folders/.../router.sock
router stderr:
  INFO link_assistant_router: Link.Assistant.Router v0.123.6
 ERROR link_assistant_router: Configuration error: TOKEN_SECRET environment variable is required
```

| | before | after |
|---|---|---|
| Reason reported | discarded | printed verbatim |
| Time to report | 40 s | **0.95 s** |

## On the underlying flake

I did not reproduce it: 12 consecutive macOS runs passed at 5.9 s each against a 40 s deadline, including under artificial CPU contention. It is also the first macOS failure in the last 12 main runs, and the test file has not changed since #273 — nothing in #364 touches the serve startup path, and this run used `STORAGE_POLICY=text`.

So rather than guess at a cause or paper over it with a longer timeout, this makes the next occurrence carry its own explanation. If it never recurs, the cost is a few lines; if it does, the log will say why instead of leaving another 40-second silence.

## Checks

`cargo +1.98.0 test --test unix_socket_test` — 3 passed. Clippy clean, fmt clean.
