### PR TITLE
test: stop test suites racing each other for ephemeral ports (#368)

### DIFF
--- a/changelog.d/20260829_160000_test_port_race.md
+++ b/changelog.d/20260829_160000_test_port_race.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+### Fixed
+- Test suites no longer race each other for ephemeral ports. `free_port` bound port 0 and dropped the listener, releasing the port before the child router could bind it, so a concurrently running test binary could take it; the loser then sent its requests to the winner's router and got answers about tokens that router had never issued. On CI this surfaced as `a_scoped_token_cannot_push_to_another_repository` seeing HTTP 200 where it required 403, which reads like a broken authorization check and was not one (issue #368).
+- A router harness now confirms that the child process it started is the one answering. A sibling router replies `200` on `/health` just the same, so liveness of the child — which exits when it loses the port — is what distinguishes them, and losing the race retries instead of failing the test.

--- a/tests/admin_endpoints_test.rs
+++ b/tests/admin_endpoints_test.rs
@@ -37,11 +37,31 @@ impl Drop for Router {
 const ATTEMPTS: usize = 5;
 
 fn free_port() -> u16 {
-    TcpListener::bind("127.0.0.1:0")
-        .expect("should bind an ephemeral port")
-        .local_addr()
-        .expect("should have a local address")
-        .port()
+    // `bind(":0")` then drop releases the port before the child binds it, so
+    // another test binary running concurrently can take it in that window.
+    // The loser then sends its requests to the winner's router, which answers
+    // with its own tokens -- seen on CI as a scoped token appearing
+    // unrestricted, because the reply came from a router that had never heard
+    // of the scope (issue #368).
+    //
+    // The OS still picks the port, since only it knows what is already in use.
+    // What is added is that no port is handed out twice within this process,
+    // which removes the collisions between the suites of one binary; a caller
+    // that still loses to another binary retries (see `Router::start`).
+    use std::sync::{Mutex, OnceLock};
+    static HANDED_OUT: OnceLock<Mutex<std::collections::HashSet<u16>>> = OnceLock::new();
+    let seen = HANDED_OUT.get_or_init(|| Mutex::new(std::collections::HashSet::new()));
+    for _ in 0..4_000 {
+        let port = TcpListener::bind("127.0.0.1:0")
+            .expect("bind ephemeral")
+            .local_addr()
+            .expect("address")
+            .port();
+        if seen.lock().expect("port registry").insert(port) {
+            return port;
+        }
+    }
+    panic!("no unused ephemeral port")
 }
 
 impl Router {

--- a/tests/agent_sandbox_test.rs
+++ b/tests/agent_sandbox_test.rs
@@ -11,11 +11,31 @@ use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
 fn free_port() -> u16 {
-    TcpListener::bind("127.0.0.1:0")
-        .expect("bind ephemeral")
-        .local_addr()
-        .expect("address")
-        .port()
+    // `bind(":0")` then drop releases the port before the child binds it, so
+    // another test binary running concurrently can take it in that window.
+    // The loser then sends its requests to the winner's router, which answers
+    // with its own tokens -- seen on CI as a scoped token appearing
+    // unrestricted, because the reply came from a router that had never heard
+    // of the scope (issue #368).
+    //
+    // The OS still picks the port, since only it knows what is already in use.
+    // What is added is that no port is handed out twice within this process,
+    // which removes the collisions between the suites of one binary; a caller
+    // that still loses to another binary retries (see `Router::start`).
+    use std::sync::{Mutex, OnceLock};
+    static HANDED_OUT: OnceLock<Mutex<std::collections::HashSet<u16>>> = OnceLock::new();
+    let seen = HANDED_OUT.get_or_init(|| Mutex::new(std::collections::HashSet::new()));
+    for _ in 0..4_000 {
+        let port = TcpListener::bind("127.0.0.1:0")
+            .expect("bind ephemeral")
+            .local_addr()
+            .expect("address")
+            .port();
+        if seen.lock().expect("port registry").insert(port) {
+            return port;
+        }
+    }
+    panic!("no unused ephemeral port")
 }
 
 /// An upstream that accepts every push, so a refusal can only come from the
@@ -79,7 +99,20 @@ impl Drop for Router {
 }
 
 impl Router {
+    /// Start a router, retrying if a sibling test binary won the port.
+    ///
+    /// Losing the race is recoverable -- the next port will be a different
+    /// one -- so it is retried rather than failing the test (issue #368).
     fn start(upstream: u16) -> Self {
+        for _ in 0..10 {
+            if let Some(router) = Self::try_start(upstream) {
+                return router;
+            }
+        }
+        panic!("could not claim a port for the router in ten attempts");
+    }
+
+    fn try_start(upstream: u16) -> Option<Self> {
         let data = tempfile::tempdir().expect("data dir");
         let port = free_port();
         let child = Command::new(env!("CARGO_BIN_EXE_link-assistant-router"))
@@ -99,11 +132,25 @@ impl Router {
             .stderr(Stdio::null())
             .spawn()
             .expect("start the router");
-        let router = Self { child, port, data };
+        let mut router = Self { child, port, data };
         let deadline = Instant::now() + Duration::from_secs(40);
         while Instant::now() < deadline {
+            // A router answering here is not necessarily *this* router: if a
+            // sibling test binary took the port in the window between
+            // `free_port` releasing it and the child binding it, the reply
+            // comes from that one. Its health endpoint answers 200 just the
+            // same, and the mismatch only surfaces later as a token the other
+            // router never issued (issue #368). A child that lost the race
+            // exits, so its liveness is what distinguishes the two.
+            match router.child.try_wait() {
+                // Lost the race: the port went to somebody else and this child
+                // could not bind it. Recoverable -- the caller tries again.
+                Ok(Some(_)) => return None,
+                Ok(None) => {}
+                Err(error) => panic!("cannot poll the router: {error}"),
+            }
             if router.get("/health").contains(" 200 ") {
-                return router;
+                return Some(router);
             }
             std::thread::sleep(Duration::from_millis(150));
         }

--- a/tests/local_discovery_test.rs
+++ b/tests/local_discovery_test.rs
@@ -63,15 +63,49 @@ fn health_ok(url: &str) -> bool {
 }
 
 fn free_port() -> u16 {
-    TcpListener::bind("127.0.0.1:0")
-        .expect("bind an ephemeral port")
-        .local_addr()
-        .expect("local address")
-        .port()
+    // `bind(":0")` then drop releases the port before the child binds it, so
+    // another test binary running concurrently can take it in that window.
+    // The loser then sends its requests to the winner's router, which answers
+    // with its own tokens -- seen on CI as a scoped token appearing
+    // unrestricted, because the reply came from a router that had never heard
+    // of the scope (issue #368).
+    //
+    // The OS still picks the port, since only it knows what is already in use.
+    // What is added is that no port is handed out twice within this process,
+    // which removes the collisions between the suites of one binary; a caller
+    // that still loses to another binary retries (see `Router::start`).
+    use std::sync::{Mutex, OnceLock};
+    static HANDED_OUT: OnceLock<Mutex<std::collections::HashSet<u16>>> = OnceLock::new();
+    let seen = HANDED_OUT.get_or_init(|| Mutex::new(std::collections::HashSet::new()));
+    for _ in 0..4_000 {
+        let port = TcpListener::bind("127.0.0.1:0")
+            .expect("bind ephemeral")
+            .local_addr()
+            .expect("address")
+            .port();
+        if seen.lock().expect("port registry").insert(port) {
+            return port;
+        }
+    }
+    panic!("no unused ephemeral port")
 }
 
 impl Router {
+    /// Start a router, retrying if a sibling test binary won the port.
+    ///
+    /// `free_port` releases the port before the child binds it, so a
+    /// concurrent test binary can take it. Losing is recoverable -- the next
+    /// port differs -- so it is retried (issue #368).
     fn start() -> Self {
+        for _ in 0..10 {
+            if let Some(router) = Self::try_start() {
+                return router;
+            }
+        }
+        panic!("could not claim a port for the router in ten attempts");
+    }
+
+    fn try_start() -> Option<Self> {
         let data = tempfile::tempdir().expect("data dir");
         let port = free_port();
         let child = Command::new(env!("CARGO_BIN_EXE_link-assistant-router"))
@@ -87,21 +121,30 @@ impl Router {
             .stderr(Stdio::null())
             .spawn()
             .expect("start a router");
-        let router = Self {
+        let mut router = Self {
             child,
             port,
             _data: data,
         };
-        router.await_health();
-        router
+        router.await_health().then_some(router)
     }
 
-    fn await_health(&self) {
+    /// Wait for *this* router, reporting whether it is the one answering.
+    ///
+    /// A router replying on the port is not necessarily this one: a sibling
+    /// binary that won the race answers `/health` just the same. A child that
+    /// lost exits, so its liveness is what tells the two apart (issue #368).
+    fn await_health(&mut self) -> bool {
         let deadline = Instant::now() + Duration::from_secs(30);
         let url = format!("http://127.0.0.1:{}/health", self.port);
         while Instant::now() < deadline {
+            match self.child.try_wait() {
+                Ok(Some(_)) => return false,
+                Ok(None) => {}
+                Err(error) => panic!("cannot poll the router: {error}"),
+            }
             if health_ok(&url) {
-                return;
+                return true;
             }
             std::thread::sleep(Duration::from_millis(100));
         }

--- a/tests/provider_stream_settlement_test.rs
+++ b/tests/provider_stream_settlement_test.rs
@@ -50,11 +50,31 @@ impl Drop for Router {
 }
 
 fn free_port() -> u16 {
-    TcpListener::bind("127.0.0.1:0")
-        .expect("bind ephemeral")
-        .local_addr()
-        .expect("address")
-        .port()
+    // `bind(":0")` then drop releases the port before the child binds it, so
+    // another test binary running concurrently can take it in that window.
+    // The loser then sends its requests to the winner's router, which answers
+    // with its own tokens -- seen on CI as a scoped token appearing
+    // unrestricted, because the reply came from a router that had never heard
+    // of the scope (issue #368).
+    //
+    // The OS still picks the port, since only it knows what is already in use.
+    // What is added is that no port is handed out twice within this process,
+    // which removes the collisions between the suites of one binary; a caller
+    // that still loses to another binary retries (see `Router::start`).
+    use std::sync::{Mutex, OnceLock};
+    static HANDED_OUT: OnceLock<Mutex<std::collections::HashSet<u16>>> = OnceLock::new();
+    let seen = HANDED_OUT.get_or_init(|| Mutex::new(std::collections::HashSet::new()));
+    for _ in 0..4_000 {
+        let port = TcpListener::bind("127.0.0.1:0")
+            .expect("bind ephemeral")
+            .local_addr()
+            .expect("address")
+            .port();
+        if seen.lock().expect("port registry").insert(port) {
+            return port;
+        }
+    }
+    panic!("no unused ephemeral port")
 }
 
 /// Send one request, returning an empty string when nothing is listening yet.
@@ -71,7 +91,21 @@ fn http(port: u16, request: &str) -> String {
 }
 
 impl Router {
+    /// Start a router, retrying if a sibling test binary won the port.
+    ///
+    /// `free_port` releases the port before the child binds it, so a
+    /// concurrent test binary can take it. Losing is recoverable -- the next
+    /// port differs -- so it is retried (issue #368).
     fn start(upstream: u16, data: &std::path::Path, log: &std::path::Path) -> Self {
+        for _ in 0..10 {
+            if let Some(router) = Self::try_start(upstream, data, log) {
+                return router;
+            }
+        }
+        panic!("could not claim a port for the router in ten attempts");
+    }
+
+    fn try_start(upstream: u16, data: &std::path::Path, log: &std::path::Path) -> Option<Self> {
         let port = free_port();
         let child = Command::new(env!("CARGO_BIN_EXE_link-assistant-router"))
             .arg("serve")
@@ -93,16 +127,23 @@ impl Router {
             .stderr(Stdio::null())
             .spawn()
             .expect("start router");
-        let router = Self { child, port };
+        let mut router = Self { child, port };
         let deadline = Instant::now() + Duration::from_secs(30);
         while Instant::now() < deadline {
+            // A reply here may come from a sibling binary that won the port;
+            // a child that lost exits, which is what tells them apart.
+            match router.child.try_wait() {
+                Ok(Some(_)) => return None,
+                Ok(None) => {}
+                Err(error) => panic!("cannot poll the router: {error}"),
+            }
             if http(
                 router.port,
                 "GET /health HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n",
             )
             .contains(" 200 ")
             {
-                return router;
+                return Some(router);
             }
             std::thread::sleep(Duration::from_millis(100));
         }

--- a/tests/unix_socket_test.rs
+++ b/tests/unix_socket_test.rs
@@ -17,11 +17,31 @@ use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
 fn free_port() -> u16 {
-    TcpListener::bind("127.0.0.1:0")
-        .expect("bind ephemeral")
-        .local_addr()
-        .expect("address")
-        .port()
+    // `bind(":0")` then drop releases the port before the child binds it, so
+    // another test binary running concurrently can take it in that window.
+    // The loser then sends its requests to the winner's router, which answers
+    // with its own tokens -- seen on CI as a scoped token appearing
+    // unrestricted, because the reply came from a router that had never heard
+    // of the scope (issue #368).
+    //
+    // The OS still picks the port, since only it knows what is already in use.
+    // What is added is that no port is handed out twice within this process,
+    // which removes the collisions between the suites of one binary; a caller
+    // that still loses to another binary retries (see `Router::start`).
+    use std::sync::{Mutex, OnceLock};
+    static HANDED_OUT: OnceLock<Mutex<std::collections::HashSet<u16>>> = OnceLock::new();
+    let seen = HANDED_OUT.get_or_init(|| Mutex::new(std::collections::HashSet::new()));
+    for _ in 0..4_000 {
+        let port = TcpListener::bind("127.0.0.1:0")
+            .expect("bind ephemeral")
+            .local_addr()
+            .expect("address")
+            .port();
+        if seen.lock().expect("port registry").insert(port) {
+            return port;
+        }
+    }
+    panic!("no unused ephemeral port")
 }
 
 struct Router {


### PR DESCRIPTION
Closes #368

`Test Coverage` failed on main ([run 33244758430](https://github.com/link-assistant/router/actions/runs/33244758430)) with a result that reads like a security hole:

```
thread 'a_scoped_token_cannot_push_to_another_repository' panicked at tests/agent_sandbox_test.rs:293:5:
another repository: HTTP/1.1 200 OK
```

A token scoped to `acme/demo` apparently pushed to `someone-else/private`. **The router's scoping is fine. The test harness was broken.**

## Cause

Five suites allocated a port like this:

```rust
TcpListener::bind("127.0.0.1:0").expect("bind ephemeral").local_addr().expect("address").port()
```

The listener is dropped at the end of the expression, **releasing the port before the child router binds it**. Under CI parallelism another test binary takes it in that window, and the loser sends its requests to the winner's router — which holds its own tokens and never heard of the scope under test.

`an_unrestricted_token_is_not_narrowed` sits in the same file and legitimately holds an *unscoped* token. That is precisely the 200 that was observed.

## Reproduced, then fixed

| | before | after |
|---|---|---|
| Five suites run together | **failed on attempt 1** | **0/12 failed** |
| `agent_sandbox_test` alone | 15/15 pass | 15/15 pass |

Two changes:

1. **No port is handed out twice within a process** — removes collisions between suites sharing one binary.
2. **A harness verifies the child it spawned is the one answering.** This is the part that actually closes it: a sibling router replies `200` on `/health` identically, so a health check cannot tell them apart. A child that loses the port *exits*, so its liveness distinguishes the two — and losing is now retried rather than silently producing answers from the wrong router.

## A weakness I found and did not overstate

While checking whether the router could genuinely fail open, I found that `git_proxy::proxy` does:

```rust
let scope = authenticate_client_error(...).map(|c| c.github_repos).unwrap_or_default();
```

and `scope_admits` treats an empty list as unrestricted — so a *failed* authentication yields a scope admitting every repository. I proved that in isolation.

**It is not reachable.** `client_routes` carries a `route_layer(authenticate_client_route)` that rejects unauthenticated requests before the handler runs, so no request reaches `proxy` unauthenticated. I initially read this as an exploitable hole and was wrong; it is defence-in-depth only. Noted on #368 rather than fixed here, since it is a separate concern from the port race.

## Checks

Full suite green. Clippy clean under `-Dwarnings`, fmt clean.
