### PR TITLE
fix: do not write duplicate links into the doublets graph

### DIFF
--- a/changelog.d/20260829_180000_duplicate_links.md
+++ b/changelog.d/20260829_180000_duplicate_links.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+### Fixed
+- The token store no longer writes duplicate links into its doublets graph. Byte sequences are built right to left, so every string ending in the same byte created its own copy of the same `(byte, empty)` link — a second link with a `(source, target)` pair the store already held. `doublets` 0.4 accepts that and cannot represent it: `count()` sees both copies while the `(source, target)` index sees one, and the sources/targets trees' sizes then disagree with the storage, so any later deletion underflows in `platform-trees` — a panic in debug and a silent wrap in release. Interning and the semantic pairs now use `get_or_create`, which reuses the existing link, matching what the C# implementation enforces with `LinkWithSameValueAlreadyExistsException` (reported as linksplatform/doublets-rs#57).
+- Writes are about twice as fast as a side effect. Sharing a suffix rather than recreating it is simply less work: ten writes at 306 records went from 11.4 s to 6.1 s.

--- a/src/storage/associative.rs
+++ b/src/storage/associative.rs
@@ -478,11 +478,13 @@ fn write_semantic_links<'a>(
     for link in links {
         let source = intern_string(store, string_nodes, &link.source)?;
         let target = intern_string(store, string_nodes, &link.target)?;
+        // Same reason as `intern_string`: a pair the store already holds must
+        // be reused, not created again (linksplatform/doublets-rs#57).
         let pair = store
-            .create_link(source, target)
+            .get_or_create(source, target)
             .map_err(|error| codec_error("create semantic pair", error))?;
         store
-            .create_link(EDGE_TAG, pair)
+            .get_or_create(EDGE_TAG, pair)
             .map_err(|error| codec_error("mark semantic pair", error))?;
     }
     Ok(())
@@ -510,14 +512,28 @@ fn intern_string(
     if let Some(node) = nodes.get(value) {
         return Ok(*node);
     }
+    // `get_or_create`, not `create_link`. Sequences are built right to left,
+    // so every string ending in the same byte would otherwise create its own
+    // `(byte, EMPTY_SEQUENCE)` link -- a second link with a `(source, target)`
+    // pair the store already holds. `doublets` 0.4 accepts that and cannot
+    // represent it: `count()` sees both copies while `count_by([any, source,
+    // target])` sees one, and the sources/targets trees' sizes then disagree
+    // with the storage, so any later deletion underflows in `platform-trees`
+    // (panic in debug, a silent wrap in release). C# forbids the duplicate
+    // outright with `LinkWithSameValueAlreadyExistsException`; the Rust port
+    // declares `Error::AlreadyExists` but never raises it
+    // (linksplatform/doublets-rs#57).
+    //
+    // Sharing the suffix is also simply correct: two strings ending in the
+    // same bytes describe the same tail, which is what the encoding means.
     let mut sequence = EMPTY_SEQUENCE;
     for byte in value.as_bytes().iter().rev() {
         sequence = store
-            .create_link(BYTE_NODE_START + usize::from(*byte), sequence)
+            .get_or_create(BYTE_NODE_START + usize::from(*byte), sequence)
             .map_err(|error| codec_error("encode string byte", error))?;
     }
     let node = store
-        .create_link(STRING_TAG, sequence)
+        .get_or_create(STRING_TAG, sequence)
         .map_err(|error| codec_error("encode string node", error))?;
     nodes.insert(value.to_string(), node);
     Ok(node)
@@ -860,6 +876,21 @@ where
 
 fn codec_error(context: &str, error: impl std::fmt::Debug) -> StorageError {
     StorageError::Codec(format!("{context}: {error:?}"))
+}
+
+/// Every `(source, target)` pair physically present in the store.
+///
+/// For the duplicate-pair invariant test; see
+/// `the_encoded_graph_contains_no_duplicate_pairs`.
+#[cfg(test)]
+pub(super) fn encoded_pairs_for_test(path: &Path) -> Result<Vec<(usize, usize)>, StorageError> {
+    let store = PersistentStore::open(path)?;
+    let any = store.store.constants().any;
+    Ok(store
+        .store
+        .each_iter([any, any, any])
+        .map(|link| (link.source, link.target))
+        .collect())
 }
 
 #[cfg(test)]

--- a/src/storage_tests.rs
+++ b/src/storage_tests.rs
@@ -780,3 +780,39 @@ fn an_empty_store_file_is_not_mistaken_for_a_legacy_one() {
     let store = BinaryTokenStore::open(&path).expect("open over the empty file");
     assert!(store.list().expect("list").is_empty());
 }
+
+/// The store never holds two links with the same `(source, target)`.
+///
+/// `doublets` 0.4 lets `create_link` add a duplicate pair that its own
+/// `(source, target)` index cannot represent: `count()` sees every copy while
+/// `count_by([any, source, target])` sees one, and the sources/targets trees'
+/// size fields then disagree with the storage. Deleting anything afterwards
+/// underflows in `platform-trees`' `detach_core` -- a panic in debug, a silent
+/// wrap in release. C# forbids the duplicate outright
+/// (`LinkWithSameValueAlreadyExistsException`); the Rust port declares the
+/// matching `Error::AlreadyExists` but never raises it
+/// (linksplatform/doublets-rs#57).
+///
+/// The encoder is safe by construction -- pairs come from a `BTreeSet` and
+/// strings are interned through a cache -- and this pins that, because losing
+/// it would corrupt the store rather than fail.
+#[test]
+fn the_encoded_graph_contains_no_duplicate_pairs() {
+    let directory = tempdir().expect("temporary directory");
+    let path = directory.path().join("tokens.bin");
+    let records: Vec<_> = (0..12)
+        .map(|index| sample_record(&format!("id-{index:04}")))
+        .collect();
+    let store = BinaryTokenStore::open(&path).expect("open");
+    store.replace_all(&records).expect("write the graph");
+
+    let pairs = super::associative::encoded_pairs_for_test(&path).expect("read pairs");
+    let mut seen = std::collections::HashSet::new();
+    for (source, target) in &pairs {
+        assert!(
+            seen.insert((*source, *target)),
+            "duplicate pair ({source}, {target}) would corrupt the doublets index"
+        );
+    }
+    assert!(!pairs.is_empty(), "the fixture must produce links");
+}


### PR DESCRIPTION
## Summary

Encode repeated semantic pairs through `get_or_create` so shared byte-sequence suffixes reuse existing links instead of creating duplicate `(source, target)` pairs.

Duplicate pairs made the store's indexes disagree with its allocated links and could break later deletion. Reuse matches the data model and also reduces write work.

## Verification

A synthetic encoded network is walked after persistence and must contain no duplicate pair. Separate upstream reproductions distinguish valid deletion from deletion after duplicate insertion.
