### PR TITLE
fix: keep the capacity of a store written by a previous release (#374)

### DIFF
--- a/changelog.d/20260830_090000_issue_374_unstored_token.md
+++ b/changelog.d/20260830_090000_issue_374_unstored_token.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Fixed
+- A token that could not be stored is no longer returned to the caller. `issue` logged a failed `put` at `warn` and returned the token anyway, so a router whose store had stopped accepting writes went on minting credentials it could not subsequently recognise — the holder found out only when they tried to use one. The storage failure now fails the issue path, and is logged at `error` rather than `warn`, so an automated upgrade sees a non-zero exit instead of a line nothing reads (issue #374).

--- a/changelog.d/20260830_100000_issue_374_reopen_capacity.md
+++ b/changelog.d/20260830_100000_issue_374_reopen_capacity.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+### Fixed
+- A token store written by a previous release accepts writes again. v0.125.0 mapped the store through `link_cli::storage::PersistentFileMapped`, which starts with a logical capacity of zero however much the file already holds, so reopening it read a truncated store — 91 links from a 64 MB file holding 524,766 — and schema validation then failed at the first point past the truncation. Because the dual store answers reads from the text projection, the store looked healthy while every write failed with `doublets schema contains an invalid point` (issue #374).
+- The mapping restores the capacity its bytes represent, returns the complete allocation from `grow` rather than only the new tail, and refuses the store's initial bootstrap `shrink` once so the restored capacity is not immediately discarded. `grow_filled`, the safe alternative, cannot be used: despite its documentation it writes the fill value across the persisted region and empties the store, reported as link-foundation/link-cli#102.

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -40,6 +40,7 @@ use serde::{Deserialize, Serialize};
 use crate::config::StoragePolicy;
 
 mod associative;
+mod file_mapped;
 mod legacy;
 
 /// One persisted token record.

--- a/src/storage/associative.rs
+++ b/src/storage/associative.rs
@@ -4,11 +4,10 @@ use std::path::{Path, PathBuf};
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD_NO_PAD;
-use doublets::mem::unit::LinkPart;
 use doublets::{Doublets, DoubletsExt, Links, unit};
-use link_cli::storage::PersistentFileMapped;
 use lino_objects_codec::LinoValue;
 
+use super::file_mapped::LoadedFileMapped;
 use super::{StorageError, TokenRecord};
 
 const TYPE: &str = "Type";
@@ -34,7 +33,7 @@ const SCHEMA_NODE_COUNT: usize = 259;
 /// so reopening a file-mapped store zeroed it. `PersistentFileMapped` forwards
 /// to `grow_filled_exact`, which fills only the genuinely uninitialised tail
 /// (issue #372).
-type FileStore = unit::Store<usize, PersistentFileMapped<LinkPart<usize>>>;
+type FileStore = unit::Store<usize, LoadedFileMapped>;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct SemanticLink {
@@ -358,7 +357,7 @@ impl PersistentStore {
             options.mode(0o600);
         }
         let file = options.open(path)?;
-        let mapped = PersistentFileMapped::new(file)?;
+        let mapped = LoadedFileMapped::new(file)?;
         let store = unit::Store::<usize, _>::new(mapped)
             .map_err(|error| codec_error("open doublets store", error))?;
         Ok(Self {
@@ -376,7 +375,7 @@ impl PersistentStore {
     /// to any more (issue #357).
     pub(super) fn remap(&mut self) -> Result<(), StorageError> {
         let file = OpenOptions::new().read(true).write(true).open(&self.path)?;
-        let mapped = PersistentFileMapped::new(file)?;
+        let mapped = LoadedFileMapped::new(file)?;
         self.store = unit::Store::<usize, _>::new(mapped)
             .map_err(|error| codec_error("reopen doublets store", error))?;
         Ok(())
@@ -449,7 +448,7 @@ impl PersistentStore {
             options.mode(0o600);
         }
         let file = options.open(&temporary)?;
-        let mapped = PersistentFileMapped::new(file)?;
+        let mapped = LoadedFileMapped::new(file)?;
         self.store = unit::Store::<usize, _>::new(mapped)
             .map_err(|error| codec_error("reopen doublets store", error))?;
         self.pending = Some(temporary);
@@ -972,7 +971,7 @@ mod tests {
             .write(true)
             .open(&path)
             .unwrap();
-        let memory = PersistentFileMapped::new(file).unwrap();
+        let memory = LoadedFileMapped::new(file).unwrap();
         let links_network = unit::Store::<usize, _>::new(memory).unwrap();
         assert!(
             links_network.count() > 8 * 1024,

--- a/src/storage/file_mapped.rs
+++ b/src/storage/file_mapped.rs
@@ -1,0 +1,107 @@
+//! Capacity-preserving file mapping for the doublets token store.
+//!
+//! Split from `associative.rs` to keep that file within the repository's
+//! 1000-line limit.
+
+use std::mem::{MaybeUninit, size_of};
+
+use doublets::mem::RawMem;
+use doublets::mem::unit::LinkPart;
+use link_cli::storage::PersistentFileMapped;
+
+use super::StorageError;
+
+/// Number of items `unit::Store` bootstraps with before it sizes itself.
+const DOUBLETS_BOOTSTRAP_ITEMS: usize = 8 * 1024;
+
+/// A mapping that keeps the capacity an existing file already represents.
+///
+/// `FileMapped` starts with a logical capacity of zero however much the file
+/// holds, so `unit::Store::new` reads a truncated store: on a 64 MB file
+/// carrying 307 token records it saw **91** links where this wrapper sees
+/// **524,766**, and schema validation then failed at the first point past the
+/// truncation with "doublets schema contains an invalid point". Reads still
+/// answered -- the dual store falls back to the text projection -- so the
+/// store looked healthy while every write failed (issue #374).
+///
+/// Three things are needed, and `PersistentFileMapped` alone provides none of
+/// them:
+///
+/// * the capacity has to be adopted without writing over the persisted bytes,
+///   which `grow_filled` does not do -- despite its documentation it fills the
+///   whole region and empties the store (link-foundation/link-cli#102);
+/// * `grow` must return the complete allocation, because that is what
+///   `doublets` re-derives its pointers from, not just the new tail;
+/// * the store's initial bootstrap `shrink` has to be refused once, or it
+///   discards the capacity that was just adopted.
+pub(super) struct LoadedFileMapped {
+    inner: PersistentFileMapped<LinkPart<usize>>,
+    preserve_bootstrap: bool,
+}
+
+impl LoadedFileMapped {
+    pub(super) fn new(file: std::fs::File) -> Result<Self, StorageError> {
+        let bytes = usize::try_from(file.metadata()?.len())
+            .map_err(|_| std::io::Error::other("mapped file is too large for this platform"))?;
+        if bytes % size_of::<LinkPart<usize>>() != 0 && bytes >= 4096 {
+            return Err(StorageError::Codec(
+                "mapped file length is not aligned to a doublets link part".into(),
+            ));
+        }
+        let mut inner = PersistentFileMapped::new(file)?;
+        let items = bytes.max(4096) / size_of::<LinkPart<usize>>();
+        // SAFETY: `grow_assumed` requires the grown region to be initialised.
+        // It is: these bytes were written as `LinkPart<usize>` values by a
+        // doublets store on this platform, and `LinkPart<usize>` is `repr(C)`
+        // over `usize` fields, so every bit pattern is valid. Its fill closure
+        // writes nothing, so no persisted byte is touched.
+        #[allow(unsafe_code)]
+        unsafe {
+            inner
+                .grow_assumed(items)
+                .map_err(|error| StorageError::Codec(format!("restore capacity: {error}")))?;
+        }
+        Ok(Self {
+            inner,
+            preserve_bootstrap: items > DOUBLETS_BOOTSTRAP_ITEMS,
+        })
+    }
+}
+
+impl RawMem for LoadedFileMapped {
+    type Item = LinkPart<usize>;
+
+    fn allocated(&self) -> &[Self::Item] {
+        self.inner.allocated()
+    }
+
+    fn allocated_mut(&mut self) -> &mut [Self::Item] {
+        self.inner.allocated_mut()
+    }
+
+    #[allow(unsafe_code)]
+    unsafe fn grow(
+        &mut self,
+        addition: usize,
+        fill: impl FnOnce(usize, (&mut [Self::Item], &mut [MaybeUninit<Self::Item>])),
+    ) -> doublets::mem::Result<&mut [Self::Item]> {
+        // SAFETY: the caller supplies the initialisation callback `RawMem`
+        // requires, and the wrapped mapping enforces the same contract.
+        unsafe {
+            self.inner.grow(addition, fill)?;
+        }
+        // The mapping returns only the newly grown tail; `doublets` expects the
+        // complete allocation when it refreshes its internal pointers.
+        Ok(self.inner.allocated_mut())
+    }
+
+    fn shrink(&mut self, count: usize) -> doublets::mem::Result<()> {
+        if self.preserve_bootstrap
+            && self.inner.allocated().len().saturating_sub(count) == DOUBLETS_BOOTSTRAP_ITEMS
+        {
+            self.preserve_bootstrap = false;
+            return Ok(());
+        }
+        self.inner.shrink(count)
+    }
+}

--- a/src/storage_tests.rs
+++ b/src/storage_tests.rs
@@ -818,3 +818,40 @@ fn the_encoded_links_network_contains_no_duplicate_pairs() {
     }
     assert!(!pairs.is_empty(), "the fixture must produce links");
 }
+
+/// A store carried over from a previous release still accepts writes.
+///
+/// `FileMapped` starts with a logical capacity of zero however much the file
+/// holds, so a reopened store reads truncated: 91 links from a 64 MB file that
+/// holds 524,766. Schema validation then failed at the first point past the
+/// truncation, and because the dual store answers reads from the text
+/// projection, the store looked healthy while every write failed (issue #374).
+///
+/// The fixture is written and reopened in separate `PersistentStore`
+/// instances, which is what makes it a reopen rather than a continuation.
+#[test]
+fn a_reopened_store_keeps_every_link_it_holds() {
+    let directory = tempdir().expect("temporary directory");
+    let path = directory.path().join("tokens.bin");
+    let records: Vec<_> = (0..40)
+        .map(|index| sample_record(&format!("id-{index:04}")))
+        .collect();
+    {
+        let store = BinaryTokenStore::open(&path).expect("open");
+        store.replace_all(&records).expect("seed");
+    }
+
+    // A second open is a different mapping of the same file.
+    let reopened = BinaryTokenStore::open(&path).expect("reopen");
+    assert_eq!(
+        reopened.list().expect("list").len(),
+        records.len(),
+        "a reopened store must see every record it holds"
+    );
+
+    // And it must still accept writes: this is what #374 reported failing.
+    let mut extended = records;
+    extended.push(sample_record("id-new0"));
+    reopened.replace_all(&extended).expect("write after reopen");
+    assert_eq!(reopened.list().expect("list").len(), extended.len());
+}

--- a/src/token.rs
+++ b/src/token.rs
@@ -358,9 +358,14 @@ impl TokenManager {
             github_repos: claims.github_repos,
         };
         let id = record.id.clone();
-        if let Err(e) = self.store.put(record) {
-            tracing::warn!("token store put failed: {e}");
-        }
+        // A token that was handed out but never stored is worse than a
+        // refusal: the router cannot recognise it, and the holder only finds
+        // out when they try to use it. The failure has to reach the caller
+        // rather than a log line nothing reads (issue #374).
+        self.store.put(record).map_err(|error| {
+            tracing::error!("token store put failed, no token issued: {error}");
+            jsonwebtoken::errors::Error::from(jsonwebtoken::errors::ErrorKind::InvalidToken)
+        })?;
         Ok((format!("{TOKEN_PREFIX}{jwt}"), id))
     }
 

--- a/src/token_tests.rs
+++ b/src/token_tests.rs
@@ -887,3 +887,73 @@ fn a_fixed_token_is_still_refused_when_it_expires() {
         "without a window an expired token stays expired"
     );
 }
+
+/// A store that refuses every write, like one the process cannot persist to.
+struct RefusingStore;
+
+impl crate::storage::TokenStore for RefusingStore {
+    fn list(&self) -> Result<Vec<TokenRecord>, crate::storage::StorageError> {
+        Ok(Vec::new())
+    }
+    fn get(&self, _: &str) -> Result<Option<TokenRecord>, crate::storage::StorageError> {
+        Ok(None)
+    }
+    fn put(&self, _: TokenRecord) -> Result<(), crate::storage::StorageError> {
+        Err(crate::storage::StorageError::Codec(
+            "doublets schema contains an invalid point".into(),
+        ))
+    }
+    fn delete(&self, _: &str) -> Result<bool, crate::storage::StorageError> {
+        Ok(false)
+    }
+    fn try_consume_request(&self, _: &str) -> Result<bool, crate::storage::StorageError> {
+        Ok(true)
+    }
+    fn try_admit_request_reserving(
+        &self,
+        _: &str,
+        _: i64,
+        _: u64,
+    ) -> Result<crate::storage::RequestAdmission, crate::storage::StorageError> {
+        Ok(crate::storage::RequestAdmission::Admitted)
+    }
+    fn record_token_usage(&self, _: &str, _: u64) -> Result<(), crate::storage::StorageError> {
+        Ok(())
+    }
+    fn settle_token_usage(
+        &self,
+        _: &str,
+        _: u64,
+        _: u64,
+    ) -> Result<(), crate::storage::StorageError> {
+        Ok(())
+    }
+}
+
+/// A token that could not be stored is never handed to the caller.
+///
+/// The failure used to be a `warn!` followed by `Ok(...)`, so an upgraded
+/// deployment whose store had stopped accepting writes went on minting
+/// credentials the router could not recognise. The holder found out when they
+/// tried to use one, against a token they were already carrying (issue #374).
+#[test]
+fn a_token_that_could_not_be_stored_is_not_returned() {
+    let manager = TokenManager::with_store("secret", std::sync::Arc::new(RefusingStore));
+
+    let result = manager.issue(&IssueRequest {
+        ttl_hours: 1,
+        label: "unstorable",
+        account: None,
+        max_requests: None,
+        max_tokens: None,
+        rate_limit_per_minute: None,
+        scope: "",
+        github_repos: Vec::new(),
+        sliding_window_seconds: None,
+    });
+
+    assert!(
+        result.is_err(),
+        "issuing must fail when the record cannot be persisted, got {result:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Preserve the capacity represented by an existing binary token-store file when reopening it, and never return a token whose persistence failed.

The mapping wrapper adopts existing capacity without overwriting bytes, returns the complete allocation after growth, and prevents the initial bootstrap shrink from discarding restored capacity. Token issuance now propagates store failures and prints no credential on failure.

Resolves #374.

## Verification

A synthetic store written in the previous format is reopened, read, and updated successfully. A forced write failure returns an error and no token. Captured store sizes, link counts, and token identifiers are not part of the fixtures or description.
